### PR TITLE
chore: rename kube-api-proxy /healthz to /livez and wire /readyz to OpenFGA

### DIFF
--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -65,7 +65,7 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/kube-api-proxy/pkg/proxy/server.go
+++ b/kube-api-proxy/pkg/proxy/server.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/fundament-oss/fundament/common/auth"
 	"github.com/fundament-oss/fundament/common/authz"
@@ -55,11 +57,18 @@ func New(logger *slog.Logger, cfg *Config, authzClient *authz.Client) (*Server, 
 	// Both prefixes are registered explicitly to prevent SSRF — only these paths reach the proxy
 	mux.Handle("/apis/", http.HandlerFunc(s.handleClusterProxy))
 	mux.Handle("/api/", http.HandlerFunc(s.handleClusterProxy))
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		if err := s.authz.Healthy(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("openfga: " + err.Error()))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ready"))
 	})


### PR DESCRIPTION
Adopts the modern Kubernetes /livez convention. /readyz now performs a cheap GetStore call against OpenFGA (via authz.Client.Healthy) with a 5s timeout, so readiness actually reflects the one external dependency the proxy needs to authorize requests.

Gardener is intentionally not checked: its client has no cheap health endpoint, and transient Gardener outages should not cycle pods. Startup-time client construction failure already catches misconfig.