### PR TITLE
feat: replace confirm with modal, improve table overflow

### DIFF
--- a/console-frontend/src/app/api-keys/api-keys.component.html
+++ b/console-frontend/src/app/api-keys/api-keys.component.html
@@ -209,7 +209,7 @@
                     @if (!isRevoked(apiKey.revoked) && !isExpired(apiKey.expires)) {
                       <button
                         type="button"
-                        (click)="revokeApiKey(apiKey.id)"
+                        (click)="openRevokeModal(apiKey.id, apiKey.name)"
                         [disabled]="loading()"
                         class="btn-light inline-flex shrink-0 items-center"
                       >
@@ -218,7 +218,7 @@
                     }
                     <button
                       type="button"
-                      (click)="deleteApiKey(apiKey.id)"
+                      (click)="openDeleteModal(apiKey.id, apiKey.name)"
                       [disabled]="loading()"
                       class="btn-remove inline-flex shrink-0 items-center"
                     >
@@ -242,3 +242,84 @@
     }
   </div>
 </div>
+
+<!-- Revoke API Key Modal -->
+<app-modal
+  [show]="showRevokeModal()"
+  title="Revoke API key"
+  [maxWidth]="'max-w-lg'"
+  (modalClose)="showRevokeModal.set(false)"
+>
+  <div class="sm:flex sm:items-start">
+    <div
+      class="mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-rose-900/20"
+    >
+      <ng-icon
+        name="tablerAlertTriangle"
+        size="1.5rem"
+        class="text-rose-600! dark:text-rose-400!"
+      />
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <div class="mt-2">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Are you sure you want to revoke API key
+          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingKeyName() }}</span
+          >? It will no longer be usable.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div modal-footer class="modal-footer">
+    <button type="button" (click)="showRevokeModal.set(false)" class="btn-secondary">Cancel</button>
+    <button
+      type="button"
+      (click)="confirmRevoke()"
+      class="cursor-pointer items-center rounded-md border border-rose-700 bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-sm ring-rose-500 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 focus:outline-none dark:border-rose-800 dark:bg-rose-700 dark:ring-offset-gray-950 dark:hover:bg-rose-800"
+    >
+      Yes, revoke this key
+    </button>
+  </div>
+</app-modal>
+
+<!-- Delete API Key Modal -->
+<app-modal
+  [show]="showDeleteModal()"
+  title="Delete API key"
+  [maxWidth]="'max-w-lg'"
+  (modalClose)="showDeleteModal.set(false)"
+>
+  <div class="sm:flex sm:items-start">
+    <div
+      class="mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-rose-900/20"
+    >
+      <ng-icon
+        name="tablerAlertTriangle"
+        size="1.5rem"
+        class="text-rose-600! dark:text-rose-400!"
+      />
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <div class="mt-2">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Are you sure you want to delete API key
+          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingKeyName() }}</span
+          >?
+        </p>
+        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
+      </div>
+    </div>
+  </div>
+
+  <div modal-footer class="modal-footer">
+    <button type="button" (click)="showDeleteModal.set(false)" class="btn-secondary">Cancel</button>
+    <button
+      type="button"
+      (click)="confirmDelete()"
+      class="cursor-pointer items-center rounded-md border border-rose-700 bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-sm ring-rose-500 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 focus:outline-none dark:border-rose-800 dark:bg-rose-700 dark:ring-offset-gray-950 dark:hover:bg-rose-800"
+    >
+      Yes, delete this key
+    </button>
+  </div>
+</app-modal>

--- a/console-frontend/src/app/api-keys/api-keys.component.html
+++ b/console-frontend/src/app/api-keys/api-keys.component.html
@@ -262,9 +262,9 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to revoke API key
-          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingKeyName() }}</span
+          <span class="font-semibold text-gray-800 dark:text-white">{{ pendingKeyName() }}</span
           >? It will no longer be usable.
         </p>
       </div>
@@ -302,12 +302,11 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to delete API key
-          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingKeyName() }}</span
+          <span class="font-semibold text-gray-800 dark:text-white">{{ pendingKeyName() }}</span
           >?
         </p>
-        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
       </div>
     </div>
   </div>

