### PR TITLE
Improve ADR options quality

### DIFF
--- a/docs/adr/0002-design-scale-target.adoc
+++ b/docs/adr/0002-design-scale-target.adoc
@@ -16,20 +16,20 @@ Fundament must define its design scale to make informed architecture decisions. 
 == Options
 
 === Option 1: Single-org scale (up to 500 physical servers)
-* Pros: most tools work, small team viable
-* Cons: not relevant for national government platform
+* Pros: most tools work out of the box; small team viable; fastest time to production
+* Cons: limits the platform to a single organization or small consortium
 
 === Option 2: Medium scale (up to 5,000 physical servers)
-* Pros: broad tool support, proven architectures available
-* Cons: insufficient for stated government ambition
+* Pros: broad tool support; proven architectures available; serves multiple organizations
+* Cons: may require re-architecture if demand grows beyond this target
 
 === Option 3: Hyperscale (up to 50,000 physical servers / ~2M logical CPUs)
-* Pros: meets government target (30-50% sovereign compute)
-* Cons: eliminates many tools, requires automation-first approach, dedicated DC network automation required
+* Pros: meets stated government ambition (30-50% sovereign compute); future-proof for multi-year growth; serves all government organizations on one platform
+* Cons: eliminates many tools that are not proven at this scale; requires automation-first approach from day one; dedicated DC network automation required
 
 == Decision
 
-Design for 50,000 physical servers / ~2,000,000 logical CPUs, to be reached within 3 years. All architecture decisions must be validated against this target.
+Design for 50,000 physical servers / ~2,000,000 logical CPUs, to be reached within 3 years. Options 1 and 2 were considered but do not match the government ambition to consolidate 30-50% of sovereign compute onto a single platform. Designing for a smaller target risks costly re-architecture when demand exceeds the initial design. All architecture decisions must be validated against this target.
 
 == Consequences
 

--- a/docs/adr/0004-datacenter-network-topology.adoc
+++ b/docs/adr/0004-datacenter-network-topology.adoc
@@ -16,20 +16,20 @@ At 50,000 physical servers across 3+ sites, the physical network architecture mu
 == Options
 
 === Option 1: Spine-leaf with BGP/EVPN
-* Pros: industry standard for large-scale DCs, horizontal scaling by adding leaves, well-understood fault domains, automated via open tooling (SONiC, FRR)
-* Cons: opinionated — requires compatible switch hardware, less flexible for legacy network designs
+* Pros: industry standard for large-scale DCs; horizontal scaling by adding leaves; well-understood fault domains; automated via open tooling (SONiC, FRR)
+* Cons: opinionated — requires compatible switch hardware; less flexible for legacy network designs
 
 === Option 2: Traditional three-tier (core/distribution/access)
-* Pros: familiar to most network teams, works with any vendor
-* Cons: spanning tree limits scale, poor east-west performance, difficult to automate, does not scale to 50,000 physical servers
+* Pros: familiar to most network teams; works with any vendor; large installed base in existing government DCs
+* Cons: spanning tree limits scale; poor east-west performance; difficult to automate
 
 === Option 3: SDN overlay (e.g. NSX, Contrail)
-* Pros: abstraction from physical topology, multi-tenant network virtualization built in
-* Cons: proprietary vendor dependency, additional software layer, licensing costs at scale
+* Pros: abstraction from physical topology; multi-tenant network virtualization built in
+* Cons: proprietary vendor dependency; additional software layer; licensing costs at scale
 
 == Decision
 
-Spine-leaf with BGP/EVPN. Only topology proven to scale to 50,000+ physical servers with full automation. Aligns with the automation-first requirement from ADR-0002.
+Spine-leaf with BGP/EVPN. At our target scale (ADR-0002), three-tier topology hits fundamental scaling limits due to spanning tree, and its east-west performance is insufficient for distributed systems like Ceph and etcd. SDN overlays add a proprietary dependency that conflicts with sovereignty requirements. Spine-leaf with BGP/EVPN is the only topology proven at 50,000+ servers with full automation, and aligns with the automation-first requirement from ADR-0002.
 
 == Consequences
 

