### PR TITLE
feat: add liveness and readiness endpoints to authn-api

### DIFF
--- a/authn-api/cmd/fun-authn-api/main.go
+++ b/authn-api/cmd/fun-authn-api/main.go
@@ -184,6 +184,36 @@ func run() error {
 
 	mux := http.NewServeMux()
 
+	// Health endpoints
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		var errs []string
+
+		if err := db.Pool.Ping(ctx); err != nil {
+			errs = append(errs, "database: "+err.Error())
+		}
+		if err := authzClient.Healthy(ctx); err != nil {
+			errs = append(errs, "openfga: "+err.Error())
+		}
+		if err := checkOIDC(ctx, cfg.OIDCDiscoveryURL); err != nil {
+			errs = append(errs, "oidc: "+err.Error())
+		}
+
+		if len(errs) > 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(strings.Join(errs, "\n")))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
 	// Connect RPC handler for GetUserInfo
 	loggingInterceptor := logging.UnaryServerInterceptor(
 		logging.LoggerFunc(func(ctx context.Context, level logging.Level, msg string, fields ...any) {
@@ -235,6 +265,22 @@ func run() error {
 		return fmt.Errorf("server failed: %w", err)
 	}
 
+	return nil
+}
+
+func checkOIDC(ctx context.Context, discoveryURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL+"/.well-known/openid-configuration", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
 	return nil
 }
 

--- a/charts/fundament/templates/authn-api.yaml
+++ b/charts/fundament/templates/authn-api.yaml
@@ -69,6 +69,18 @@ spec:
                 configMapKeyRef:
                   name: openfga-config
                   key: authorization-model-id
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
           {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}
           volumeMounts:
             - name: gardener-kubeconfig

--- a/common/authz/client.go
+++ b/common/authz/client.go
@@ -35,6 +35,15 @@ func New(cfg Config) (*Client, error) {
 	return &Client{fga: fgaClient}, nil
 }
 
+// Healthy checks that the OpenFGA store is reachable.
+func (c *Client) Healthy(ctx context.Context) error {
+	_, err := c.fga.GetStore(ctx).Execute()
+	if err != nil {
+		return fmt.Errorf("openfga: %w", err)
+	}
+	return nil
+}
+
 // Evaluate performs a single access evaluation following the AuthZEN Access Evaluation API.
 // Returns a Decision indicating whether the subject can perform the action on the resource.
 func (c *Client) Evaluate(ctx context.Context, req EvaluationRequest) (Decision, error) {


### PR DESCRIPTION
Add /healthz and /readyz endpoints so Kubernetes can detect when authn-api is unhealthy or not ready to serve traffic. Readiness checks PostgreSQL, OpenFGA, and OIDC provider connectivity.