### PR TITLE
feat: make PluginInstallation CRD cluster-scoped

### DIFF
--- a/charts/fundament/crds/plugininstallations.plugins.fundament.io.yaml
+++ b/charts/fundament/crds/plugininstallations.plugins.fundament.io.yaml
@@ -11,7 +11,7 @@ spec:
     singular: plugininstallation
     shortNames:
       - pi
-  scope: Namespaced
+  scope: Cluster
   versions:
     - name: v1
       served: true

--- a/charts/fundament/crds/plugininstallations.plugins.fundament.io.yaml
+++ b/charts/fundament/crds/plugininstallations.plugins.fundament.io.yaml
@@ -39,6 +39,9 @@ spec:
           type: object
           required:
             - spec
+          x-kubernetes-validations:
+            - rule: "self.metadata.name == self.spec.pluginName"
+              message: "metadata.name must match spec.pluginName"
           properties:
             spec:
               type: object
@@ -57,6 +60,9 @@ spec:
                     - Never
                 pluginName:
                   type: string
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "spec.pluginName is immutable"
                 version:
                   type: string
                 clusterRoles:

--- a/docs/plugins/example-cert-manager.md
+++ b/docs/plugins/example-cert-manager.md
@@ -43,7 +43,6 @@ apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
   name: cert-manager-test
-  namespace: fundament
 spec:
   image: localhost:5111/cert-manager-plugin:latest
   pluginName: cert-manager-test

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -12,16 +12,23 @@ The plugin system allows extending Fundament with installable plugins that integ
   ┌──────────────────────────────────────────────────────────────────────────┐
   │                         Fundament Cluster                                │
   │                                                                          │
+  │  PluginInstallation CRs (cluster-scoped)                                 │
+  │  ┌──────────────────────┐                                                │
+  │  │ cert-manager-test    │                                                │
+  │  │ another-plugin       │                                                │
+  │  └──────────┬───────────┘                                                │
+  │             │                                                            │
   │  fundament namespace                                                     │
-  │  ┌───────────────────────────────────────────────────────────────────┐   │
-  │  │  PluginInstallation CRs          Plugin Controller                │   │
-  │  │  ┌──────────────────────┐       ┌──────────────────────────────┐  │   │
-  │  │  │ cert-manager-test    │──────►│ Watches CRs                  │  │   │
-  │  │  │ another-plugin       │       │ Creates plugin namespaces    │  │   │
-  │  │  └──────────────────────┘       │ Manages RBAC + deployments   │  │   │
-  │  │                                 │ Polls plugin status          │  │   │
-  │  │                                 └──────┬───────────────────────┘  │   │
-  │  └────────────────────────────────────────┼──────────────────────────┘   │
+  │  ┌──────────┼────────────────────────────────────────────────────────┐   │
+  │  │          ▼                                                        │   │
+  │  │  Plugin Controller                                                │   │
+  │  │  ┌──────────────────────────────┐                                 │   │
+  │  │  │ Watches CRs                  │                                 │   │
+  │  │  │ Creates plugin namespaces    │                                 │   │
+  │  │  │ Manages RBAC + deployments   │                                 │   │
+  │  │  │ Polls plugin status          │                                 │   │
+  │  │  └──────┬───────────────────────┘                                 │   │
+  │  └─────────┼─────────────────────────────────────────────────────────┘   │
   │                                           │ creates                      │
   │               ┌───────────────────────────┼─────────────────────┐        │
   │               ▼                           ▼                     ▼        │
@@ -179,7 +186,7 @@ The SDK provides optional helpers that plugins can use. Plugins are free to choo
 
 ## Plugin Controller
 
-The controller runs in the `fundament` namespace and watches `PluginInstallation` CRs.
+The controller watches `PluginInstallation` CRs.
 
 ### PluginInstallation CRD
 
@@ -188,7 +195,6 @@ apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
   name: cert-manager-test
-  namespace: fundament
 spec:
   image: ghcr.io/fundament-oss/fundament/cert-manager-plugin:v1.0.0
   pluginName: cert-manager-test

