### PR TITLE
refactor: use JWT Subject as user ID instead of custom claim

### DIFF
--- a/authn-api/pkg/authn/auth.go
+++ b/authn-api/pkg/authn/auth.go
@@ -101,7 +101,6 @@ func (s *AuthnServer) generateJWTWithExpiry(u *user, groups []string, expiry tim
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(expiry)),
 		},
-		UserID:          u.ID,
 		OrganizationIDs: u.OrganizationIDs,
 		Name:            u.Name,
 		Groups:          groups,

--- a/authn-api/pkg/authn/get_user_info.go
+++ b/authn-api/pkg/authn/get_user_info.go
@@ -33,7 +33,7 @@ func protoUserFromClaims(claims *auth.Claims) *authnv1.User {
 	}
 
 	return authnv1.User_builder{
-		Id:              claims.UserID.String(),
+		Id:              claims.Subject,
 		OrganizationIds: organizationIds,
 		Name:            claims.Name,
 		Groups:          claims.Groups,

--- a/authn-api/pkg/authn/refresh.go
+++ b/authn-api/pkg/authn/refresh.go
@@ -14,7 +14,9 @@ func (s *AuthnServer) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	organizationIDs, err := s.getUserOrganizationIDs(r.Context(), claims.UserID)
+	userID := claims.UserID()
+
+	organizationIDs, err := s.getUserOrganizationIDs(r.Context(), userID)
 	if err != nil {
 		s.logger.Error("failed to get user organizations", "error", err)
 		s.writeErrorJSON(w, http.StatusInternalServerError, "Failed to get user organizations")
@@ -22,7 +24,7 @@ func (s *AuthnServer) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	u := &user{
-		ID:              claims.UserID,
+		ID:              userID,
 		OrganizationIDs: organizationIDs,
 		Name:            claims.Name,
 	}

--- a/common/auth/auth.go
+++ b/common/auth/auth.go
@@ -17,10 +17,13 @@ const AuthCookieName = "fundament_auth"
 // Claims represents the JWT claims used across fundament services.
 type Claims struct {
 	jwt.RegisteredClaims
-	UserID          uuid.UUID   `json:"user_id"`
 	OrganizationIDs []uuid.UUID `json:"organization_ids"`
 	Groups          []string    `json:"groups"`
 	Name            string      `json:"name"`
+}
+
+func (c *Claims) UserID() uuid.UUID {
+	return uuid.MustParse(c.Subject)
 }
 
 // Validator handles JWT validation from HTTP headers.
@@ -97,7 +100,12 @@ func (v *Validator) validateToken(tokenString string) (*Claims, error) {
 		return nil, fmt.Errorf("invalid token claims")
 	}
 
-	v.logger.Debug("token validated", "user_id", claims.UserID, "organization_ids", claims.OrganizationIDs)
+	if _, err := uuid.Parse(claims.Subject); err != nil {
+		v.logger.Debug("invalid user ID in token subject", "subject", claims.Subject)
+		return nil, fmt.Errorf("invalid user ID in token subject: %w", err)
+	}
+
+	v.logger.Debug("token validated", "user_id", claims.Subject, "organization_ids", claims.OrganizationIDs)
 	return claims, nil
 }
 

--- a/common/auth/auth_test.go
+++ b/common/auth/auth_test.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+var testSecret = []byte("test-secret")
+
+func signToken(t *testing.T, claims *Claims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString(testSecret)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return s
+}
+
+func newValidator() *Validator {
+	return NewValidator(testSecret, nil)
+}
+
+func TestValidateToken_RejectsNonUUIDSubject(t *testing.T) {
+	claims := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "not-a-uuid",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tokenString := signToken(t, claims)
+
+	v := newValidator()
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+tokenString)
+
+	_, err := v.Validate(header)
+	if err == nil {
+		t.Fatal("expected error for non-UUID subject, got nil")
+	}
+}
+
+func TestValidateToken_AcceptsValidUUIDSubject(t *testing.T) {
+	userID := uuid.New()
+	claims := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID.String(),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tokenString := signToken(t, claims)
+
+	v := newValidator()
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+tokenString)
+
+	got, err := v.Validate(header)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Subject != userID.String() {
+		t.Errorf("subject = %q, want %q", got.Subject, userID.String())
+	}
+}
+
+func TestClaimsUserID(t *testing.T) {
+	userID := uuid.New()
+	claims := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: userID.String(),
+		},
+	}
+	if got := claims.UserID(); got != userID {
+		t.Errorf("UserID() = %v, want %v", got, userID)
+	}
+}