--- a/docs/adr/0006-cluster-lifecycle-management.adoc
+++ b/docs/adr/0006-cluster-lifecycle-management.adoc
@@ -16,20 +16,28 @@ With bare-metal provisioning in place (ADR-0005), tenant organizations need dedi
 == Options
 
 === Option 1: Gardener
-* Pros: full lifecycle management built in (upgrades, cert rotation, node rotation, auto-scaling, self-healing), proven at scale (SAP runs thousands of clusters), control planes run as pods on Seed cluster (efficient), native metal-stack integration, European origin (SAP/NeoNephos/LF Europe), Apache 2.0
-* Cons: has its own concept model (Garden/Seed/Shoot) with learning curve, Seed cluster is critical component
+* Pros: full lifecycle management built in (upgrades, cert rotation, node rotation, auto-scaling, self-healing); proven at scale (SAP runs thousands of clusters); control planes run as pods on Seed cluster (efficient); native metal-stack integration; European origin (SAP/NeoNephos/LF Europe); Apache 2.0
+* Cons: complex to set up and operate; own concept model (Garden/Seed/Shoot) with learning curve; Seed cluster is a critical component; smaller community than CAPI
 
-=== Option 2: Kamaji
-* Pros: efficient shared control planes, CNCF Sandbox, fast provisioning
-* Cons: young project, smaller community, central etcd requires careful capacity planning, less mature tooling
+=== Option 2: Cluster API (CAPI) with infrastructure providers
+* Pros: Kubernetes-native declarative API; CNCF project; large community; modular — swap infrastructure providers; familiar to Kubernetes operators
+* Cons: no built-in day-2 operations (upgrades, cert rotation, self-healing are separate concerns); requires assembling multiple components; Metal³ provider is less mature than Gardener's metal-stack integration
 
-=== Option 3: vCluster
-* Pros: lowest overhead, seconds to provision, works within existing cluster
-* Cons: no kernel isolation (container breakout affects other tenants), fails EUCS SEAL-4 isolation requirements, sync mechanism adds attack surface
+=== Option 3: Kamaji
+* Pros: efficient shared control planes; CNCF Sandbox; fast provisioning
+* Cons: young project; smaller community; central etcd requires careful capacity planning; less mature day-2 tooling
+
+=== Option 4: Rancher (SUSE)
+* Pros: widely deployed in European government; UI-driven cluster management; supports multiple Kubernetes distributions; large community
+* Cons: commercial vendor dependency (SUSE); less suited for bare-metal at scale; no native metal-stack integration; day-2 operations less mature than Gardener
+
+=== Option 5: vCluster
+* Pros: lowest overhead; seconds to provision; works within existing cluster
+* Cons: no kernel isolation (container breakout affects other tenants); sync mechanism adds attack surface; commercial vendor dependency (Loft Labs)
 
 == Decision
 
-Gardener. Native metal-stack integration means the full stack (provisioning → cluster lifecycle) is proven in production together. Mature project with a lot of production exposure. European governance aligns with sovereignty requirements.
+Gardener. Native metal-stack integration means the full stack (provisioning → cluster lifecycle) is proven in production together. Gardener is the only option with comprehensive built-in day-2 operations at scale. CAPI requires assembling multiple components to achieve what Gardener provides out of the box. Rancher lacks native metal-stack integration. Kamaji is too young for production use at our scale. vCluster does not provide the kernel-level isolation required by ADR-0008 and EUCS SEAL-4. European governance aligns with sovereignty requirements.
 
 == Consequences
 

