### PR TITLE
fix: allow updating organizations

### DIFF
--- a/common/dbversion/version.go
+++ b/common/dbversion/version.go
@@ -1,4 +1,4 @@
 package dbversion
 
 // LatestVersion is the latest version for the db migrations.
-const LatestVersion = 2
+const LatestVersion = 3

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -1070,6 +1070,10 @@ AND authn.is_project_member(id, authn.current_user_id(), 'admin')]]> </expressio
 	<expression type="using-exp"> <![CDATA[authn.is_organization_member(id)]]> </expression>
 </policy>
 
+<policy name="organizations_update_policy" table="tenant.organizations" command="UPDATE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[authn.is_organization_member(id)]]> </expression>
+</policy>
+
 <policy name="organizations_authn_api_policy" table="tenant.organizations" command="ALL" permissive="true">	<roles names="fun_authn_api"/>
 	<expression type="using-exp"> <![CDATA[true]]> </expression>
 </policy>

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1,5 +1,5 @@
 -- ** Database generated with pgModeler (PostgreSQL Database Modeler).
--- ** pgModeler version: 1.2.2
+-- ** pgModeler version: 1.2.3
 -- ** PostgreSQL version: 18.0
 -- ** Project Site: pgmodeler.io
 -- ** Model Author: ---
@@ -894,6 +894,15 @@ CREATE POLICY namespaces_organization_policy ON tenant.namespaces
 CREATE POLICY organizations_select_policy ON tenant.organizations
 	AS PERMISSIVE
 	FOR SELECT
+	TO fun_fundament_api
+	USING (authn.is_organization_member(id));
+-- ddl-end --
+
+-- object: organizations_update_policy | type: POLICY --
+-- DROP POLICY IF EXISTS organizations_update_policy ON tenant.organizations CASCADE;
+CREATE POLICY organizations_update_policy ON tenant.organizations
+	AS PERMISSIVE
+	FOR UPDATE
 	TO fun_fundament_api
 	USING (authn.is_organization_member(id));
 -- ddl-end --

--- a/db/migrations/003_organizations-policy-update.up.sql
+++ b/db/migrations/003_organizations-policy-update.up.sql
@@ -1,0 +1,11 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "organizations_update_policy" ON "tenant"."organizations"
+	AS PERMISSIVE
+	FOR UPDATE
+	TO fun_fundament_api
+	USING (authn.is_organization_member(id));


### PR DESCRIPTION
Claude-only PR. The issue was that organizations could not be updated using the `UpdateOrganization` endpoint (http://console.fundament.localhost:8080/organization page). According to Claude:

Root cause: The multi-org refactoring enabled Row Level Security (RLS) on `tenant.organizations` but only added a SELECT policy for `fun_fundament_api`. There was no UPDATE policy, so when the backend runs `UPDATE tenant.organizations SET name = $2 WHERE id = $1`, RLS silently filters out the row, returning 0 rows affected, which the Go code maps to "organization not found".

Fix: Added an `organizations_update_policy` to [fundament.dbm:1072](vscode-webview://1jj9gffkf69jkmve8bfi1pu1r66ei55ng1unopr9fav6640bl03k/db/fundament.dbm#L1072) with the same `authn.is_organization_member(id)` check used by the select policy, then regenerated [fundament.sql](vscode-webview://1jj9gffkf69jkmve8bfi1pu1r66ei55ng1unopr9fav6640bl03k/db/fundament.sql) with pgmodeler.