### PR TITLE
fix: change ConfigMap handling in OpenFGA setup

### DIFF
--- a/charts/fundament/templates/openfga-setup.yaml
+++ b/charts/fundament/templates/openfga-setup.yaml
@@ -76,20 +76,10 @@ spec:
                 echo "Authorization model ID: $MODEL_ID"
               fi
 
-              # Write store ID and model ID to a ConfigMap for the organization-api to read
-              cat <<ENDOFCM | kubectl apply -f -
-              apiVersion: v1
-              kind: ConfigMap
-              metadata:
-                name: {{ $.Release.Name }}-openfga-config
-                namespace: {{ $.Release.Namespace }}
-                labels:
-                  {{- include "fundament.labels" . | nindent 18 }}
-                  app.kubernetes.io/component: openfga
-              data:
-                store-id: "$FGA_STORE_ID"
-                authorization-model-id: "$MODEL_ID"
-              ENDOFCM
+              # Write store ID and model ID to the ConfigMap managed by Helm
+              kubectl patch configmap {{ $.Release.Name }}-openfga-config \
+                -n {{ $.Release.Namespace }} \
+                --patch "{\"data\":{\"store-id\":\"$FGA_STORE_ID\",\"authorization-model-id\":\"$MODEL_ID\"}}"
 
               echo "ConfigMap updated successfully"
           volumeMounts:

--- a/charts/fundament/templates/openfga.yaml
+++ b/charts/fundament/templates/openfga.yaml
@@ -49,16 +49,24 @@ data:
   model.fga: |
 {{- .Files.Get "openfga/model.fga" | nindent 4 }}
 ---
+{{- $openfgaConfigName := printf "%s-openfga-config" $.Release.Name }}
+{{- $openfgaConfigExisting := lookup "v1" "ConfigMap" $.Release.Namespace $openfgaConfigName }}
+{{- $openfgaStoreID := "pending" }}
+{{- $openfgaAuthModelID := "pending" }}
+{{- if $openfgaConfigExisting }}
+{{- $openfgaStoreID = index $openfgaConfigExisting.data "store-id" | default "pending" }}
+{{- $openfgaAuthModelID = index $openfgaConfigExisting.data "authorization-model-id" | default "pending" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $.Release.Name }}-openfga-config
+  name: {{ $openfgaConfigName }}
   labels:
     {{- include "fundament.labels" . | nindent 4 }}
     app.kubernetes.io/component: openfga
 data:
-  store-id: "pending"
-  authorization-model-id: "pending"
+  store-id: {{ $openfgaStoreID | quote }}
+  authorization-model-id: {{ $openfgaAuthModelID | quote }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Fixes the following (at least for me):
- OpenFGA status that stays pending
- Warning about missing last-applied-configuration annotation