--- a/docs/plugins/writing-a-plugin.md
+++ b/docs/plugins/writing-a-plugin.md
@@ -129,7 +129,6 @@ apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
   name: my-plugin
-  namespace: fundament
 spec:
   image: registry.example.com/my-plugin:v1.0.0
   pluginName: my-plugin

--- a/plugin-controller/pkg/controller/reconciler.go
+++ b/plugin-controller/pkg/controller/reconciler.go
@@ -54,7 +54,7 @@ func NewReconciler(c client.Client, logger *slog.Logger, cfg *config.Config, opt
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.logger.With("plugin", req.NamespacedName)
+	log := r.logger.With("plugin", req.Name)
 
 	var cr pluginsv1.PluginInstallation
 	if err := r.client.Get(ctx, req.NamespacedName, &cr); err != nil {

--- a/plugin-controller/pkg/controller/reconciler_test.go
+++ b/plugin-controller/pkg/controller/reconciler_test.go
@@ -32,7 +32,6 @@ func testCR() *pluginsv1.PluginInstallation {
 	return &pluginsv1.PluginInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-cert-manager",
-			Namespace:  "fundament",
 			Generation: 1,
 		},
 		Spec: pluginsv1.PluginInstallationSpec{

--- a/plugin-controller/pkg/controller/resources.go
+++ b/plugin-controller/pkg/controller/resources.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	labelManagedBy             = "app.kubernetes.io/managed-by"
-	labelPlugin                = "plugins.fundament.io/plugin"
-	labelInstallationName      = "plugins.fundament.io/installation-name"
-	labelInstallationNamespace = "plugins.fundament.io/installation-namespace"
-	managedByValue             = "plugin-controller"
+	labelManagedBy        = "app.kubernetes.io/managed-by"
+	labelPlugin           = "plugins.fundament.io/plugin"
+	labelInstallationName = "plugins.fundament.io/installation-name"
+	managedByValue        = "plugin-controller"
 )
 
 // dnsLabelRegex matches valid DNS label names (RFC 1123).
@@ -53,10 +52,9 @@ func pluginNamespace(pluginName string) string {
 
 func childLabels(cr *pluginsv1.PluginInstallation) map[string]string {
 	return map[string]string{
-		labelManagedBy:             managedByValue,
-		labelPlugin:                cr.Spec.PluginName,
-		labelInstallationName:      cr.Name,
-		labelInstallationNamespace: cr.Namespace,
+		labelManagedBy:        managedByValue,
+		labelPlugin:           cr.Spec.PluginName,
+		labelInstallationName: cr.Name,
 	}
 }
 

--- a/plugins/Justfile
+++ b/plugins/Justfile
@@ -58,18 +58,17 @@ plugin-install plugin:
     kind: PluginInstallation
     metadata:
       name: {{ plugin }}
-      namespace: fundament
     spec:
       image: ${image}
       pluginName: {{ plugin }}
-      version: ${tag}
+      version: "${tag}"
       clusterRoles:
         - cluster-admin
     EOF
 
 # Delete a PluginInstallation CR
 plugin-uninstall plugin:
-    kubectl --context {{ kube_context }} delete plugininstallation -n fundament {{ plugin }}
+    kubectl --context {{ kube_context }} delete plugininstallation {{ plugin }}
 
 # Stream logs for a specific plugin
 plugin-logs plugin:
@@ -77,7 +76,7 @@ plugin-logs plugin:
 
 # Show all PluginInstallation CRs
 plugin-status:
-    kubectl --context {{ kube_context }} get plugininstallations -n fundament
+    kubectl --context {{ kube_context }} get plugininstallations
 
 # View logs from all pods
 logs:


### PR DESCRIPTION
Prevents collisions when two PluginInstallations in different namespaces share the same pluginName, as all child resources are derived solely from pluginName. Making the CRD cluster-scoped enforces at most one installation per plugin name cluster-wide.