### PR TITLE
ADR-0022, 0023: Networking fabric and tenant isolation

### DIFF
--- a/docs/adr/0005-bare-metal-provisioning-tool.adoc
+++ b/docs/adr/0005-bare-metal-provisioning-tool.adoc
@@ -7,11 +7,11 @@
 Status:: proposed
 Date:: 2026-03-09
 Group:: hardware
-Depends-on:: ADR-0003, ADR-0004
+Depends-on:: ADR-0003, ADR-0022, ADR-0023
 
 == Context
 
-With bare-metal infrastructure (ADR-0003) and spine-leaf networking (ADR-0004) chosen, we need a tool that provisions servers and manages their lifecycle. At 50,000 servers, manual provisioning is not viable.
+With bare-metal infrastructure (ADR-0003), partition-based fabric scaling (ADR-0022), and VRF-per-tenant network isolation (ADR-0023), we need a tool that provisions both compute and network in an integrated, zero-touch manner. At 50,000 physical servers, manual provisioning is not viable. The provisioning tool must natively implement the fabric and isolation model we chose.
 
 == Options
 

--- a/docs/adr/0022-datacenter-fabric-scaling.adoc
+++ b/docs/adr/0022-datacenter-fabric-scaling.adoc
@@ -1,0 +1,46 @@
+:showtitle:
+:state: proposed
+
+= ADR-0022: Datacenter fabric scaling
+
+Status:: proposed
+Date:: 2026-03-11
+Group:: networking
+Depends-on:: ADR-0002, ADR-0004
+
+== Context
+
+ADR-0004 chose spine-leaf with BGP/EVPN. At 50,000 physical servers (ADR-0002), a single 2-tier leaf-spine CLOS cannot accommodate all servers: switch radix limits how many leaves a spine layer can connect. At the same time, tenant workloads include large Kubernetes clusters, and a cluster placed in a partition must be able to grow later without being forced to move. A 2-tier partition does not leave enough headroom once several clusters share it. Confining each partition to a small 2-tier pod is therefore not workable. The question is how the fabric scales beyond a single pod while still giving clusters room to grow inside one flat L3 fabric.
+
+== Options
+
+=== Option 1: Multiple independent 2-tier fabric partitions
+* Pros: each partition is a self-contained 2-tier leaf-spine CLOS and a natural failure domain; partitions can be added incrementally; no super-spine complexity; cross-partition communication via exit/border switches; well-understood operational model
+* Cons: partition size capped by spine radix, leaving too little headroom for co-located Kubernetes clusters to scale up in place; cross-partition traffic goes through exit layer (higher latency than intra-partition); no single flat L3 fabric spanning all servers; partition sizing must be planned
+
+=== Option 2: Single multi-stage CLOS (5-stage with super-spine)
+* Pros: single flat fabric across all servers; optimal east-west bandwidth; well-understood in hyperscale datacenters (Google, Meta)
+* Cons: enormous blast radius; complex to operate and automate; not incrementally deployable; requires custom tooling for provisioning and lifecycle management
+
+=== Option 3: Partition groups with inter-partition spine layer
+* Pros: groups of partitions get low-latency interconnect; better than pure exit-layer routing for cross-partition traffic
+* Cons: additional switch layer to operate; hybrid approach with unclear failure domains; custom topology
+
+=== Option 4: Multiple partitions, each a multi-tier (4/5/6-tier) CLOS
+* Pros: combines Option 1 and Option 2. Partitions remain the unit of failure isolation and incremental growth, while each partition is itself a multi-tier CLOS (4/5/6-tier) large enough to host very large Kubernetes clusters inside one flat L3 fabric; blast radius bounded by the partition, not the whole fleet; no fleet-wide super-spine; aligns with the partition model the provisioning tool (ADR-0005) already needs to support
+* Cons: per-partition complexity higher than a 2-tier spine-leaf pod, with more switch tiers, more cabling, and more BGP sessions to operate; provisioning tooling must natively handle multi-tier CLOS fabrics within a partition; partition sizing trade-off becomes richer (tier count per partition is now a parameter)
+
+== Decision
+
+Multiple independent fabric partitions, each built as a multi-tier (4/5/6-tier) CLOS. Partitions are the unit of scaling and the outer failure domain, so adding capacity means adding partitions. Inside a partition, the fabric is a multi-tier CLOS sized so a large Kubernetes cluster fits in a single flat L3 fabric without crossing partition boundaries. Cross-partition traffic routes through exit switches. The exact tier count per partition (4, 5, or 6) is chosen per deployment based on target cluster size and switch radix, not fixed globally. The provisioning tool (ADR-0005) must natively support this partition-based multi-tier model.
+
+== Consequences
+
+* Partition sizing must be defined per deployment, including how many tiers each partition uses (4/5/6) and the resulting server capacity
+* Large Kubernetes clusters can be placed inside a single partition, avoiding cross-partition east-west traffic for the common case
+* Cross-partition latency is higher than intra-partition, so clusters should be placed within a single partition where possible
+* Exit switch capacity must be planned for cross-partition and external traffic
+* Partition placement across AZs (ADR-0009) must be defined
+* Adding capacity means adding partitions, not expanding existing fabrics
+* The provisioning tool must support partition-based multi-tier CLOS fabric management (ADR-0005)
+* Operational tooling and runbooks must cover multi-tier CLOS within a partition, not just 2-tier leaf-spine

