### PR TITLE
ci: skip PR env on drafts and no-preview-env label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches: [master]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
     branches: [master]
 
 concurrency:
@@ -17,8 +25,45 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.check.outputs.should_deploy }}
+      should_teardown: ${{ steps.check.outputs.should_teardown }}
+    steps:
+      - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no-preview-env') }}
+        run: |
+          should_deploy=false
+          should_teardown=false
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            case "$ACTION" in
+              closed|converted_to_draft)
+                should_teardown=true
+                ;;
+              labeled)
+                [ "$LABEL_NAME" = "no-preview-env" ] && should_teardown=true
+                ;;
+              opened|reopened|synchronize|ready_for_review|unlabeled)
+                if [ "$IS_DRAFT" = "false" ] && [ "$HAS_SKIP_LABEL" = "false" ]; then
+                  should_deploy=true
+                fi
+                ;;
+            esac
+          fi
+
+          echo "should_deploy=$should_deploy" >> "$GITHUB_OUTPUT"
+          echo "should_teardown=$should_teardown" >> "$GITHUB_OUTPUT"
+
   build:
-    if: github.event.action != 'closed'
+    needs: gate
+    if: github.event_name == 'push' || needs.gate.outputs.should_deploy == 'true'
     strategy:
       matrix:
         include:
@@ -60,8 +105,8 @@ jobs:
       context: ${{ matrix.context }}
 
   deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    needs: build
+    needs: [gate, build]
+    if: needs.gate.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -171,7 +216,6 @@ jobs:
 
   terraform-acc-tests:
     needs: deploy
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -226,7 +270,6 @@ jobs:
 
   e2e-tests:
     needs: deploy
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -287,7 +330,8 @@ jobs:
           path: e2e/reports/
 
   teardown:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    needs: gate
+    if: needs.gate.outputs.should_teardown == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Previously a PR environment was created as soon as the PR was opened, including for drafts. Now the deploy/tear-down decision is centralized in a small gate job that computes should_deploy/should_teardown from the PR state:

- drafts and PRs labeled no-preview-env are not deployed
- converting a PR to draft or adding the no-preview-env label tears the env down
- taking a PR out of draft or removing the label re-deploys it