### PR TITLE
Enable using test clock in the Organization API

### DIFF
--- a/organization-api/cmd/fun-organization-api/main.go
+++ b/organization-api/cmd/fun-organization-api/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/fundament-oss/fundament/organization-api/pkg/clock"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/net/http2"
@@ -143,6 +144,7 @@ func run() error {
 	server, err := organization.New(logger, &organization.Config{
 		JWTSecret:          []byte(cfg.JWTSecret),
 		CORSAllowedOrigins: cfg.CORSAllowedOrigins,
+		Clock:              clock.New(),
 	}, db)
 	if err != nil {
 		return fmt.Errorf("failed to create organization server: %w", err)

--- a/organization-api/pkg/clock/clock.go
+++ b/organization-api/pkg/clock/clock.go
@@ -1,0 +1,38 @@
+package clock
+
+import (
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+	UpdateTime(t time.Time)
+}
+
+type realClock struct{}
+
+func New() Clock {
+	return &realClock{}
+}
+
+func (c *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (c *realClock) UpdateTime(time.Time) {}
+
+type testClock struct {
+	now time.Time
+}
+
+func NewTest(t time.Time) Clock {
+	return &testClock{now: t}
+}
+
+func (c *testClock) Now() time.Time {
+	return c.now
+}
+
+func (c *testClock) UpdateTime(t time.Time) {
+	c.now = t
+}

--- a/organization-api/pkg/organization/apikey_create.go
+++ b/organization-api/pkg/organization/apikey_create.go
@@ -41,7 +41,7 @@ func (s *Server) CreateAPIKey(
 		}
 
 		expires = pgtype.Timestamptz{
-			Time:  time.Now().Add(expiresIn),
+			Time:  s.clock.Now().Add(expiresIn),
 			Valid: true,
 		}
 	}

--- a/organization-api/pkg/organization/apikey_create_test.go
+++ b/organization-api/pkg/organization/apikey_create_test.go
@@ -49,8 +49,8 @@ func Test_APIKey_Create(t *testing.T) {
 
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	inTwoMinutes := testClock.Now().Add(2 * time.Minute)
-	inFiveDays := testClock.Now().Add(120 * time.Hour)
+	inTwoMinutes := testClock.Now().Add(2 * time.Minute).Truncate(time.Microsecond)
+	inFiveDays := testClock.Now().Add(120 * time.Hour).Truncate(time.Microsecond)
 
 	tests := map[string]struct {
 		CreateRequest *organizationv1.CreateAPIKeyRequest

--- a/organization-api/pkg/organization/apikey_create_test.go
+++ b/organization-api/pkg/organization/apikey_create_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/fundament-oss/fundament/organization-api/pkg/clock"
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1/organizationv1connect"
 	"github.com/google/uuid"
@@ -33,44 +34,48 @@ func Test_APIKey_Create_Unauthenticated(t *testing.T) {
 func Test_APIKey_Create(t *testing.T) {
 	t.Parallel()
 
+	testClock := clock.NewTest(time.Now().UTC())
+
 	orgID := uuid.New()
 	userID := uuid.New()
 
 	env := newTestAPI(t,
 		WithOrganization(orgID, "test-org"),
 		WithUser(userID, "test-user", orgID),
+		WithClock(testClock),
 	)
 
 	token := env.createAuthnToken(t, userID)
 
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	twoMinutes := 2 * time.Minute
-	fiveDaysInHours := 5 * 24 * time.Hour
+	inTwoMinutes := testClock.Now().Add(2 * time.Minute)
+	inFiveDays := testClock.Now().Add(120 * time.Hour)
 
 	tests := map[string]struct {
 		CreateRequest *organizationv1.CreateAPIKeyRequest
-		WantExpires   *time.Duration
+		WantExpiresAt *time.Time
 	}{
 		"without_expiration": {
 			CreateRequest: &organizationv1.CreateAPIKeyRequest{
 				Name:      "my-first-key",
 				ExpiresIn: "",
 			},
+			WantExpiresAt: nil,
 		},
 		"with_expiration_in_minutes": {
 			CreateRequest: &organizationv1.CreateAPIKeyRequest{
 				Name:      "another-key",
 				ExpiresIn: "2m",
 			},
-			WantExpires: &twoMinutes,
+			WantExpiresAt: &inTwoMinutes,
 		},
 		"with_expiration_in_hours": {
 			CreateRequest: &organizationv1.CreateAPIKeyRequest{
 				Name:      "yet-another-key",
 				ExpiresIn: "120h",
 			},
-			WantExpires: &fiveDaysInHours,
+			WantExpiresAt: &inFiveDays,
 		},
 	}
 
@@ -92,12 +97,11 @@ func Test_APIKey_Create(t *testing.T) {
 			getRes, err := client.GetAPIKey(context.Background(), getReq)
 			require.NoError(t, err)
 
-			if tc.WantExpires == nil {
+			if tc.WantExpiresAt == nil {
 				assert.Nil(t, getRes.Msg.ApiKey.Expires)
 			} else {
 				require.NotNil(t, getRes.Msg.ApiKey.Expires)
-				expected := time.Now().Add(*tc.WantExpires)
-				assert.WithinDuration(t, expected, getRes.Msg.ApiKey.Expires.AsTime(), time.Minute)
+				assert.Equal(t, *tc.WantExpiresAt, getRes.Msg.ApiKey.Expires.AsTime())
 			}
 		})
 	}

--- a/organization-api/pkg/organization/server_test.go
+++ b/organization-api/pkg/organization/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fundament-oss/fundament/common/psqldb"
+	"github.com/fundament-oss/fundament/organization-api/pkg/clock"
 	"github.com/fundament-oss/fundament/organization-api/pkg/organization"
 )
 
@@ -36,6 +37,7 @@ type testUser struct {
 type APIOptions struct {
 	Organizations map[uuid.UUID]string
 	Users         map[uuid.UUID]testUser
+	Clock         clock.Clock
 }
 
 type APIOption func(*APIOptions)
@@ -49,6 +51,12 @@ func WithOrganization(id uuid.UUID, name string) APIOption {
 func WithUser(id uuid.UUID, name string, orgID uuid.UUID) APIOption {
 	return func(o *APIOptions) {
 		o.Users[id] = testUser{Name: name, OrgID: orgID}
+	}
+}
+
+func WithClock(c clock.Clock) APIOption {
+	return func(o *APIOptions) {
+		o.Clock = c
 	}
 }
 
@@ -72,6 +80,7 @@ func newTestAPI(t *testing.T, options ...APIOption) *testEnv {
 	organizationCfg := &organization.Config{
 		JWTSecret:          jwtSecret,
 		CORSAllowedOrigins: []string{"*"},
+		Clock:              opts.Clock,
 	}
 
 	organizationServer, err := organization.New(testLogger, organizationCfg, testDb)


### PR DESCRIPTION
So we can make exact assertions when the server responds with data using the datetimes.