--- a/docs/adr/0023-tenant-network-isolation.adoc
+++ b/docs/adr/0023-tenant-network-isolation.adoc
@@ -1,0 +1,40 @@
+:showtitle:
+:state: proposed
+
+= ADR-0023: Tenant network isolation
+
+Status:: proposed
+Date:: 2026-03-11
+Group:: networking
+Depends-on:: ADR-0004, ADR-0008
+
+== Context
+
+ADR-0008 requires dedicated physical clusters per tenant and states that network isolation must be enforced at the physical network level. With a spine-leaf BGP/EVPN fabric (ADR-0004), the question is how tenant traffic is isolated on the wire.
+
+== Options
+
+=== Option 1: VRF per tenant with EVPN/VXLAN
+* Pros: each tenant gets a dedicated VRF (routing table) on the leaf switches; complete L3 isolation at the fabric level — no tenant can see another tenant's traffic; EVPN distributes VRF state automatically across the fabric; VXLAN provides the overlay transport; scales to thousands of tenants (24-bit VNI space); per-tenant firewall for external connectivity provides explicit control over what enters/leaves the tenant boundary
+* Cons: VRF state on leaf switches grows with number of tenants; per-tenant firewall consumes capacity; cross-tenant communication requires explicit route leaking
+
+=== Option 2: VLAN-based isolation
+* Pros: simple and well-understood; no overlay required
+* Cons: limited to 4094 VLANs — does not scale; L2 only, no L3 isolation; spanning tree dependency
+
+=== Option 3: Network policy only (Cilium/CNI level)
+* Pros: software-defined; flexible; no switch configuration needed
+* Cons: isolation is only within the cluster, not between clusters on the wire; a compromised node could see other tenants' traffic on the physical network; does not satisfy EUCS SEAL-4 requirements for infrastructure-level isolation
+
+== Decision
+
+VRF per tenant with EVPN/VXLAN. Each tenant's traffic is confined to its own VRF, distributed across the CLOS fabric via EVPN Type-5 routes over VXLAN. Per-tenant firewalls provide controlled external connectivity with explicit route leaking between tenant VRF and Internet VRF. Combined with dedicated physical clusters (ADR-0008), tenant isolation is enforced at both compute and network level. The provisioning tool (separate ADR) must implement this model natively.
+
+== Consequences
+
+* Network isolation is a property of the infrastructure, not a software policy
+* Each tenant consumes a VRF and at least one VNI on the fabric
+* Per-tenant firewalls are required for external connectivity
+* Cilium network policies (ADR-0013) provide additional in-cluster isolation but are not the primary tenant boundary
+* Cross-tenant communication requires explicit route leaking — default is full isolation
+* The provisioning tool must automate VRF lifecycle as part of tenant provisioning (separate ADR)

--- a/docs/adr/0024-internal-network-addressing.adoc
+++ b/docs/adr/0024-internal-network-addressing.adoc
@@ -1,0 +1,38 @@
+:showtitle:
+:state: proposed
+
+= ADR-0024: Internal network addressing
+
+Status:: proposed
+Date:: 2026-03-11
+Group:: networking
+Depends-on:: ADR-0004, ADR-0013
+
+== Context
+
+The platform must choose an IP addressing model for internal networking: the pod network, service network, and inter-node communication within the CLOS fabric. Government policy promotes IPv6 adoption, but this applies to externally reachable services, not necessarily to internal infrastructure. The fabric already uses IPv6 link-local addresses for BGP Unnumbered peering (RFC 5549), so the underlay is IPv6-capable regardless of this decision. The question is what addressing the pod and service CIDRs use.
+
+== Options
+
+=== Option 1: IPv4 internally
+* Pros: all Kubernetes tooling, operators, and CNI plugins are mature on IPv4; simpler troubleshooting and operational model; no dual-stack complexity; address space is not a constraint for internal networks (RFC 1918); metal-stack and Cilium are proven on IPv4
+* Cons: does not satisfy a strict interpretation of "everything must be IPv6"; future migration to dual-stack requires re-addressing
+
+=== Option 2: IPv6 only internally
+* Pros: future-proof; unlimited address space; aligns with a strict reading of government IPv6 policy
+* Cons: many Kubernetes operators and third-party tools still assume IPv4; Helm charts and container images often hardcode IPv4 assumptions; debugging is harder (longer addresses, less familiar to most engineers); some legacy workloads cannot run on IPv6-only
+
+=== Option 3: Dual-stack (IPv4 + IPv6) internally
+* Pros: supports both; tenants can choose; most flexible
+* Cons: doubles the operational surface (two address families to monitor, troubleshoot, and secure); dual-stack Kubernetes is supported but adds complexity to network policies, service discovery, and CNI configuration; every component must be tested on both stacks; increases attack surface
+
+== Decision
+
+IPv4 internally. The pod network, service network, and internal communication use IPv4. Government IPv6 policy applies to externally reachable services, not internal infrastructure. The fabric underlay already uses IPv6 link-local for BGP peering, so the infrastructure is not "IPv6-unaware." Dual-stack was considered but rejected: the operational complexity of maintaining two address families internally is not justified when the internal address space is not constrained. IPv6 support for external-facing services (ingress, load balancing) is a separate concern handled at the ingress layer.
+
+== Consequences
+
+* Pod and service CIDRs are IPv4 (RFC 1918)
+* Internal tooling, monitoring, and network policies only need to handle IPv4
+* IPv6 at the ingress/load balancer layer is a separate decision (bare-metal load balancing ADR)
+* Migration to dual-stack remains possible in the future if requirements change, but is not designed for now


### PR DESCRIPTION
## Summary
- ADR-0022: Datacenter fabric scaling (partition-based, independent 2-tier CLOS per partition)
- ADR-0023: Tenant network isolation (VRF per tenant with EVPN/VXLAN)
- ADR-0005: Updated dependencies (metal-stack chosen because it implements these requirements)