### PR TITLE
fix: improve frontend Docker build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+console-frontend/node_modules/
+console-frontend/dist/
+
+console-frontend/.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 console-frontend/node_modules/
 console-frontend/dist/
 
-console-frontend/.gitignore
+.git
+**/.gitignore
+**/.gitattributes
+.claude
+.github
+**/.vscode

--- a/console-frontend/.dockerignore
+++ b/console-frontend/.dockerignore
@@ -1,4 +1,0 @@
-node_modules/
-dist/
-
-.gitignore


### PR DESCRIPTION
Move .dockerignore to the repo root, since it is otherwise ignored. Note: skaffold context `.` (repo root) is required, since the frontend Docker build uses proto files outside the `console-frontend` dir.

This prevents copying the large `node_modules` dir into the container when building.