### PR TITLE
Fundament CLI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -86,3 +86,7 @@ functl *args:
     set -euo pipefail
     PASSWORD=$(kubectl --context k3d-fundament get secret -n fundament fundament-db-fun-operator -o jsonpath='{.data.password}' | {{ if os() == "macos" { "base64 -D" } else { "base64 -d" } }})
     DATABASE_URL="postgresql://fun_operator:${PASSWORD}@localhost:54328/fundament" go run ./functl/cmd/functl {{ args }}
+
+# Run fundament CLI
+fundament *args:
+    go run ./fundament-cli/cmd/fundament {{ args }}

--- a/bruno/Organization/Namespace/Create Namespace.bru
+++ b/bruno/Organization/Namespace/Create Namespace.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Create Namespace
+  type: grpc
+  seq: 5
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ClusterService/CreateNamespace
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "project_id": "{{projectId}}",
+      "cluster_id": "{{clusterId}}",
+      "name": "my-namespace"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/Delete Namespace.bru
+++ b/bruno/Organization/Namespace/Delete Namespace.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Delete Namespace
+  type: grpc
+  seq: 6
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ClusterService/DeleteNamespace
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "namespace_id": "{{namespaceId}}"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/Get Namespace by Cluster and Name.bru
+++ b/bruno/Organization/Namespace/Get Namespace by Cluster and Name.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get Namespace by Cluster and Name
+  type: grpc
+  seq: 1
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ClusterService/GetNamespaceByClusterAndName
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "cluster_name": "{{clusterName}}",
+      "namespace_name": "{{namespaceName}}"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/Get Namespace by Project and Name.bru
+++ b/bruno/Organization/Namespace/Get Namespace by Project and Name.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get Namespace by Project and Name
+  type: grpc
+  seq: 2
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ClusterService/GetNamespaceByProjectAndName
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "project_name": "{{projectName}}",
+      "namespace_name": "{{namespaceName}}"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/List Cluster Namespaces.bru
+++ b/bruno/Organization/Namespace/List Cluster Namespaces.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Cluster Namespaces
+  type: grpc
+  seq: 3
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ClusterService/ListClusterNamespaces
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "cluster_id": "{{clusterId}}"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/List Project Namespaces.bru
+++ b/bruno/Organization/Namespace/List Project Namespaces.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Project Namespaces
+  type: grpc
+  seq: 4
+}
+
+grpc {
+  url: {{organizationUrl}}
+  method: /organization.v1.ProjectService/ListProjectNamespaces
+  body: grpc
+  auth: inherit
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "project_id": "{{projectId}}"
+    }
+  '''
+}

--- a/bruno/Organization/Namespace/folder.bru
+++ b/bruno/Organization/Namespace/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Namespace
+}

--- a/fundament-cli/README.md
+++ b/fundament-cli/README.md
@@ -1,0 +1,106 @@
+# Fundament CLI
+
+CLI for managing Fundament platform resources using an API key.
+
+## Installation
+
+### Build from source
+
+```bash
+go build -o fundament ./fundament-cli/cmd/fundament
+```
+
+### Using Just
+
+```bash
+just fundament --help
+```
+
+Or run commands directly:
+
+```bash
+just fundament auth status
+```
+
+## Configuration
+
+Configuration files are stored in `~/.fundament/`:
+
+| File | Description |
+|------|-------------|
+| `config.yaml` | API endpoints and default settings |
+| `credentials` | Stored API key (created after login) |
+
+### Configuration file
+
+Create `~/.fundament/config.yaml` to override defaults:
+
+```yaml
+api_endpoint: http://organization.127.0.0.1.nip.io:8080
+authn_url: http://authn.127.0.0.1.nip.io:8080
+output: table
+```
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `FUNDAMENT_API_KEY` | API key for authentication (takes precedence over credentials file) |
+
+## Authentication
+
+Before using most commands, you need to authenticate with an API key.
+
+### Login
+
+```bash
+# Interactive prompt for API key
+fundament auth login
+
+# Or provide the API key directly
+fundament auth login <API_KEY>
+```
+
+## Commands
+
+### Global flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--debug` | `-d` | Enable debug logging |
+| `--output` | `-o` | Output format: `table` (default) or `json` |
+| `--help` | `-h` | Show help |
+
+## Output formats
+
+### Table (default)
+
+Human-readable tabular format:
+
+```bash
+fundament project list
+```
+
+```
+ID                                      NAME            CREATED
+019424a8-1234-7000-8000-000000000001    my-project      2024-01-15 10:30:00
+019424a8-5678-7000-8000-000000000002    another-proj    2024-01-16 14:22:00
+```
+
+### JSON
+
+Machine-readable JSON format for scripting:
+
+```bash
+fundament project list -o json
+```
+
+```json
+[
+  {
+    "id": "019424a8-1234-7000-8000-000000000001",
+    "name": "my-project",
+    "created_at": "2024-01-15T10:30:00Z"
+  }
+]
+```

--- a/fundament-cli/cmd/fundament/main.go
+++ b/fundament-cli/cmd/fundament/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/cli"
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/config"
+)
+
+func main() {
+	var root cli.CLI
+	ctx := kong.Parse(&root,
+		kong.Name("fundament"),
+		kong.Description("CLI for interacting with the Fundament platform."),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			NoExpandSubcommands: true,
+		}),
+	)
+
+	logLevel := slog.LevelInfo
+	if root.Debug {
+		logLevel = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	runCtx := &cli.Context{
+		Debug:  root.Debug,
+		Output: root.Output,
+		Logger: logger,
+		Config: cfg,
+	}
+
+	err = ctx.Run(runCtx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/fundament-cli/pkg/cli/apikey.go
+++ b/fundament-cli/pkg/cli/apikey.go
@@ -10,6 +10,7 @@ type APIKeyCmd struct {
 	List   APIKeyListCmd   `cmd:"" help:"List all API keys."`
 	Create APIKeyCreateCmd `cmd:"" help:"Create a new API key."`
 	Revoke APIKeyRevokeCmd `cmd:"" help:"Revoke an API key."`
+	Delete APIKeyDeleteCmd `cmd:"" help:"Delete an API key."`
 }
 
 // APIKeyListCmd handles the apikey list command.
@@ -116,5 +117,25 @@ func (c *APIKeyRevokeCmd) Run(ctx *Context) error {
 	}
 
 	fmt.Printf("API key %s has been revoked\n", c.APIKeyID)
+	return nil
+}
+
+// APIKeyDeleteCmd handles the apikey delete command.
+type APIKeyDeleteCmd struct {
+	APIKeyID string `arg:"" help:"ID of the API key to delete."`
+}
+
+// Run executes the apikey delete command.
+func (c *APIKeyDeleteCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	if err := apiClient.DeleteAPIKey(context.Background(), c.APIKeyID); err != nil {
+		return fmt.Errorf("failed to delete API key: %w", err)
+	}
+
+	fmt.Printf("API key %s has been deleted\n", c.APIKeyID)
 	return nil
 }

--- a/fundament-cli/pkg/cli/apikey.go
+++ b/fundament-cli/pkg/cli/apikey.go
@@ -40,19 +40,19 @@ func (c *APIKeyListCmd) Run(ctx *Context) error {
 	fmt.Fprintln(w, "ID\tNAME\tPREFIX\tCREATED\tEXPIRES\tLAST USED\tREVOKED")
 	for _, key := range apiKeys {
 		created := ""
-		if key.CreatedAt != nil {
+		if key.CreatedAt.IsValid() {
 			created = key.CreatedAt.AsTime().Format(TimeFormat)
 		}
 		expires := "never"
-		if key.ExpiresAt != nil {
+		if key.ExpiresAt.IsValid() {
 			expires = key.ExpiresAt.AsTime().Format(TimeFormat)
 		}
 		lastUsed := "never"
-		if key.LastUsedAt != nil {
+		if key.LastUsedAt.IsValid() {
 			lastUsed = key.LastUsedAt.AsTime().Format(TimeFormat)
 		}
 		revoked := "no"
-		if key.RevokedAt != nil {
+		if key.RevokedAt.IsValid() {
 			revoked = key.RevokedAt.AsTime().Format(TimeFormat)
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s...\t%s\t%s\t%s\t%s\n",

--- a/fundament-cli/pkg/cli/apikey.go
+++ b/fundament-cli/pkg/cli/apikey.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+// APIKeyCmd contains API key subcommands.
+type APIKeyCmd struct {
+	List   APIKeyListCmd   `cmd:"" help:"List all API keys."`
+	Create APIKeyCreateCmd `cmd:"" help:"Create a new API key."`
+	Revoke APIKeyRevokeCmd `cmd:"" help:"Revoke an API key."`
+}
+
+// APIKeyListCmd handles the apikey list command.
+type APIKeyListCmd struct{}
+
+// Run executes the apikey list command.
+func (c *APIKeyListCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	apiKeys, err := apiClient.ListAPIKeys(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to list API keys: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(apiKeys)
+	}
+
+	if len(apiKeys) == 0 {
+		fmt.Println("No API keys found")
+		return nil
+	}
+
+	w := NewTableWriter()
+	fmt.Fprintln(w, "ID\tNAME\tPREFIX\tCREATED\tEXPIRES\tLAST USED\tREVOKED")
+	for _, key := range apiKeys {
+		created := ""
+		if key.CreatedAt != nil {
+			created = key.CreatedAt.AsTime().Format(TimeFormat)
+		}
+		expires := "never"
+		if key.ExpiresAt != nil {
+			expires = key.ExpiresAt.AsTime().Format(TimeFormat)
+		}
+		lastUsed := "never"
+		if key.LastUsedAt != nil {
+			lastUsed = key.LastUsedAt.AsTime().Format(TimeFormat)
+		}
+		revoked := "no"
+		if key.RevokedAt != nil {
+			revoked = key.RevokedAt.AsTime().Format(TimeFormat)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s...\t%s\t%s\t%s\t%s\n",
+			key.Id,
+			key.Name,
+			key.TokenPrefix,
+			created,
+			expires,
+			lastUsed,
+			revoked,
+		)
+	}
+	return w.Flush()
+}
+
+// APIKeyCreateCmd handles the apikey create command.
+type APIKeyCreateCmd struct {
+	Name          string `arg:"" help:"Name for the API key."`
+	ExpiresInDays *int64 `help:"Number of days until the key expires. Omit for no expiry." short:"e"`
+}
+
+// Run executes the apikey create command.
+func (c *APIKeyCreateCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	resp, err := apiClient.CreateAPIKey(context.Background(), c.Name, c.ExpiresInDays)
+	if err != nil {
+		return fmt.Errorf("failed to create API key: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(resp)
+	}
+
+	fmt.Println("API key created successfully!")
+	fmt.Println()
+	fmt.Printf("ID:    %s\n", resp.Id)
+	fmt.Printf("Token: %s\n", resp.Token)
+	fmt.Println()
+	fmt.Println("IMPORTANT: Copy this token now. You will not be able to see it again.")
+	return nil
+}
+
+// APIKeyRevokeCmd handles the apikey revoke command.
+type APIKeyRevokeCmd struct {
+	APIKeyID string `arg:"" help:"ID of the API key to revoke."`
+}
+
+// Run executes the apikey revoke command.
+func (c *APIKeyRevokeCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	if err := apiClient.RevokeAPIKey(context.Background(), c.APIKeyID); err != nil {
+		return fmt.Errorf("failed to revoke API key: %w", err)
+	}
+
+	fmt.Printf("API key %s has been revoked\n", c.APIKeyID)
+	return nil
+}

--- a/fundament-cli/pkg/cli/auth.go
+++ b/fundament-cli/pkg/cli/auth.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/client"
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/config"
+)
+
+// AuthCmd contains authentication subcommands.
+type AuthCmd struct {
+	Login  AuthLoginCmd  `cmd:"" help:"Login with an API key."`
+	Status AuthStatusCmd `cmd:"" help:"Show current authentication status."`
+	Logout AuthLogoutCmd `cmd:"" help:"Remove stored credentials."`
+}
+
+// AuthLoginCmd handles the login command.
+type AuthLoginCmd struct {
+	APIKey string `help:"API key to use for authentication. If not provided, will prompt." arg:"" optional:""`
+}
+
+// Run executes the login command.
+func (c *AuthLoginCmd) Run(ctx *Context) error {
+	apiKey := c.APIKey
+
+	// If no API key provided, prompt for it
+	if apiKey == "" {
+		fmt.Print("Enter your API key: ")
+		reader := bufio.NewReader(os.Stdin)
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+		apiKey = strings.TrimSpace(input)
+	}
+
+	if apiKey == "" {
+		return fmt.Errorf("API key cannot be empty")
+	}
+
+	// Validate the API key by trying to get user info
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	testClient := client.New(apiKey, cfg.APIEndpoint, cfg.AuthnURL)
+	user, err := testClient.GetUserInfo(context.Background())
+	if err != nil {
+		return fmt.Errorf("invalid API key: %w", err)
+	}
+
+	// Save the credentials
+	creds := &config.Credentials{
+		APIKey: apiKey,
+	}
+	if err := config.SaveCredentials(creds); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged in as %s\n", user.Name)
+	return nil
+}
+
+// AuthStatusCmd handles the status command.
+type AuthStatusCmd struct{}
+
+// Run executes the status command.
+func (c *AuthStatusCmd) Run(ctx *Context) error {
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		fmt.Println("Not authenticated")
+		fmt.Println("Run 'fundament auth login' to authenticate")
+		return nil
+	}
+
+	// Try to get user info
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	apiClient := client.New(creds.APIKey, cfg.APIEndpoint, cfg.AuthnURL)
+	user, err := apiClient.GetUserInfo(context.Background())
+	if err != nil {
+		fmt.Println("Authentication failed: credentials may be invalid or expired")
+		fmt.Println("Run 'fundament auth login' to re-authenticate")
+		return nil
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(map[string]any{
+			"authenticated": true,
+			"user_id":       user.Id,
+			"user_name":     user.Name,
+			"organization":  user.OrganizationId,
+		})
+	}
+
+	w := NewTableWriter()
+	PrintKeyValue(w, "Authenticated", "yes")
+	PrintKeyValue(w, "User ID", user.Id)
+	PrintKeyValue(w, "User Name", user.Name)
+	PrintKeyValue(w, "Organization", user.OrganizationId)
+	return w.Flush()
+}
+
+// AuthLogoutCmd handles the logout command.
+type AuthLogoutCmd struct{}
+
+// Run executes the logout command.
+func (c *AuthLogoutCmd) Run(ctx *Context) error {
+	if err := config.DeleteCredentials(); err != nil {
+		return err
+	}
+	fmt.Println("Logged out successfully")
+	return nil
+}

--- a/fundament-cli/pkg/cli/cli.go
+++ b/fundament-cli/pkg/cli/cli.go
@@ -1,0 +1,45 @@
+// Package cli provides the command-line interface for the fundament CLI.
+package cli
+
+import (
+	"log/slog"
+
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/client"
+	"github.com/fundament-oss/fundament/fundament-cli/pkg/config"
+)
+
+// CLI defines the root command-line interface structure.
+type CLI struct {
+	Debug  bool         `help:"Enable debug logging."`
+	Output OutputFormat `help:"Output format: table or json." short:"o" default:"table" enum:"table,json"`
+
+	Auth    AuthCmd    `cmd:"" help:"Authentication commands."`
+	Cluster ClusterCmd `cmd:"" help:"Manage clusters."`
+	Project ProjectCmd `cmd:"" help:"Manage projects."`
+	APIKey  APIKeyCmd  `cmd:"" name:"apikey" help:"Manage API keys."`
+}
+
+// Context holds shared dependencies for command execution.
+type Context struct {
+	Debug  bool
+	Output OutputFormat
+	Logger *slog.Logger
+	Config *config.Config
+	Client *client.Client
+}
+
+// NewClientFromConfig creates a new API client from configuration.
+// Returns an error if not authenticated.
+func NewClientFromConfig() (*client.Client, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(creds.APIKey, cfg.APIEndpoint, cfg.AuthnURL), nil
+}

--- a/fundament-cli/pkg/cli/cli.go
+++ b/fundament-cli/pkg/cli/cli.go
@@ -1,4 +1,4 @@
-// Package cli provides the command-line interface for the fundament CLI.
+// Package cli provides the command-line interface for the Fundament CLI.
 package cli
 
 import (

--- a/fundament-cli/pkg/cli/cluster.go
+++ b/fundament-cli/pkg/cli/cluster.go
@@ -86,6 +86,8 @@ func (c *ClusterGetCmd) Run(ctx *Context) error {
 // formatClusterStatus formats a cluster status for display.
 func formatClusterStatus(status organizationv1.ClusterStatus) string {
 	switch status {
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_UNSPECIFIED:
+		return "unspecified"
 	case organizationv1.ClusterStatus_CLUSTER_STATUS_PROVISIONING:
 		return "provisioning"
 	case organizationv1.ClusterStatus_CLUSTER_STATUS_STARTING:

--- a/fundament-cli/pkg/cli/cluster.go
+++ b/fundament-cli/pkg/cli/cluster.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
+)
+
+// ClusterCmd contains cluster subcommands.
+type ClusterCmd struct {
+	List ClusterListCmd `cmd:"" help:"List all clusters."`
+	Get  ClusterGetCmd  `cmd:"" help:"Get cluster details."`
+}
+
+// ClusterListCmd handles the cluster list command.
+type ClusterListCmd struct{}
+
+// Run executes the cluster list command.
+func (c *ClusterListCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	clusters, err := apiClient.ListClusters(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(clusters)
+	}
+
+	if len(clusters) == 0 {
+		fmt.Println("No clusters found")
+		return nil
+	}
+
+	w := NewTableWriter()
+	fmt.Fprintln(w, "ID\tNAME\tSTATUS\tREGION")
+	for _, cluster := range clusters {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			cluster.Id,
+			cluster.Name,
+			formatClusterStatus(cluster.Status),
+			cluster.Region,
+		)
+	}
+	return w.Flush()
+}
+
+// ClusterGetCmd handles the cluster get command.
+type ClusterGetCmd struct {
+	ClusterID string `arg:"" help:"Cluster ID to get."`
+}
+
+// Run executes the cluster get command.
+func (c *ClusterGetCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	cluster, err := apiClient.GetCluster(context.Background(), c.ClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(cluster)
+	}
+
+	w := NewTableWriter()
+	PrintKeyValue(w, "ID", cluster.Id)
+	PrintKeyValue(w, "Name", cluster.Name)
+	PrintKeyValue(w, "Region", cluster.Region)
+	PrintKeyValue(w, "Kubernetes Version", cluster.KubernetesVersion)
+	PrintKeyValue(w, "Status", formatClusterStatus(cluster.Status))
+	if cluster.CreatedAt != nil {
+		PrintKeyValue(w, "Created", cluster.CreatedAt.AsTime().Format(TimeFormat))
+	}
+	return w.Flush()
+}
+
+// formatClusterStatus formats a cluster status for display.
+func formatClusterStatus(status organizationv1.ClusterStatus) string {
+	switch status {
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_PROVISIONING:
+		return "provisioning"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_STARTING:
+		return "starting"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_RUNNING:
+		return "running"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_UPGRADING:
+		return "upgrading"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_ERROR:
+		return "error"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_STOPPING:
+		return "stopping"
+	case organizationv1.ClusterStatus_CLUSTER_STATUS_STOPPED:
+		return "stopped"
+	default:
+		return "unknown"
+	}
+}

--- a/fundament-cli/pkg/cli/output.go
+++ b/fundament-cli/pkg/cli/output.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+)
+
+// OutputFormat represents the output format type.
+type OutputFormat string
+
+const (
+	OutputTable OutputFormat = "table"
+	OutputJSON  OutputFormat = "json"
+)
+
+// TimeFormat is the standard time format for CLI output.
+const TimeFormat = "2006-01-02T15:04:05Z07:00"
+
+// PrintJSON outputs data as formatted JSON to stdout.
+func PrintJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// NewTableWriter creates a new tabwriter for formatted table output.
+func NewTableWriter() *tabwriter.Writer {
+	return tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+}
+
+// PrintKeyValue prints a key-value pair to the given writer.
+func PrintKeyValue(w io.Writer, key string, value any) {
+	fmt.Fprintf(w, "%s:\t%v\n", key, value)
+}

--- a/fundament-cli/pkg/cli/project.go
+++ b/fundament-cli/pkg/cli/project.go
@@ -76,9 +76,11 @@ func (c *ProjectGetCmd) Run(ctx *Context) error {
 	w := NewTableWriter()
 	PrintKeyValue(w, "ID", project.Id)
 	PrintKeyValue(w, "Name", project.Name)
-	if project.CreatedAt != nil {
+
+	if project.CreatedAt.IsValid() {
 		PrintKeyValue(w, "Created", project.CreatedAt.AsTime().Format(TimeFormat))
 	}
+
 	return w.Flush()
 }
 

--- a/fundament-cli/pkg/cli/project.go
+++ b/fundament-cli/pkg/cli/project.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+// ProjectCmd contains project subcommands.
+type ProjectCmd struct {
+	List   ProjectListCmd   `cmd:"" help:"List all projects."`
+	Get    ProjectGetCmd    `cmd:"" help:"Get project details."`
+	Create ProjectCreateCmd `cmd:"" help:"Create a new project."`
+}
+
+// ProjectListCmd handles the project list command.
+type ProjectListCmd struct{}
+
+// Run executes the project list command.
+func (c *ProjectListCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	projects, err := apiClient.ListProjects(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(projects)
+	}
+
+	if len(projects) == 0 {
+		fmt.Println("No projects found")
+		return nil
+	}
+
+	w := NewTableWriter()
+	fmt.Fprintln(w, "ID\tNAME\tCREATED")
+	for _, project := range projects {
+		created := ""
+		if project.CreatedAt != nil {
+			created = project.CreatedAt.AsTime().Format(TimeFormat)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			project.Id,
+			project.Name,
+			created,
+		)
+	}
+	return w.Flush()
+}
+
+// ProjectGetCmd handles the project get command.
+type ProjectGetCmd struct {
+	ProjectID string `arg:"" help:"Project ID to get."`
+}
+
+// Run executes the project get command.
+func (c *ProjectGetCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	project, err := apiClient.GetProject(context.Background(), c.ProjectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(project)
+	}
+
+	w := NewTableWriter()
+	PrintKeyValue(w, "ID", project.Id)
+	PrintKeyValue(w, "Name", project.Name)
+	if project.CreatedAt != nil {
+		PrintKeyValue(w, "Created", project.CreatedAt.AsTime().Format(TimeFormat))
+	}
+	return w.Flush()
+}
+
+// ProjectCreateCmd handles the project create command.
+type ProjectCreateCmd struct {
+	Name string `arg:"" help:"Name of the project to create."`
+}
+
+// Run executes the project create command.
+func (c *ProjectCreateCmd) Run(ctx *Context) error {
+	apiClient, err := NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	projectID, err := apiClient.CreateProject(context.Background(), c.Name)
+	if err != nil {
+		return fmt.Errorf("failed to create project: %w", err)
+	}
+
+	if ctx.Output == OutputJSON {
+		return PrintJSON(map[string]string{
+			"project_id": projectID,
+			"name":       c.Name,
+		})
+	}
+
+	fmt.Printf("Created project %s (ID: %s)\n", c.Name, projectID)
+	return nil
+}

--- a/fundament-cli/pkg/client/apikeys.go
+++ b/fundament-cli/pkg/client/apikeys.go
@@ -39,3 +39,11 @@ func (c *Client) RevokeAPIKey(ctx context.Context, apiKeyID string) error {
 	}))
 	return err
 }
+
+// DeleteAPIKey deletes an API key.
+func (c *Client) DeleteAPIKey(ctx context.Context, apiKeyID string) error {
+	_, err := c.apiKeys().DeleteAPIKey(ctx, connect.NewRequest(&organizationv1.DeleteAPIKeyRequest{
+		ApiKeyId: apiKeyID,
+	}))
+	return err
+}

--- a/fundament-cli/pkg/client/apikeys.go
+++ b/fundament-cli/pkg/client/apikeys.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
+)
+
+// ListAPIKeys lists all API keys.
+func (c *Client) ListAPIKeys(ctx context.Context) ([]*organizationv1.APIKey, error) {
+	resp, err := c.apiKeys().ListAPIKeys(ctx, connect.NewRequest(&organizationv1.ListAPIKeysRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.ApiKeys, nil
+}
+
+// CreateAPIKey creates a new API key.
+func (c *Client) CreateAPIKey(ctx context.Context, name string, expiresInDays *int64) (*organizationv1.CreateAPIKeyResponse, error) {
+	req := &organizationv1.CreateAPIKeyRequest{
+		Name: name,
+	}
+	if expiresInDays != nil {
+		req.ExpiresInDays = expiresInDays
+	}
+	resp, err := c.apiKeys().CreateAPIKey(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// RevokeAPIKey revokes an API key.
+func (c *Client) RevokeAPIKey(ctx context.Context, apiKeyID string) error {
+	_, err := c.apiKeys().RevokeAPIKey(ctx, connect.NewRequest(&organizationv1.RevokeAPIKeyRequest{
+		ApiKeyId: apiKeyID,
+	}))
+	return err
+}

--- a/fundament-cli/pkg/client/auth.go
+++ b/fundament-cli/pkg/client/auth.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	authnv1 "github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1"
+)
+
+// GetUserInfo gets the current user's information.
+func (c *Client) GetUserInfo(ctx context.Context) (*authnv1.User, error) {
+	resp, err := c.authn().GetUserInfo(ctx, connect.NewRequest(&authnv1.GetUserInfoRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.User, nil
+}

--- a/fundament-cli/pkg/client/client.go
+++ b/fundament-cli/pkg/client/client.go
@@ -1,0 +1,124 @@
+// Package client provides an authenticated API client for the fundament CLI.
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+
+	authnv1 "github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1"
+	"github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1/authnv1connect"
+	"github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1/organizationv1connect"
+)
+
+// Client provides authenticated access to Fundament APIs.
+type Client struct {
+	apiKey      string
+	apiEndpoint string
+	authnURL    string
+
+	mu     sync.Mutex
+	jwt    string
+	expiry time.Time
+
+	httpClient  *http.Client
+	tokenClient authnv1connect.TokenServiceClient
+}
+
+// New creates a new API client.
+func New(apiKey, apiEndpoint, authnURL string) *Client {
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	c := &Client{
+		apiKey:      apiKey,
+		apiEndpoint: apiEndpoint,
+		authnURL:    authnURL,
+		httpClient:  httpClient,
+	}
+
+	// Create the token client without auth (we'll add the API key manually)
+	c.tokenClient = authnv1connect.NewTokenServiceClient(httpClient, authnURL)
+
+	return c
+}
+
+// ensureToken ensures we have a valid JWT, exchanging the API key if necessary.
+func (c *Client) ensureToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Return cached token if still valid (with 30 second buffer)
+	if c.jwt != "" && time.Now().Add(30*time.Second).Before(c.expiry) {
+		return c.jwt, nil
+	}
+
+	// Exchange API key for JWT
+	req := connect.NewRequest(&authnv1.ExchangeTokenRequest{})
+	req.Header().Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.tokenClient.ExchangeToken(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to exchange API key for token: %w", err)
+	}
+
+	c.jwt = resp.Msg.AccessToken
+	c.expiry = time.Now().Add(time.Duration(resp.Msg.ExpiresIn) * time.Second)
+
+	return c.jwt, nil
+}
+
+// authInterceptor returns a connect interceptor that adds authentication.
+func (c *Client) authInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			token, err := c.ensureToken(ctx)
+			if err != nil {
+				return nil, err
+			}
+			req.Header().Set("Authorization", "Bearer "+token)
+			return next(ctx, req)
+		}
+	}
+}
+
+// clusters returns the cluster service client.
+func (c *Client) clusters() organizationv1connect.ClusterServiceClient {
+	return organizationv1connect.NewClusterServiceClient(
+		c.httpClient,
+		c.apiEndpoint,
+		connect.WithInterceptors(c.authInterceptor()),
+	)
+}
+
+// projects returns the project service client.
+func (c *Client) projects() organizationv1connect.ProjectServiceClient {
+	return organizationv1connect.NewProjectServiceClient(
+		c.httpClient,
+		c.apiEndpoint,
+		connect.WithInterceptors(c.authInterceptor()),
+	)
+}
+
+// apiKeys returns the API key service client.
+func (c *Client) apiKeys() organizationv1connect.APIKeyServiceClient {
+	return organizationv1connect.NewAPIKeyServiceClient(
+		c.httpClient,
+		c.apiEndpoint,
+		connect.WithInterceptors(c.authInterceptor()),
+	)
+}
+
+// authn returns the authn service client (for user info).
+func (c *Client) authn() authnv1connect.AuthnServiceClient {
+	return authnv1connect.NewAuthnServiceClient(
+		c.httpClient,
+		c.authnURL,
+		connect.WithInterceptors(c.authInterceptor()),
+	)
+}

--- a/fundament-cli/pkg/client/client.go
+++ b/fundament-cli/pkg/client/client.go
@@ -1,4 +1,4 @@
-// Package client provides an authenticated API client for the fundament CLI.
+// Package client provides an authenticated API client for the Fundament CLI.
 package client
 
 import (

--- a/fundament-cli/pkg/client/clusters.go
+++ b/fundament-cli/pkg/client/clusters.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
+)
+
+// ListClusters lists all clusters.
+func (c *Client) ListClusters(ctx context.Context) ([]*organizationv1.ClusterSummary, error) {
+	resp, err := c.clusters().ListClusters(ctx, connect.NewRequest(&organizationv1.ListClustersRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.Clusters, nil
+}
+
+// GetCluster gets a cluster by ID.
+func (c *Client) GetCluster(ctx context.Context, clusterID string) (*organizationv1.ClusterDetails, error) {
+	resp, err := c.clusters().GetCluster(ctx, connect.NewRequest(&organizationv1.GetClusterRequest{
+		ClusterId: clusterID,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.Cluster, nil
+}

--- a/fundament-cli/pkg/client/projects.go
+++ b/fundament-cli/pkg/client/projects.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
+)
+
+// ListProjects lists all projects.
+func (c *Client) ListProjects(ctx context.Context) ([]*organizationv1.Project, error) {
+	resp, err := c.projects().ListProjects(ctx, connect.NewRequest(&organizationv1.ListProjectsRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.Projects, nil
+}
+
+// GetProject gets a project by ID.
+func (c *Client) GetProject(ctx context.Context, projectID string) (*organizationv1.Project, error) {
+	resp, err := c.projects().GetProject(ctx, connect.NewRequest(&organizationv1.GetProjectRequest{
+		ProjectId: projectID,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.Project, nil
+}
+
+// CreateProject creates a new project.
+func (c *Client) CreateProject(ctx context.Context, name string) (string, error) {
+	resp, err := c.projects().CreateProject(ctx, connect.NewRequest(&organizationv1.CreateProjectRequest{
+		Name: name,
+	}))
+	if err != nil {
+		return "", err
+	}
+	return resp.Msg.ProjectId, nil
+}

--- a/fundament-cli/pkg/config/config.go
+++ b/fundament-cli/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Package config provides configuration and credentials management for the fundament CLI.
+// Package config provides configuration and credentials management for the Fundament CLI.
 package config
 
 import (
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config holds the fundament CLI configuration.
+// Config holds the Fundament CLI configuration.
 type Config struct {
 	APIEndpoint string `yaml:"api_endpoint"`
 	AuthnURL    string `yaml:"authn_url"`

--- a/fundament-cli/pkg/config/config.go
+++ b/fundament-cli/pkg/config/config.go
@@ -1,0 +1,188 @@
+// Package config provides configuration and credentials management for the fundament CLI.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds the fundament CLI configuration.
+type Config struct {
+	APIEndpoint string `yaml:"api_endpoint"`
+	AuthnURL    string `yaml:"authn_url"`
+	Output      string `yaml:"output"`
+}
+
+// Credentials holds the API key for authentication.
+type Credentials struct {
+	APIKey string `yaml:"api_key"`
+}
+
+// DefaultConfig returns the default configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		APIEndpoint: "http://organization.127.0.0.1.nip.io:8080",
+		AuthnURL:    "http://authn.127.0.0.1.nip.io:8080",
+		Output:      "table",
+	}
+}
+
+// ConfigDir returns the path to the configuration directory.
+func ConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".fundament"), nil
+}
+
+// ConfigPath returns the path to the configuration file.
+func ConfigPath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil
+}
+
+// CredentialsPath returns the path to the credentials file.
+func CredentialsPath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "credentials"), nil
+}
+
+// EnsureConfigDir creates the configuration directory if it doesn't exist.
+func EnsureConfigDir() error {
+	dir, err := ConfigDir()
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(dir, 0700)
+}
+
+// LoadConfig loads the configuration from the config file.
+// If the file doesn't exist, it returns the default configuration.
+func LoadConfig() (*Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// SaveConfig saves the configuration to the config file.
+func SaveConfig(cfg *Config) error {
+	if err := EnsureConfigDir(); err != nil {
+		return err
+	}
+
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadCredentials loads the credentials from the credentials file or environment.
+func LoadCredentials() (*Credentials, error) {
+	// Check environment variable first
+	if apiKey := os.Getenv("FUNDAMENT_API_KEY"); apiKey != "" {
+		return &Credentials{APIKey: apiKey}, nil
+	}
+
+	path, err := CredentialsPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotAuthenticated
+		}
+		return nil, fmt.Errorf("failed to read credentials file: %w", err)
+	}
+
+	creds := &Credentials{}
+	if err := yaml.Unmarshal(data, creds); err != nil {
+		return nil, fmt.Errorf("failed to parse credentials file: %w", err)
+	}
+
+	if creds.APIKey == "" {
+		return nil, ErrNotAuthenticated
+	}
+
+	return creds, nil
+}
+
+// SaveCredentials saves the credentials to the credentials file.
+func SaveCredentials(creds *Credentials) error {
+	if err := EnsureConfigDir(); err != nil {
+		return err
+	}
+
+	path, err := CredentialsPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(creds)
+	if err != nil {
+		return fmt.Errorf("failed to marshal credentials: %w", err)
+	}
+
+	// Write with restricted permissions (owner read/write only)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write credentials file: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteCredentials removes the credentials file.
+func DeleteCredentials() error {
+	path, err := CredentialsPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove credentials file: %w", err)
+	}
+
+	return nil
+}
+
+// ErrNotAuthenticated is returned when no API key is configured.
+var ErrNotAuthenticated = errors.New("not authenticated: run 'fundament auth login' to authenticate")

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (


### PR DESCRIPTION
⚠️ Branched from `feat-add-api-keys-page-to-console`.

See `fundament-cli/README.md` or `just fundament --help` for the available commands.

- Cluster list/get
- Project list/get/create
- API key list/create/revoke

**TODO**
- [ ] CRUD Organization: I actually think this should be part of `functl` and not `fundament-cli`. Since a user belongs to a single organization.
- [ ] CRUD Namespace