### PR TITLE
feat: migrate plugin-sdk and plugin-controller to /livez

### DIFF
--- a/charts/fundament/templates/plugin-controller.yaml
+++ b/charts/fundament/templates/plugin-controller.yaml
@@ -142,7 +142,7 @@ spec:
               value: {{ $.Values.pluginController.logLevel }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: 8097
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/docs/funs/FUN-11.adoc
+++ b/docs/funs/FUN-11.adoc
@@ -139,7 +139,7 @@ The Plugin SDK (`plugin-sdk/pluginruntime/`) provides the framework for building
 * Environment configuration via env vars (`FUNDAMENT_CLUSTER_ID`, `FUNDAMENT_INSTALL_ID`, `FUNDAMENT_ORGANIZATION_ID`, `FUNP_LOG_LEVEL`, `FUNP_RECONCILE_INTERVAL`).
 * Structured JSON logging (slog).
 * HTTP server on port 8080 (configurable via `WithMetadataPort()`) with:
-** `GET /healthz` - Liveness probe (always 200 OK).
+** `GET /livez` - Liveness probe (always 200 OK).
 ** `GET /readyz` - Readiness probe (200 OK when plugin reports ready, 503 otherwise).
 ** `PluginMetadataService` - Connect RPC endpoint serving plugin status and definition.
 ** `/console/` - Static file server for console assets (if `ConsoleProvider` is implemented).
@@ -206,7 +206,7 @@ When a `PluginInstallation` is created, the controller:
 . Creates a RoleBinding binding the ServiceAccount to the built-in `admin` ClusterRole within the plugin namespace.
 . Optionally creates ClusterRoleBindings for any `clusterRoles` specified in the spec.
 . Creates a Deployment `runtime` in the plugin namespace with the specified container image.
-. The Deployment includes liveness (`/healthz`) and readiness (`/readyz`) probes.
+. The Deployment includes liveness (`/livez`) and readiness (`/readyz`) probes.
 . Plugin config values are injected as `FUNP_*` environment variables.
 . Polls the plugin's `PluginMetadataService` endpoint to track status and readiness.
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -97,7 +97,7 @@ When a plugin binary calls `pluginruntime.Run(plugin)`, the SDK:
         ├─ Create Host (provides logger, telemetry, status reporting)
         │
         ├─ Start HTTP server on :8080
-        │   ├─ GET /healthz ──────── Liveness probe (always 200)
+        │   ├─ GET /livez ───────── Liveness probe (always 200)
         │   ├─ GET /readyz ───────── Readiness probe (200 after ReportReady())
         │   ├─ ConnectRPC ─────────── PluginMetadataService (status + definition)
         │   └─ GET /console/ ──────── Static UI assets (if ConsoleProvider)

--- a/plugin-controller/cmd/main.go
+++ b/plugin-controller/cmd/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/go-logr/logr"
@@ -57,15 +60,24 @@ func run() error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: fmt.Sprintf(":%d", cfg.HealthPort),
+		LivenessEndpointName:   "/livez",
+		ReadinessEndpointName:  "/readyz",
 	})
 	if err != nil {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz check: %w", err)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("cache-sync", func(req *http.Request) error {
+		ctx, cancel := context.WithTimeout(req.Context(), 100*time.Millisecond)
+		defer cancel()
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
+			return fmt.Errorf("cache not synced")
+		}
+		return nil
+	}); err != nil {
 		return fmt.Errorf("add readyz check: %w", err)
 	}
 

--- a/plugin-controller/pkg/controller/reconciler_test.go
+++ b/plugin-controller/pkg/controller/reconciler_test.go
@@ -120,6 +120,8 @@ func TestMutateDeployment(t *testing.T) {
 	// Health probes
 	assert.NotNil(t, container.LivenessProbe)
 	assert.NotNil(t, container.ReadinessProbe)
+	assert.Equal(t, "/livez", container.LivenessProbe.HTTPGet.Path)
+	assert.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)
 }
 
 func TestMutateService(t *testing.T) {

--- a/plugin-controller/pkg/controller/resources.go
+++ b/plugin-controller/pkg/controller/resources.go
@@ -171,7 +171,7 @@ func mutateDeployment(deploy *appsv1.Deployment, cr *pluginsv1.PluginInstallatio
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/healthz",
+								Path: "/livez",
 								Port: intstr.FromString("http"),
 							},
 						},

--- a/plugin-sdk/pluginruntime/health/health_test.go
+++ b/plugin-sdk/pluginruntime/health/health_test.go
@@ -17,7 +17,7 @@ func (m *mockChecker) IsReady() bool {
 
 func TestLivenessHandler(t *testing.T) {
 	handler := LivenessHandler()
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/healthz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", http.NoBody)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/plugin-sdk/pluginruntime/run.go
+++ b/plugin-sdk/pluginruntime/run.go
@@ -57,7 +57,7 @@ func run(plugin Plugin, opts ...RunOption) error {
 
 	mux := http.NewServeMux()
 
-	mux.Handle("GET /healthz", health.LivenessHandler())
+	mux.Handle("GET /livez", health.LivenessHandler())
 	mux.Handle("GET /readyz", health.ReadinessHandler(h))
 
 	handler := NewMetadataHandler(


### PR DESCRIPTION
- plugin-sdk: rename /healthz -> /livez in the runtime HTTP server.
- plugin-controller:
  - Configure manager Liveness/ReadinessEndpointName to /livez and /readyz.
  - Replace the /readyz Ping no-op (which falsely flips ready before the cache syncs) with a real cache-sync check via mgr.GetCache().
  - Update the path baked into plugin Deployments so newly-installed plugins point at /livez. /readyz path is unchanged.
- Update tests, docs, and Helm chart for the controller.

Note: plugin images must be rebuilt from this commit to expose /livez. For local development under just dev this happens automatically. The SDK and controller change must ship together because the controller hardcodes the probe path into the Deployment spec for plugin pods.