--- a/organization-api/pkg/organization/apikey_create.go
+++ b/organization-api/pkg/organization/apikey_create.go
@@ -31,9 +31,9 @@ func (s *Server) CreateAPIKey(
 		return nil, err
 	}
 
-	claims, ok := ClaimsFromContext(ctx)
+	userID, ok := UserIDFromContext(ctx)
 	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("claims missing from context"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
 	token, hash, err := apitoken.GenerateToken()
@@ -59,7 +59,7 @@ func (s *Server) CreateAPIKey(
 
 	params := db.APIKeyCreateParams{
 		OrganizationID: organizationID,
-		UserID:         claims.UserID,
+		UserID:         userID,
 		Name:           req.Msg.GetName(),
 		TokenHash:      hash,
 		TokenPrefix:    prefix,
@@ -80,7 +80,7 @@ func (s *Server) CreateAPIKey(
 	s.logger.InfoContext(ctx, "api key created",
 		"api_key_id", id,
 		"organization_id", organizationID,
-		"user_id", claims.UserID,
+		"user_id", userID,
 		"name", req.Msg.GetName(),
 	)
 

--- a/organization-api/pkg/organization/apikey_delete.go
+++ b/organization-api/pkg/organization/apikey_delete.go
@@ -22,12 +22,12 @@ func (s *Server) DeleteAPIKey(
 		return nil, err
 	}
 
-	claims, ok := ClaimsFromContext(ctx)
+	userID, ok := UserIDFromContext(ctx)
 	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("claims missing from context"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
-	rowsAffected, err := s.queries.APIKeyDelete(ctx, db.APIKeyDeleteParams{ID: apiKeyID, UserID: claims.UserID})
+	rowsAffected, err := s.queries.APIKeyDelete(ctx, db.APIKeyDeleteParams{ID: apiKeyID, UserID: userID})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete api key: %w", err))
 	}

--- a/organization-api/pkg/organization/apikey_get.go
+++ b/organization-api/pkg/organization/apikey_get.go
@@ -24,14 +24,14 @@ func (s *Server) GetAPIKey(
 		return nil, err
 	}
 
-	claims, ok := ClaimsFromContext(ctx)
+	userID, ok := UserIDFromContext(ctx)
 	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("claims missing from context"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
 	key, err := s.queries.APIKeyGetByID(ctx, db.APIKeyGetByIDParams{
 		ID:     apiKeyID,
-		UserID: claims.UserID,
+		UserID: userID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/organization-api/pkg/organization/apikey_list.go
+++ b/organization-api/pkg/organization/apikey_list.go
@@ -24,14 +24,14 @@ func (s *Server) ListAPIKeys(
 		return nil, err
 	}
 
-	claims, ok := ClaimsFromContext(ctx)
+	userID, ok := UserIDFromContext(ctx)
 	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("claims missing from context"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
 	keys, err := s.queries.APIKeyListByOrganizationID(ctx, db.APIKeyListByOrganizationIDParams{
 		OrganizationID: organizationID,
-		UserID:         claims.UserID,
+		UserID:         userID,
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list api keys: %w", err))

--- a/organization-api/pkg/organization/apikey_revoke.go
+++ b/organization-api/pkg/organization/apikey_revoke.go
@@ -22,12 +22,12 @@ func (s *Server) RevokeAPIKey(
 		return nil, err
 	}
 
-	claims, ok := ClaimsFromContext(ctx)
+	userID, ok := UserIDFromContext(ctx)
 	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("claims missing from context"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
-	rowsAffected, err := s.queries.APIKeyRevoke(ctx, db.APIKeyRevokeParams{ID: apiKeyID, UserID: claims.UserID})
+	rowsAffected, err := s.queries.APIKeyRevoke(ctx, db.APIKeyRevokeParams{ID: apiKeyID, UserID: userID})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to revoke api key: %w", err))
 	}

--- a/organization-api/pkg/organization/auth_interceptor.go
+++ b/organization-api/pkg/organization/auth_interceptor.go
@@ -31,15 +31,17 @@ func (s *Server) authInterceptor() connect.UnaryInterceptorFunc {
 				return nil, connect.NewError(connect.CodeUnauthenticated, err)
 			}
 
+			// Parse user ID from JWT subject
+			userID := claims.UserID()
+
 			// Inject user info into context
-			ctx = WithUserID(ctx, claims.UserID)
-			ctx = WithClaims(ctx, claims)
+			ctx = WithUserID(ctx, userID)
 
 			// Skip organization header check for user-scoped endpoints
 			if s.isUserScopedEndpoint(req.Spec().Procedure) {
 				s.logger.DebugContext(ctx, "skipping organization check for user-scoped endpoint",
 					"procedure", req.Spec().Procedure,
-					"user_id", claims.UserID,
+					"user_id", userID,
 				)
 				return next(ctx, req)
 			}
@@ -65,7 +67,7 @@ func (s *Server) authInterceptor() connect.UnaryInterceptorFunc {
 
 			s.logger.DebugContext(ctx, "request authenticated",
 				"organization_id", organizationID,
-				"user_id", claims.UserID,
+				"user_id", userID,
 			)
 
 			// Call next handler with enriched context

--- a/organization-api/pkg/organization/context.go
+++ b/organization-api/pkg/organization/context.go
@@ -4,13 +4,10 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-
-	"github.com/fundament-oss/fundament/common/auth"
 )
 
 type contextKeyOrganizationID struct{}
 type contextKeyUserID struct{}
-type contextKeyClaims struct{}
 
 // WithOrganizationID stores organization_id in context.
 func WithOrganizationID(ctx context.Context, organizationID uuid.UUID) context.Context {
@@ -34,16 +31,4 @@ func WithUserID(ctx context.Context, userID uuid.UUID) context.Context {
 func UserIDFromContext(ctx context.Context) (uuid.UUID, bool) {
 	userID, ok := ctx.Value(contextKeyUserID{}).(uuid.UUID)
 	return userID, ok
-}
-
-// WithClaims stores full claims in context for additional metadata like Groups.
-func WithClaims(ctx context.Context, claims *auth.Claims) context.Context {
-	return context.WithValue(ctx, contextKeyClaims{}, claims)
-}
-
-// ClaimsFromContext extracts claims from context.
-// Returns the claims and true if found, or nil and false if not found.
-func ClaimsFromContext(ctx context.Context) (*auth.Claims, bool) {
-	claims, ok := ctx.Value(contextKeyClaims{}).(*auth.Claims)
-	return claims, ok
 }

--- a/organization-api/pkg/organization/db.go
+++ b/organization-api/pkg/organization/db.go
@@ -48,14 +48,6 @@ func rlsOptions(logger *slog.Logger) []psqldb.Option {
 					logger.Debug("no user_id in context for PrepareConn")
 				}
 
-				if claims, ok := ClaimsFromContext(ctx); ok {
-					if err := queries.SetUserContext(ctx, dbgen.SetUserContextParams{
-						SetConfig: claims.UserID.String(),
-					}); err != nil {
-						return false, fmt.Errorf("failed to set user context: %w", err)
-					}
-				}
-
 				return true, nil
 			}
 

--- a/organization-api/pkg/organization/server_test.go
+++ b/organization-api/pkg/organization/server_test.go
@@ -229,11 +229,10 @@ func (e *testEnv) createAuthnToken(t *testing.T, userID uuid.UUID) string {
 	claims := auth.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    "fundament-authn-api",
-			Subject:   "external-" + userID.String(),
+			Subject:   userID.String(),
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
 		},
-		UserID:          userID,
 		OrganizationIDs: user.OrgIDs,
 		Name:            user.Name,
 	}


### PR DESCRIPTION
Removed the redundant `user_id` JWT claim and use the standard `Subject` field.