### PR TITLE
refactor: use buf generate via mise instead of npm dependencies

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -66,7 +66,7 @@ db-shell:
 
 generate:
     go generate -x ./...
-    cd console-frontend && pnpm run generate
+    cd console-frontend && buf generate
 
 # Lint all Go code
 lint:

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -8,7 +8,6 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "generate": "buf generate",
     "lint": "ng lint",
     "format": "prettier --write ."
   },
@@ -48,7 +47,6 @@
     "@angular/cli": "^21.0.5",
     "@angular/compiler-cli": "^21.0.7",
     "@bufbuild/buf": "^1.63.0",
-    "@bufbuild/protoc-gen-es": "^2.10.2",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
     "@connectrpc/protoc-gen-connect-es": "^1.7.0",

--- a/console-frontend/pnpm-lock.yaml
+++ b/console-frontend/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@bufbuild/buf':
         specifier: ^1.63.0
         version: 1.63.0
-      '@bufbuild/protoc-gen-es':
-        specifier: ^2.10.2
-        version: 2.10.2(@bufbuild/protobuf@2.10.2)
       '@connectrpc/connect':
         specifier: ^2.1.1
         version: 2.1.1(@bufbuild/protobuf@2.10.2)
@@ -68,7 +65,7 @@ importers:
         version: 2.1.1(@bufbuild/protobuf@2.10.2)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))
       '@connectrpc/protoc-gen-connect-es':
         specifier: ^1.7.0
-        version: 1.7.0(@bufbuild/protoc-gen-es@2.10.2(@bufbuild/protobuf@2.10.2))(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))
+        version: 1.7.0(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
@@ -517,21 +514,8 @@ packages:
   '@bufbuild/protobuf@2.10.2':
     resolution: {integrity: sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==}
 
-  '@bufbuild/protoc-gen-es@2.10.2':
-    resolution: {integrity: sha512-vbjPsuofbtZwZXuOP7Y16CQsxrwCjuRONffmJSBEhoC7PQu/Cabp0+Fu/poLPm9CNM0tDCQA0xvgobgudaEYxQ==}
-    engines: {node: '>=20'}
-    hasBin: true
-    peerDependencies:
-      '@bufbuild/protobuf': 2.10.2
-    peerDependenciesMeta:
-      '@bufbuild/protobuf':
-        optional: true
-
   '@bufbuild/protoplugin@1.10.1':
     resolution: {integrity: sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ==}
-
-  '@bufbuild/protoplugin@2.10.2':
-    resolution: {integrity: sha512-RAWVs9tCzRqSS3tUtaFhOcauOAazCrm7tlGh0WHFq/44n5Fj6YgefdlZEPIaAK6VAA+FdOoFgtOJK2Ji5U24pw==}
 
   '@connectrpc/connect-web@2.1.1':
     resolution: {integrity: sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==}
@@ -3938,11 +3922,6 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4754,27 +4733,11 @@ snapshots:
 
   '@bufbuild/protobuf@2.10.2': {}
 
-  '@bufbuild/protoc-gen-es@2.10.2(@bufbuild/protobuf@2.10.2)':
-    dependencies:
-      '@bufbuild/protoplugin': 2.10.2
-    optionalDependencies:
-      '@bufbuild/protobuf': 2.10.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@bufbuild/protoplugin@1.10.1':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
       '@typescript/vfs': 1.6.2(typescript@4.5.2)
       typescript: 4.5.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@bufbuild/protoplugin@2.10.2':
-    dependencies:
-      '@bufbuild/protobuf': 2.10.2
-      '@typescript/vfs': 1.6.2(typescript@5.4.5)
-      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -4787,12 +4750,11 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.10.2
 
-  '@connectrpc/protoc-gen-connect-es@1.7.0(@bufbuild/protoc-gen-es@2.10.2(@bufbuild/protobuf@2.10.2))(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))':
+  '@connectrpc/protoc-gen-connect-es@1.7.0(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
       '@bufbuild/protoplugin': 1.10.1
     optionalDependencies:
-      '@bufbuild/protoc-gen-es': 2.10.2(@bufbuild/protobuf@2.10.2)
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.10.2)
     transitivePeerDependencies:
       - supports-color
@@ -5871,13 +5833,6 @@ snapshots:
     dependencies:
       debug: 4.4.3
       typescript: 4.5.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript/vfs@1.6.2(typescript@5.4.5)':
-    dependencies:
-      debug: 4.4.3
-      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8188,8 +8143,6 @@ snapshots:
       - supports-color
 
   typescript@4.5.2: {}
-
-  typescript@5.4.5: {}
 
   typescript@5.9.3: {}
 

--- a/mise.toml
+++ b/mise.toml
@@ -32,3 +32,4 @@ golangci-lint = "2.7.2"
 # Console Frontend
 node = "24"
 pnpm = "10.27.0"
+"npm:@bufbuild/protoc-gen-es" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -32,4 +32,4 @@ golangci-lint = "2.7.2"
 # Console Frontend
 node = "24"
 pnpm = "10.27.0"
-"npm:@bufbuild/protoc-gen-es" = "latest"
+"npm:@bufbuild/protoc-gen-es" = "2.10.2"


### PR DESCRIPTION
So `pnpm install` is no longer needed.

Note: requires `mise install` to be run once.