### PR TITLE
Fix: remove duplicate permissions directive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ permissions:
 env:
   FUNDAMENT_TEST_CACHE_DIR: /tmp/fundament-test-pg
 
-permissions:
-  contents: read
-
 jobs:
   organization-api:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The test.yml workflow had two top-level `permissions:` keys, causing GitHub Actions to reject the file. The duplicate was introduced when the Copilot Autofix bot added a second `permissions: contents: read` block alongside the one from the permissions hardening commit.