--- a/docs/adr/0009-availability-zones.adoc
+++ b/docs/adr/0009-availability-zones.adoc
@@ -16,20 +16,24 @@ Government workloads require high availability and disaster resilience. A single
 == Options
 
 === Option 1: Single AZ (1 datacenter)
-* Pros: simplest operations, no cross-site networking, no replication latency
-* Cons: single point of failure, unacceptable for government continuity requirements
+* Pros: simplest operations; no cross-site networking; no replication latency; lowest infrastructure cost
+* Cons: single point of failure; no disaster resilience
 
 === Option 2: 2 AZs
-* Pros: survives single-site failure, simpler than 3-site
-* Cons: split-brain risk for distributed systems (no quorum possible), failover capacity requires 2x provisioning
+* Pros: survives single-site failure; simpler than 3-site; lower infrastructure investment than 3 AZs
+* Cons: split-brain risk for distributed systems (no quorum possible with 2 sites); failover capacity requires 2x provisioning
 
-=== Option 3: 3+ AZs
-* Pros: quorum-based consensus possible (etcd, Ceph, etc.), survives single-site failure without split-brain, capacity can be distributed (each site runs at ~66% instead of 50%)
-* Cons: cross-site network complexity, data replication across 3 sites, higher infrastructure investment
+=== Option 3: 3 AZs
+* Pros: quorum-based consensus possible (etcd, Ceph, etc.); survives single-site failure without split-brain; capacity can be distributed (each site runs at ~66% instead of 50%)
+* Cons: cross-site network complexity; data replication across 3 sites; higher infrastructure investment
+
+=== Option 4: 4+ AZs
+* Pros: survives multiple simultaneous site failures; more granular capacity distribution
+* Cons: significantly higher infrastructure and operational cost; diminishing returns beyond 3 for quorum-based systems; cross-site replication complexity increases with each AZ
 
 == Decision
 
-Minimum 3 availability zones across physically separate government datacenters (ODCs). Three is the minimum for quorum-based distributed systems. Each AZ must be independently operational (separate power, cooling, network uplinks). Gardener Seed clusters, etcd, and storage replication all require odd-numbered site counts for consensus.
+Minimum 3 availability zones across physically separate government datacenters (ODCs). A single AZ does not provide disaster resilience, which is a hard requirement for government continuity. Two AZs create split-brain risk for all quorum-based systems (etcd, Ceph, Gardener). Three is the minimum for quorum-based consensus. Each AZ must be independently operational (separate power, cooling, network uplinks). Four or more AZs may be added later but 3 is the design target.
 
 == Consequences
 

--- a/docs/adr/0010-api-architecture.adoc
+++ b/docs/adr/0010-api-architecture.adoc
@@ -11,25 +11,25 @@ Depends-on:: ADR-0002
 
 == Context
 
-At 50,000 physical servers (ADR-0002), manual operations are not viable. Every action — tenant onboarding, cluster provisioning, network configuration, storage allocation — must be automatable. This requires a decision on whether the platform is API-first or UI-first.
+At 50,000 physical servers (ADR-0002), every action — tenant onboarding, cluster provisioning, network configuration, storage allocation — must be automatable. This requires a decision on whether the platform is API-first or UI-first, and how the UI relates to the API.
 
 == Options
 
 === Option 1: API-first
 * Pros: all operations are automatable from day one; UI is just an API client; third-party integrations use the same interface; enables GitOps and IaC workflows; single source of truth for platform state
-* Cons: higher upfront investment in API design; UI development depends on API readiness
+* Cons: higher upfront investment in API design; UI development depends on API readiness; slower initial demo-ability
 
 === Option 2: UI-first with API added later
-* Pros: faster initial user-facing progress; easier to demo
-* Cons: API becomes an afterthought; UI often accumulates business logic that must be extracted later; dual code paths; does not scale to 50,000 physical servers
+* Pros: faster initial user-facing progress; easier to demo and get stakeholder buy-in; lower initial engineering investment
+* Cons: API becomes an afterthought; UI often accumulates business logic that must be extracted later; dual code paths; automation consumers are second-class citizens
 
 === Option 3: Mixed (some operations API, some UI-only)
