### PR TITLE
feat: functl uses XDG Base Directory

### DIFF
--- a/functl/README.md
+++ b/functl/README.md
@@ -24,16 +24,25 @@ just functl auth status
 
 ## Configuration
 
-Configuration files are stored in `~/.fundament/`:
+Configuration files are stored in `~/.config/fundament/` by default, following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/):
 
 | File | Description |
 |------|-------------|
 | `config.yaml` | API endpoints and default settings |
 | `credentials` | Stored API key (created after login) |
 
+The config directory is resolved in this order:
+
+1. `FUNCTL_CONFIG_DIR` environment variable (explicit override)
+2. `XDG_CONFIG_HOME/fundament` (XDG spec)
+3. `%APPDATA%/fundament` (Windows default)
+4. `~/.config/fundament` (Linux/macOS fallback)
+
+Use `functl config dir` to see the resolved directory, or `functl config path` for the config file path.
+
 ### Configuration file
 
-Create `~/.fundament/config.yaml` to override defaults:
+Create `~/.config/fundament/config.yaml` to override defaults:
 
 ```yaml
 api_endpoint: http://organization.fundament.localhost:8080
@@ -45,6 +54,7 @@ output: table
 
 | Variable | Description |
 |----------|-------------|
+| `FUNCTL_CONFIG_DIR` | Override the configuration directory path (must be absolute) |
 | `FUNDAMENT_API_KEY` | API key for authentication (takes precedence over credentials file) |
 
 ## Authentication

--- a/functl/pkg/cli/cli.go
+++ b/functl/pkg/cli/cli.go
@@ -15,6 +15,7 @@ type CLI struct {
 
 	Auth      AuthCmd      `cmd:"" help:"Authentication commands."`
 	Cluster   ClusterCmd   `cmd:"" help:"Manage clusters."`
+	Config    ConfigCmd    `cmd:"" help:"Configuration introspection."`
 	Org       OrgCmd       `cmd:"" help:"Manage organization."`
 	Project   ProjectCmd   `cmd:"" help:"Manage projects."`
 	Namespace NamespaceCmd `cmd:"" help:"Manage namespaces."`

--- a/functl/pkg/cli/config.go
+++ b/functl/pkg/cli/config.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/fundament-oss/fundament/functl/pkg/config"
+)
+
+// ConfigCmd contains configuration introspection subcommands.
+type ConfigCmd struct {
+	Dir  ConfigDirCmd  `cmd:"" help:"Print the resolved configuration directory path."`
+	Path ConfigPathCmd `cmd:"" help:"Print the resolved configuration file path."`
+}
+
+// ConfigDirCmd prints the resolved config directory.
+type ConfigDirCmd struct{}
+
+// Run executes the config dir command.
+func (c *ConfigDirCmd) Run(ctx *Context) error {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return err
+	}
+	fmt.Println(dir)
+	return nil
+}
+
+// ConfigPathCmd prints the resolved config file path.
+type ConfigPathCmd struct{}
+
+// Run executes the config path command.
+func (c *ConfigPathCmd) Run(ctx *Context) error {
+	path, err := config.ConfigPath()
+	if err != nil {
+		return err
+	}
+	fmt.Println(path)
+	return nil
+}

--- a/functl/pkg/cli/config.go
+++ b/functl/pkg/cli/config.go
@@ -19,7 +19,7 @@ type ConfigDirCmd struct{}
 func (c *ConfigDirCmd) Run(ctx *Context) error {
 	dir, err := config.ConfigDir()
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving config directory: %w", err)
 	}
 	fmt.Println(dir)
 	return nil
@@ -32,7 +32,7 @@ type ConfigPathCmd struct{}
 func (c *ConfigPathCmd) Run(ctx *Context) error {
 	path, err := config.ConfigPath()
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving config path: %w", err)
 	}
 	fmt.Println(path)
 	return nil

--- a/functl/pkg/config/config.go
+++ b/functl/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"gopkg.in/yaml.v3"
 )
@@ -32,12 +33,32 @@ func DefaultConfig() *Config {
 }
 
 // ConfigDir returns the path to the configuration directory.
+//
+// Resolution order:
+//  1. FUNCTL_CONFIG_DIR environment variable (explicit override)
+//  2. XDG_CONFIG_HOME/fundament (XDG spec)
+//  3. %APPDATA%/fundament (Windows default)
+//  4. ~/.config/fundament (Linux/macOS CLI convention)
 func ConfigDir() (string, error) {
+	if v := os.Getenv("FUNCTL_CONFIG_DIR"); v != "" {
+		if !filepath.IsAbs(v) {
+			return "", fmt.Errorf("FUNCTL_CONFIG_DIR must be an absolute path, got: %s", v)
+		}
+		return v, nil
+	}
+	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" && filepath.IsAbs(v) {
+		return filepath.Join(v, "fundament"), nil
+	}
+	if runtime.GOOS == "windows" {
+		if v := os.Getenv("APPDATA"); v != "" {
+			return filepath.Join(v, "fundament"), nil
+		}
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	return filepath.Join(home, ".fundament"), nil
+	return filepath.Join(home, ".config", "fundament"), nil
 }
 
 // ConfigPath returns the path to the configuration file.

--- a/functl/pkg/config/config.go
+++ b/functl/pkg/config/config.go
@@ -85,7 +85,7 @@ func EnsureConfigDir() error {
 	if err != nil {
 		return err
 	}
-	return os.MkdirAll(dir, 0700)
+	return os.MkdirAll(dir, 0o700)
 }
 
 // LoadConfig loads the configuration from the config file.
@@ -128,7 +128,7 @@ func SaveConfig(cfg *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
@@ -184,7 +184,7 @@ func SaveCredentials(creds *Credentials) error {
 	}
 
 	// Write with restricted permissions (owner read/write only)
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write credentials file: %w", err)
 	}
 

--- a/functl/pkg/config/config_test.go
+++ b/functl/pkg/config/config_test.go
@@ -49,7 +49,7 @@ func TestConfigDir_XDGConfigHome_Absolute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join("/home/user/.myconfig", "fundament")
+	want := "/home/user/.myconfig/fundament"
 	if dir != want {
 		t.Errorf("got %q, want %q", dir, want)
 	}

--- a/functl/pkg/config/config_test.go
+++ b/functl/pkg/config/config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigDir_FunclConfigDir_Absolute(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "/tmp/functl-config")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "/tmp/functl-config" {
+		t.Errorf("got %q, want /tmp/functl-config", dir)
+	}
+}
+
+func TestConfigDir_FunclConfigDir_Relative(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "relative/path")
+
+	_, err := ConfigDir()
+	if err == nil {
+		t.Fatal("expected error for relative FUNCTL_CONFIG_DIR, got nil")
+	}
+}
+
+func TestConfigDir_FunclConfigDir_Precedence(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "/custom/dir")
+	t.Setenv("XDG_CONFIG_HOME", "/xdg/config")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "/custom/dir" {
+		t.Errorf("got %q, want /custom/dir", dir)
+	}
+}
+
+func TestConfigDir_XDGConfigHome_Absolute(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "/home/user/.myconfig")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join("/home/user/.myconfig", "fundament")
+	if dir != want {
+		t.Errorf("got %q, want %q", dir, want)
+	}
+}
+
+func TestConfigDir_XDGConfigHome_Relative(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "relative/config")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".config", "fundament")
+	if dir != want {
+		t.Errorf("got %q, want %q (should fall through to default)", dir, want)
+	}
+}
+
+func TestConfigDir_Default(t *testing.T) {
+	t.Setenv("FUNCTL_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".config", "fundament")
+	if dir != want {
+		t.Errorf("got %q, want %q", dir, want)
+	}
+}


### PR DESCRIPTION
Config directory now resolves via: FUNCTL_CONFIG_DIR → XDG_CONFIG_HOME/fundament → %APPDATA%/fundament (Windows) → ~/.config/fundament (Linux/macOS).
