### PR TITLE
chore: rename authn-api /healthz to /livez and drop OIDC readyz check

### DIFF
--- a/authn-api/cmd/fun-authn-api/main.go
+++ b/authn-api/cmd/fun-authn-api/main.go
@@ -185,7 +185,7 @@ func run() error {
 	mux := http.NewServeMux()
 
 	// Health endpoints
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
@@ -200,9 +200,6 @@ func run() error {
 		}
 		if err := authzClient.Healthy(ctx); err != nil {
 			errs = append(errs, "openfga: "+err.Error())
-		}
-		if err := checkOIDC(ctx, cfg.OIDCDiscoveryURL); err != nil {
-			errs = append(errs, "oidc: "+err.Error())
 		}
 
 		if len(errs) > 0 {
@@ -265,22 +262,6 @@ func run() error {
 		return fmt.Errorf("server failed: %w", err)
 	}
 
-	return nil
-}
-
-func checkOIDC(ctx context.Context, discoveryURL string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL+"/.well-known/openid-configuration", nil)
-	if err != nil {
-		return err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
-	}
 	return nil
 }
 

--- a/charts/fundament/templates/authn-api.yaml
+++ b/charts/fundament/templates/authn-api.yaml
@@ -73,7 +73,7 @@ spec:
                   key: authorization-model-id
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
Adopts the modern Kubernetes /livez convention. The OIDC discovery check is removed from /readyz because a transient OIDC outage should not cycle pods out of rotation - existing JWTs still validate offline against the cached JWKs, and login-time failures surface to the user directly. Readyz now only checks DB + OpenFGA, which are the real dependencies for serving requests.