-* Pros: pragmatic for early stages
+* Pros: pragmatic for early stages; critical operations get API first, others can be UI-only initially
 * Cons: inconsistent automation story; some operations cannot be scripted; technical debt accumulates; unclear contract for integrators
 
 == Decision
 
-API-first. Every platform operation must be available through a versioned API. The UI consumes the same API as external clients. No operation may exist only in the UI. This is the only model compatible with the automation-first requirement from ADR-0002.
+API-first. Every platform operation must be available through a versioned API. The UI consumes the same API as external clients. No operation may exist only in the UI. The UI-first approach was proposed but rejected: at our scale, automation is not optional and retrofitting an API onto UI-first code is more expensive than designing API-first from the start. The mixed approach creates an unpredictable integration surface that external consumers cannot rely on.
 
 == Consequences
 

--- a/docs/adr/0013-container-network-interface.adoc
+++ b/docs/adr/0013-container-network-interface.adoc
@@ -17,19 +17,23 @@ With Kubernetes on bare-metal (ADR-0007) and a spine-leaf BGP/EVPN underlay (ADR
 
 === Option 1: Cilium
 * Pros: eBPF-based — high performance, no iptables overhead; built-in network policy, observability (Hubble), encryption (WireGuard), and load balancing; large CNCF community; BGP support for bare-metal integration; service mesh capabilities without sidecars
-* Cons: Isovalent (main contributor) was acquired by Cisco — long-term sovereignty implications unclear; eBPF requires recent kernel versions; metal-stack default is Calico, so integration requires additional work
+* Cons: Isovalent (main contributor) was acquired by Cisco — long-term sovereignty implications unclear; eBPF requires recent kernel versions; metal-stack default is Calico, so integration requires additional work; steep learning curve for eBPF debugging
 
 === Option 2: Calico
-* Pros: metal-stack default — proven integration; mature and battle-tested; supports BGP natively; well-understood operational model
-* Cons: iptables-based data plane at scale has performance limitations; less built-in observability; eBPF mode exists but is less mature than Cilium's; Tigera (main contributor) is also a commercial entity
+* Pros: metal-stack default — proven integration; mature and battle-tested; supports BGP natively; well-understood operational model; eBPF data plane mode available as optional upgrade path
+* Cons: iptables-based data plane has performance limitations at scale; less built-in observability; Tigera (main contributor) is also a commercial entity; eBPF mode is less mature than Cilium's native eBPF implementation
 
-=== Option 3: Calico with eBPF data plane
-* Pros: keeps metal-stack default integration; gains some eBPF performance benefits
-* Cons: eBPF support in Calico is less mature; smaller community around this mode; still lacks Cilium's integrated observability and service mesh
+=== Option 3: Antrea
+* Pros: OVS-based with eBPF support; CNCF project; strong multi-cluster networking; good VMware/Broadcom ecosystem integration
+* Cons: smaller community than Cilium and Calico; less bare-metal focus (origins in VMware); Broadcom acquisition adds vendor uncertainty
+
+=== Option 4: Flannel
+* Pros: simplest CNI to operate; well-understood; minimal resource overhead
+* Cons: no network policy enforcement (requires a separate policy engine); limited observability; no BGP support; too simple for a multi-tenant platform
 
 == Decision
 
-Cilium. The eBPF-based architecture provides superior performance, observability, and security features that align with platform requirements at scale. The sovereignty concern (Cisco acquisition of Isovalent) is noted but mitigated by Cilium's Apache 2.0 license and large open-source community beyond Isovalent. The metal-stack Calico default can be overridden at the Gardener shoot level. This decision should be revisited if Cilium's open-source governance changes materially.
+Cilium. The eBPF-based architecture provides superior performance, observability, and security features at scale. Calico is the metal-stack default and a credible alternative, but its iptables data plane is a scaling concern and its eBPF mode is less mature than Cilium's. Antrea has a smaller community and less bare-metal focus. Flannel lacks network policy enforcement entirely. The sovereignty concern around Cisco's acquisition of Isovalent is noted but mitigated by Cilium's Apache 2.0 license and large open-source community. This decision should be revisited if Cilium's open-source governance changes materially.
 
 == Consequences
 

--- a/docs/adr/0015-distributed-storage.adoc
+++ b/docs/adr/0015-distributed-storage.adoc
@@ -19,17 +19,25 @@ The platform needs distributed storage that replicates data across nodes and ava
 * Pros: proven at scale (exabyte-class deployments); provides block (RBD), file (CephFS), and object (RGW) from one system; cross-AZ replication built in; Rook provides Kubernetes-native lifecycle management; open source (LGPL); supports both hyperconverged and disaggregated topologies
 * Cons: operationally complex; requires tuning for bare-metal performance; minimum 3 nodes per storage cluster; significant resource overhead (MON, OSD, MGR daemons)
 
-=== Option 2: Longhorn
-* Pros: simple to deploy and operate; Kubernetes-native; CNCF project; good for small-to-medium clusters
+=== Option 2: LINSTOR/DRBD
+* Pros: proven in European hosting (Linbit is Austrian); efficient synchronous block replication; low overhead; supports both hyperconverged and disaggregated
+* Cons: block storage only — no file or object; smaller community than Ceph; dual licensing (GPLv2/commercial); less Kubernetes-native than Rook
+
+=== Option 3: Longhorn
+* Pros: simple to deploy and operate; Kubernetes-native; CNCF project
 * Cons: block storage only — no file or object; not proven at large scale; no cross-AZ replication; limited to hyperconverged
 
-=== Option 3: OpenEBS (Mayastor)
+=== Option 4: Specialized tools per storage tier (e.g. LINSTOR for block, MinIO for object, CephFS for file)
+* Pros: best-of-breed per tier; each component optimized for its workload
+* Cons: three systems to operate, monitor, and upgrade; no unified management; cross-tier consistency is the operator's problem; higher operational complexity
+
+=== Option 5: OpenEBS (Mayastor)
 * Pros: NVMe-optimized; Kubernetes-native; CNCF project
-* Cons: less mature than Ceph; primarily block storage; smaller community; limited large-scale production references
+* Cons: primarily block storage; less mature than Ceph; smaller community; limited large-scale production references
 
 == Decision
 
-Ceph via Rook. The only option proven at the target scale (ADR-0002) that provides block, file, and object storage from a single system. Cross-AZ replication satisfies the 3-AZ requirement (ADR-0009). Supports both hyperconverged and future disaggregated topologies (ADR-0014). Rook handles Ceph lifecycle within Kubernetes.
+Ceph via Rook. Ceph is the only option that provides block, file, and object storage from a single system at our target scale. LINSTOR is a credible block storage alternative with European roots, but lacks file and object storage — we would need additional systems (e.g. MinIO for object), increasing operational complexity. The specialized-tools-per-tier approach was considered but rejected: operating three storage systems is significantly more complex than one. Longhorn and OpenEBS are not proven at the scale we need (ADR-0002). Cross-AZ replication satisfies the 3-AZ requirement (ADR-0009). Rook handles Ceph lifecycle within Kubernetes.
 
 == Consequences
 


### PR DESCRIPTION
## Summary
- Present all options neutrally — rejection arguments moved to decision sections
- Remove straw man language from option descriptions
- Add missing credible alternatives (Rancher, CAPI, Antrea, LINSTOR, Flannel)
- Vary option counts (2-5) instead of formulaic 3-per-ADR

Affected: ADR-0002, 0004, 0006, 0009, 0010, 0013, 0015