--- a/console-frontend/src/app/api-keys/api-keys.component.ts
+++ b/console-frontend/src/app/api-keys/api-keys.component.ts
@@ -20,7 +20,9 @@ import {
   tablerCheck,
   tablerCopy,
   tablerBan,
+  tablerAlertTriangle,
 } from '@ng-icons/tabler-icons';
+import ModalComponent from '../modal/modal.component';
 import {
   type APIKey,
   ListAPIKeysRequestSchema,
@@ -56,7 +58,7 @@ const isRevoked = (timestamp: Timestamp | undefined): boolean => timestamp !== u
 
 @Component({
   selector: 'app-api-keys',
-  imports: [CommonModule, FormsModule, NgIcon],
+  imports: [CommonModule, FormsModule, NgIcon, ModalComponent],
   viewProviders: [
     provideIcons({
       tablerPlus,
@@ -65,6 +67,7 @@ const isRevoked = (timestamp: Timestamp | undefined): boolean => timestamp !== u
       tablerCheck,
       tablerCopy,
       tablerBan,
+      tablerAlertTriangle,
     }),
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -89,6 +92,15 @@ export default class ApiKeysComponent implements OnInit {
   newKeyName = signal('');
 
   newKeyExpiresInDays = signal<number | null>(null);
+
+  // Modal state
+  showRevokeModal = signal(false);
+
+  showDeleteModal = signal(false);
+
+  pendingKeyId = signal<string | null>(null);
+
+  pendingKeyName = signal<string | null>(null);
 
   // Newly created token (only shown once)
   createdToken = signal<string | null>(null);
@@ -122,14 +134,23 @@ export default class ApiKeysComponent implements OnInit {
     }
   }
 
-  async revokeApiKey(apiKeyId: string) {
-    // eslint-disable-next-line no-alert
-    if (
-      !window.confirm('Are you sure you want to revoke this API key? It will no longer be usable.')
-    ) {
-      return;
-    }
+  openRevokeModal(apiKeyId: string, apiKeyName: string) {
+    this.pendingKeyId.set(apiKeyId);
+    this.pendingKeyName.set(apiKeyName);
+    this.showRevokeModal.set(true);
+  }
 
+  openDeleteModal(apiKeyId: string, apiKeyName: string) {
+    this.pendingKeyId.set(apiKeyId);
+    this.pendingKeyName.set(apiKeyName);
+    this.showDeleteModal.set(true);
+  }
+
+  async confirmRevoke() {
+    const apiKeyId = this.pendingKeyId();
+    if (!apiKeyId) return;
+
+    this.showRevokeModal.set(false);
     this.loading.set(true);
     this.error.set(null);
 
@@ -151,14 +172,11 @@ export default class ApiKeysComponent implements OnInit {
     }
   }
 
-  async deleteApiKey(apiKeyId: string) {
-    // eslint-disable-next-line no-alert
-    if (
-      !window.confirm('Are you sure you want to delete this API key? This action cannot be undone.')
-    ) {
-      return;
-    }
+  async confirmDelete() {
+    const apiKeyId = this.pendingKeyId();
+    if (!apiKeyId) return;
 
+    this.showDeleteModal.set(false);
     this.loading.set(true);
     this.error.set(null);
 

--- a/console-frontend/src/app/app.html
+++ b/console-frontend/src/app/app.html
@@ -362,7 +362,7 @@
     }
 
     <!-- Main Content -->
-    <main class="mx-auto max-w-7xl flex-1 px-4 py-6 sm:px-6">
+    <main class="mx-auto max-w-7xl min-w-0 flex-1 px-4 py-6 sm:px-6">
       @if (!isLoginPage()) {
         <app-breadcrumb [segments]="breadcrumbSegments()" />
       }

--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -624,7 +624,9 @@
       <div class="mt-2">
         <p class="text-sm text-gray-500 dark:text-gray-400">
           Are you sure you want to delete namespace
-          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingNamespaceName() }}</span
+          <span class="font-semibold text-gray-900 dark:text-white">{{
+            pendingNamespaceName()
+          }}</span
           >?
         </p>
         <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
@@ -633,7 +635,9 @@
   </div>
 
   <div modal-footer class="modal-footer">
-    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">Cancel</button>
+    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">
+      Cancel
+    </button>
     <button
       type="button"
       (click)="confirmDeleteNamespace()"

--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -452,7 +452,7 @@
                   </div>
                   <button
                     type="button"
-                    (click)="deleteNamespace(namespace.id, namespace.name)"
+                    (click)="openDeleteNamespaceModal(namespace.id, namespace.name)"
                     class="inline-flex cursor-pointer items-center rounded-md border border-rose-300 bg-white px-3 py-1.5 text-sm font-medium text-rose-700 shadow-sm ring-rose-500 hover:bg-rose-50 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:border-rose-600 dark:bg-gray-900 dark:text-rose-300 dark:ring-offset-gray-950 dark:hover:bg-rose-900 dark:hover:text-white"
                   >
                     <ng-icon name="tablerTrash" class="mr-1.5" />
@@ -601,4 +601,45 @@
       </button>
     </div>
   </form>
+</app-modal>
+
+<!-- Delete Namespace Modal -->
+<app-modal
+  [show]="showDeleteNamespaceModal()"
+  title="Delete namespace"
+  [maxWidth]="'max-w-lg'"
+  (modalClose)="showDeleteNamespaceModal.set(false)"
+>
+  <div class="sm:flex sm:items-start">
+    <div
+      class="mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-rose-900/20"
+    >
+      <ng-icon
+        name="tablerAlertTriangle"
+        size="1.5rem"
+        class="text-rose-600! dark:text-rose-400!"
+      />
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <div class="mt-2">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Are you sure you want to delete namespace
+          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingNamespaceName() }}</span
+          >?
+        </p>
+        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
+      </div>
+    </div>
+  </div>
+
+  <div modal-footer class="modal-footer">
+    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">Cancel</button>
+    <button
+      type="button"
+      (click)="confirmDeleteNamespace()"
+      class="cursor-pointer items-center rounded-md border border-rose-700 bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-sm ring-rose-500 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 focus:outline-none dark:border-rose-800 dark:bg-rose-700 dark:ring-offset-gray-950 dark:hover:bg-rose-800"
+    >
+      Yes, delete this namespace
+    </button>
+  </div>
 </app-modal>

--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -500,9 +500,9 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to delete cluster
-          <span class="font-semibold text-gray-900 dark:text-white">{{
+          <span class="font-semibold text-gray-800 dark:text-white">{{
             clusterData.basics.name
           }}</span
           >?
@@ -551,7 +551,7 @@
           }
         </select>
         @if (projects().length === 0) {
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
             No projects available. Create a project first.
           </p>
         }
@@ -622,14 +622,16 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to delete namespace
-          <span class="font-semibold text-gray-900 dark:text-white">{{
+          <span class="font-semibold text-gray-800 dark:text-white">{{
             pendingNamespaceName()
           }}</span
           >?
         </p>
-        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          This will remove the namespace and all resources running on it. This cannot be undone.
+        </p>
       </div>
     </div>
   </div>

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -118,6 +118,12 @@ export default class ClusterDetailsComponent implements OnInit {
 
   isCreatingNamespace = signal<boolean>(false);
 
+  showDeleteNamespaceModal = signal<boolean>(false);
+
+  pendingNamespaceId = signal<string | null>(null);
+
+  pendingNamespaceName = signal<string | null>(null);
+
   // Plugin data
   installedPlugins = signal<PluginSummary[]>([]);
 
@@ -370,11 +376,18 @@ export default class ClusterDetailsComponent implements OnInit {
     }
   }
 
-  async deleteNamespace(namespaceId: string, namespaceName: string): Promise<void> {
-    // eslint-disable-next-line no-alert
-    if (!window.confirm(`Are you sure you want to delete namespace '${namespaceName}'?`)) {
-      return;
-    }
+  openDeleteNamespaceModal(namespaceId: string, namespaceName: string): void {
+    this.pendingNamespaceId.set(namespaceId);
+    this.pendingNamespaceName.set(namespaceName);
+    this.showDeleteNamespaceModal.set(true);
+  }
+
+  async confirmDeleteNamespace(): Promise<void> {
+    const namespaceId = this.pendingNamespaceId();
+    const namespaceName = this.pendingNamespaceName();
+    if (!namespaceId) return;
+
+    this.showDeleteNamespaceModal.set(false);
 
     try {
       const request = create(DeleteNamespaceRequestSchema, { namespaceId });

--- a/console-frontend/src/app/namespaces/namespaces.component.html
+++ b/console-frontend/src/app/namespaces/namespaces.component.html
@@ -160,14 +160,16 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-800 dark:text-gray-400">
           Are you sure you want to delete namespace
-          <span class="font-semibold text-gray-900 dark:text-white">{{
+          <span class="font-semibold text-gray-800 dark:text-white">{{
             pendingNamespaceName()
           }}</span
           >?
         </p>
-        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          This will remove the namespace and all resources running on it. This cannot be undone.
+        </p>
       </div>
     </div>
   </div>

--- a/console-frontend/src/app/namespaces/namespaces.component.html
+++ b/console-frontend/src/app/namespaces/namespaces.component.html
@@ -48,7 +48,7 @@
             </div>
             <button
               type="button"
-              (click)="deleteNamespace(namespace.id, namespace.name)"
+              (click)="openDeleteNamespaceModal(namespace.id, namespace.name)"
               class="inline-flex cursor-pointer items-center rounded-md border border-rose-300 bg-white px-3 py-1.5 text-sm font-medium text-rose-700 shadow-sm ring-rose-500 hover:bg-rose-50 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:border-rose-600 dark:bg-gray-900 dark:text-rose-300 dark:ring-offset-gray-950 dark:hover:bg-rose-900 dark:hover:text-white"
             >
               <ng-icon name="tablerTrash" class="mr-1.5" />
@@ -139,4 +139,45 @@
       </button>
     </div>
   </form>
+</app-modal>
+
+<!-- Delete Namespace Modal -->
+<app-modal
+  [show]="showDeleteNamespaceModal()"
+  title="Delete namespace"
+  [maxWidth]="'max-w-lg'"
+  (modalClose)="showDeleteNamespaceModal.set(false)"
+>
+  <div class="sm:flex sm:items-start">
+    <div
+      class="mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-rose-900/20"
+    >
+      <ng-icon
+        name="tablerAlertTriangle"
+        size="1.5rem"
+        class="text-rose-600! dark:text-rose-400!"
+      />
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <div class="mt-2">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Are you sure you want to delete namespace
+          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingNamespaceName() }}</span
+          >?
+        </p>
+        <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
+      </div>
+    </div>
+  </div>
+
+  <div modal-footer class="modal-footer">
+    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">Cancel</button>
+    <button
+      type="button"
+      (click)="confirmDeleteNamespace()"
+      class="cursor-pointer items-center rounded-md border border-rose-700 bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-sm ring-rose-500 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 focus:outline-none dark:border-rose-800 dark:bg-rose-700 dark:ring-offset-gray-950 dark:hover:bg-rose-800"
+    >
+      Yes, delete this namespace
+    </button>
+  </div>
 </app-modal>

--- a/console-frontend/src/app/namespaces/namespaces.component.html
+++ b/console-frontend/src/app/namespaces/namespaces.component.html
@@ -162,7 +162,9 @@
       <div class="mt-2">
         <p class="text-sm text-gray-500 dark:text-gray-400">
           Are you sure you want to delete namespace
-          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingNamespaceName() }}</span
+          <span class="font-semibold text-gray-900 dark:text-white">{{
+            pendingNamespaceName()
+          }}</span
           >?
         </p>
         <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>
@@ -171,7 +173,9 @@
   </div>
 
   <div modal-footer class="modal-footer">
-    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">Cancel</button>
+    <button type="button" (click)="showDeleteNamespaceModal.set(false)" class="btn-secondary">
+      Cancel
+    </button>
     <button
       type="button"
       (click)="confirmDeleteNamespace()"

--- a/console-frontend/src/app/namespaces/namespaces.component.ts
+++ b/console-frontend/src/app/namespaces/namespaces.component.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { tablerPlus, tablerTrash } from '@ng-icons/tabler-icons';
+import { tablerPlus, tablerTrash, tablerAlertTriangle } from '@ng-icons/tabler-icons';
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
 import { TitleService } from '../title.service';
 import { ToastService } from '../toast.service';
@@ -31,6 +31,7 @@ import { formatDate as formatDateUtil } from '../utils/date-format';
       tablerCircleXFill,
       tablerPlus,
       tablerTrash,
+      tablerAlertTriangle,
     }),
   ],
   templateUrl: './namespaces.component.html',
@@ -64,6 +65,12 @@ export default class NamespacesComponent implements OnInit {
   isLoadingClusters = signal<boolean>(false);
 
   isCreatingNamespace = signal<boolean>(false);
+
+  showDeleteNamespaceModal = signal<boolean>(false);
+
+  pendingNamespaceId = signal<string | null>(null);
+
+  pendingNamespaceName = signal<string | null>(null);
 
   namespaceForm = this.fb.group({
     clusterId: ['', Validators.required],
@@ -169,11 +176,18 @@ export default class NamespacesComponent implements OnInit {
     }
   }
 
-  async deleteNamespace(namespaceId: string, namespaceName: string) {
-    // eslint-disable-next-line no-alert
-    if (!window.confirm(`Are you sure you want to delete namespace '${namespaceName}'?`)) {
-      return;
-    }
+  openDeleteNamespaceModal(namespaceId: string, namespaceName: string) {
+    this.pendingNamespaceId.set(namespaceId);
+    this.pendingNamespaceName.set(namespaceName);
+    this.showDeleteNamespaceModal.set(true);
+  }
+
+  async confirmDeleteNamespace() {
+    const namespaceId = this.pendingNamespaceId();
+    const namespaceName = this.pendingNamespaceName();
+    if (!namespaceId) return;
+
+    this.showDeleteNamespaceModal.set(false);
 
     try {
       const request = create(DeleteNamespaceRequestSchema, { namespaceId });

--- a/console-frontend/src/app/project-members/project-members.component.html
+++ b/console-frontend/src/app/project-members/project-members.component.html
@@ -57,7 +57,7 @@
 
                   <button
                     type="button"
-                    (click)="removeMember(member.id)"
+                    (click)="openRemoveMemberModal(member.id)"
                     class="btn-remove shrink-0"
                   >
                     <ng-icon name="tablerTrash" class="mr-1.5" /> Remove
@@ -148,4 +148,44 @@
       </button>
     </div>
   </form>
+</app-modal>
+
+<!-- Remove Member Modal -->
+<app-modal
+  [show]="showRemoveMemberModal()"
+  title="Remove member"
+  [maxWidth]="'max-w-lg'"
+  (modalClose)="showRemoveMemberModal.set(false)"
+>
+  <div class="sm:flex sm:items-start">
+    <div
+      class="mx-auto flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-rose-900/20"
+    >
+      <ng-icon
+        name="tablerAlertTriangle"
+        size="1.5rem"
+        class="text-rose-600! dark:text-rose-400!"
+      />
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <div class="mt-2">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Are you sure you want to remove
+          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingMemberName() }}</span>
+          from this project?
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div modal-footer class="modal-footer">
+    <button type="button" (click)="showRemoveMemberModal.set(false)" class="btn-secondary">Cancel</button>
+    <button
+      type="button"
+      (click)="confirmRemoveMember()"
+      class="cursor-pointer items-center rounded-md border border-rose-700 bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-sm ring-rose-500 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 focus:outline-none dark:border-rose-800 dark:bg-rose-700 dark:ring-offset-gray-950 dark:hover:bg-rose-800"
+    >
+      Yes, remove this member
+    </button>
+  </div>
 </app-modal>

--- a/console-frontend/src/app/project-members/project-members.component.html
+++ b/console-frontend/src/app/project-members/project-members.component.html
@@ -179,7 +179,9 @@
   </div>
 
   <div modal-footer class="modal-footer">
-    <button type="button" (click)="showRemoveMemberModal.set(false)" class="btn-secondary">Cancel</button>
+    <button type="button" (click)="showRemoveMemberModal.set(false)" class="btn-secondary">
+      Cancel
+    </button>
     <button
       type="button"
       (click)="confirmRemoveMember()"

--- a/console-frontend/src/app/project-members/project-members.component.html
+++ b/console-frontend/src/app/project-members/project-members.component.html
@@ -93,7 +93,7 @@
           }
         </select>
         @if (availableUsers().length === 0) {
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">No users available to add.</p>
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">No users available to add.</p>
         }
         @if (
           memberForm.get('userId')?.invalid &&
@@ -169,9 +169,9 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to remove
-          <span class="font-semibold text-gray-900 dark:text-white">{{ pendingMemberName() }}</span>
+          <span class="font-semibold text-gray-800 dark:text-white">{{ pendingMemberName() }}</span>
           from this project?
         </p>
       </div>

--- a/console-frontend/src/app/project-members/project-members.component.ts
+++ b/console-frontend/src/app/project-members/project-members.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { tablerPlus, tablerTrash, tablerPencil } from '@ng-icons/tabler-icons';
+import { tablerPlus, tablerTrash, tablerPencil, tablerAlertTriangle } from '@ng-icons/tabler-icons';
 import { TitleService } from '../title.service';
 import { ToastService } from '../toast.service';
 import ModalComponent from '../modal/modal.component';
@@ -27,6 +27,7 @@ interface ProjectMember {
       tablerPlus,
       tablerTrash,
       tablerPencil,
+      tablerAlertTriangle,
     }),
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -50,6 +51,12 @@ export default class ProjectMembersComponent implements OnInit {
   showAddMemberModal = signal<boolean>(false);
 
   isAddingMember = signal<boolean>(false);
+
+  showRemoveMemberModal = signal<boolean>(false);
+
+  pendingMemberId = signal<string | null>(null);
+
+  pendingMemberName = signal<string | null>(null);
 
   editingMember = signal<ProjectMember | null>(null);
 
@@ -161,14 +168,23 @@ export default class ProjectMembersComponent implements OnInit {
     this.editingMember.set(null);
   }
 
-  removeMember(memberId: string) {
+  openRemoveMemberModal(memberId: string) {
     const member = this.members().find((m) => m.id === memberId);
     if (!member) return;
 
-    // eslint-disable-next-line no-alert
-    if (!window.confirm(`Are you sure you want to remove ${member.name} from this project?`)) {
-      return;
-    }
+    this.pendingMemberId.set(memberId);
+    this.pendingMemberName.set(member.name);
+    this.showRemoveMemberModal.set(true);
+  }
+
+  confirmRemoveMember() {
+    const memberId = this.pendingMemberId();
+    if (!memberId) return;
+
+    const member = this.members().find((m) => m.id === memberId);
+    if (!member) return;
+
+    this.showRemoveMemberModal.set(false);
 
     // Move user back to available users
     this.availableUsers.update((users) => [

--- a/console-frontend/src/app/project-settings/project-settings.component.html
+++ b/console-frontend/src/app/project-settings/project-settings.component.html
@@ -124,9 +124,9 @@
     </div>
     <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
       <div class="mt-2">
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           Are you sure you want to delete project
-          <span class="font-semibold text-gray-900 dark:text-white">{{ project()?.name }}</span
+          <span class="font-semibold text-gray-800 dark:text-white">{{ project()?.name }}</span
           >?
         </p>
         <p class="mt-2 text-sm text-rose-600 dark:text-rose-400">This cannot be undone.</p>

--- a/console-frontend/src/styles.css
+++ b/console-frontend/src/styles.css
@@ -218,7 +218,7 @@ select {
 /* Table styles */
 
 .table-container {
-  @apply overflow-hidden rounded-md shadow ring-1 ring-gray-300 dark:ring-gray-700;
+  @apply overflow-x-auto rounded-md shadow ring-1 ring-gray-300 dark:ring-gray-700;
 }
 
 .table {

--- a/docs-frontend/src/layouts/Landing.astro
+++ b/docs-frontend/src/layouts/Landing.astro
@@ -82,16 +82,12 @@ const { title = 'Fundament' } = Astro.props;
   }
 
   .hero-title {
-    @apply mb-6 bg-clip-text text-4xl font-bold sm:text-5xl lg:text-6xl;
+    @apply mb-6 bg-clip-text! text-4xl font-bold text-transparent sm:text-5xl lg:text-6xl;
     background: linear-gradient(to right, theme('colors.blue.600'), theme('colors.cyan.600'));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
   }
 
   .hero-title:where(.dark, .dark *) {
     background: linear-gradient(to right, theme('colors.blue.400'), theme('colors.cyan.400'));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
   }
 
   /* Architecture Section */


### PR DESCRIPTION
- Replaces `confirm()` dialogs with modals
- Improves table overflow, e.g. for the API keys page on mobile
- Small improvement of docs landing page styles (no visible difference, but simplified CSS)