### PR TITLE
chore: rename cluster-worker /healthz to /livez

### DIFF
--- a/charts/fundament/templates/cluster-worker.yaml
+++ b/charts/fundament/templates/cluster-worker.yaml
@@ -50,7 +50,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: health
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/cluster-worker/cmd/main.go
+++ b/cluster-worker/cmd/main.go
@@ -238,7 +238,7 @@ func createShootAccess(cfg *config, gardenerClient gardener.Client, logger *slog
 
 func startHealthServer(cfg *config, logger *slog.Logger, checkers ...ReadyChecker) *http.Server {
 	healthMux := http.NewServeMux()
-	healthMux.HandleFunc("/healthz", func(resp http.ResponseWriter, _ *http.Request) {
+	healthMux.HandleFunc("/livez", func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
 		_, _ = resp.Write([]byte("ok"))
 	})


### PR DESCRIPTION
Adopts the modern Kubernetes /livez convention. The aggregate /readyz logic (outbox + status + reconcile IsReady) is intentionally unchanged: status and reconcile workers flip false->true after the first successful iteration, and the 3-consecutive-failure fatal handler already exits the process on real failures.