### PR TITLE
fix: move plugin metadata to top-level (Kubernetes-style)

### DIFF
--- a/docs/funs/FUN-11.adoc
+++ b/docs/funs/FUN-11.adoc
@@ -27,30 +27,29 @@ Fundament takes a minimalistic approach when it comes to Clusters, which are lig
 
 == Plugin Definition
 
-A Plugin Definition is a YAML manifest that declares the outline of a plugin. It uses a Kubernetes-style structure with `apiVersion` and `kind`:
+A Plugin Definition is a YAML manifest that declares the outline of a plugin. It uses a Kubernetes-style structure with `apiVersion`, `kind`, top-level `metadata`, and `spec`:
 
 [source,yaml]
 ---
 apiVersion: fundament.io/v1
 kind: PluginDefinition
+metadata:
+  name: cert-manager
+  displayName: Cert Manager
+  version: v1.17.2
+  description: Automated TLS certificate management for Kubernetes using cert-manager.
+  author: Fundament
+  license: Apache-2.0
+  icon: shield-check
+  urls:
+    homepage: https://cert-manager.io
+    repository: https://github.com/cert-manager/cert-manager
+    documentation: https://cert-manager.io/docs
+  tags:
+    - certificates
+    - tls
+    - security
 spec:
-  metadata:
-    name: cert-manager
-    displayName: Cert Manager
-    version: v1.17.2
-    description: Automated TLS certificate management for Kubernetes using cert-manager.
-    author: Fundament
-    license: Apache-2.0
-    icon: shield-check
-    urls:
-      homepage: https://cert-manager.io
-      repository: https://github.com/cert-manager/cert-manager
-      documentation: https://cert-manager.io/docs
-    tags:
-      - certificates
-      - tls
-      - security
-
   permissions:
     capabilities:
       - internet_access
@@ -107,7 +106,8 @@ The definition is validated by `plugin-sdk/pluginruntime/LoadDefinition()` which
 
 === Definition structure
 
-* **metadata**: Identifying information (name, displayName, version, description, author, license, icon, urls, tags).
+* **metadata** (top-level): Identifying information (name, displayName, version, description, author, license, icon, urls, tags).
+* **spec**: Behavioral configuration of the plugin, containing the fields below.
 * **permissions**: What the plugin needs from the platform.
 ** `capabilities`: Simple string list (e.g. `internet_access`).
 ** `rbac`: Kubernetes PolicyRule structures declaring the API groups, resources, and verbs the plugin requires.

--- a/docs/plugins/writing-a-plugin.md
+++ b/docs/plugins/writing-a-plugin.md
@@ -11,18 +11,17 @@ Writing a plugin consists of several steps, each described below.
 ```yaml
 apiVersion: fundament.io/v1
 kind: PluginDefinition
+metadata:
+  name: my-plugin
+  displayName: My Plugin
+  version: v1.0.0
+  description: Does something useful
+  author: My Team
+  license: Apache-2.0
+  icon: puzzle
+  tags:
+    - example
 spec:
-  metadata:
-    name: my-plugin
-    displayName: My Plugin
-    version: v1.0.0
-    description: Does something useful
-    author: My Team
-    license: Apache-2.0
-    icon: puzzle
-    tags:
-      - example
-
   permissions:
     capabilities:
       - internet_access

--- a/plugin-sdk/pluginruntime/definition.go
+++ b/plugin-sdk/pluginruntime/definition.go
@@ -1,15 +1,24 @@
 package pluginruntime
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
 
-// PluginDefinition contains the static metadata for a plugin.
+// PluginDefinition is the top-level plugin manifest, modeled after a
+// Kubernetes resource with apiVersion, kind, metadata, and spec.
 type PluginDefinition struct {
-	Metadata         PluginMetadata              `yaml:"metadata"`
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   PluginMetadata `yaml:"metadata"`
+	Spec       PluginSpec     `yaml:"spec"`
+}
+
+// PluginSpec contains the behavioral configuration of a plugin.
+type PluginSpec struct {
 	Permissions      Permissions                 `yaml:"permissions"`
 	Menu             MenuDefinition              `yaml:"menu"`
 	CustomComponents map[string]ComponentMapping `yaml:"customComponents"`
@@ -87,19 +96,13 @@ type FormGroup struct {
 type StatusMapping struct {
 	JSONPath string                 `yaml:"jsonPath"`
 	Values   map[string]StatusValue `yaml:"values"`
+	Default  *StatusValue           `yaml:"default"`
 }
 
 // StatusValue describes how a status value is displayed.
 type StatusValue struct {
 	Badge string `yaml:"badge"`
 	Label string `yaml:"label"`
-}
-
-// yamlManifest is the top-level YAML structure including apiVersion and kind.
-type yamlManifest struct {
-	APIVersion string           `yaml:"apiVersion"`
-	Kind       string           `yaml:"kind"`
-	Spec       PluginDefinition `yaml:"spec"`
 }
 
 // LoadDefinition reads a YAML plugin manifest from path and returns
@@ -111,19 +114,24 @@ func LoadDefinition(path string) (PluginDefinition, error) {
 		return PluginDefinition{}, fmt.Errorf("read plugin definition: %w", err)
 	}
 
-	var manifest yamlManifest
-	if err := yaml.Unmarshal(data, &manifest); err != nil {
+	var def PluginDefinition
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&def); err != nil {
 		return PluginDefinition{}, fmt.Errorf("parse plugin definition: %w", err)
 	}
 
-	if manifest.APIVersion != "fundament.io/v1" {
-		return PluginDefinition{}, fmt.Errorf("unsupported apiVersion %q, expected \"fundament.io/v1\"", manifest.APIVersion)
+	if def.APIVersion != "fundament.io/v1" {
+		return PluginDefinition{}, fmt.Errorf("unsupported apiVersion %q, expected \"fundament.io/v1\"", def.APIVersion)
 	}
-	if manifest.Kind != "PluginDefinition" {
-		return PluginDefinition{}, fmt.Errorf("unsupported kind %q, expected \"PluginDefinition\"", manifest.Kind)
+	if def.Kind != "PluginDefinition" {
+		return PluginDefinition{}, fmt.Errorf("unsupported kind %q, expected \"PluginDefinition\"", def.Kind)
+	}
+	if def.Metadata.Name == "" {
+		return PluginDefinition{}, fmt.Errorf("plugin definition is missing required field metadata.name")
 	}
 
-	return manifest.Spec, nil
+	return def, nil
 }
 
 // PluginPhase represents the current lifecycle phase of a plugin.

--- a/plugin-sdk/pluginruntime/definition_test.go
+++ b/plugin-sdk/pluginruntime/definition_test.go
@@ -1,0 +1,56 @@
+package pluginruntime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeDef(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "definition.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestLoadDefinition_MissingMetadataName(t *testing.T) {
+	path := writeDef(t, `apiVersion: fundament.io/v1
+kind: PluginDefinition
+metadata:
+  displayName: Example
+spec: {}
+`)
+
+	_, err := LoadDefinition(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metadata.name")
+}
+
+func TestLoadDefinition_UnsupportedAPIVersion(t *testing.T) {
+	path := writeDef(t, `apiVersion: other/v1
+kind: PluginDefinition
+metadata:
+  name: example
+spec: {}
+`)
+
+	_, err := LoadDefinition(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported apiVersion")
+}
+
+func TestLoadDefinition_UnsupportedKind(t *testing.T) {
+	path := writeDef(t, `apiVersion: fundament.io/v1
+kind: Other
+metadata:
+  name: example
+spec: {}
+`)
+
+	_, err := LoadDefinition(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported kind")
+}

--- a/plugin-sdk/pluginruntime/metadata_handler.go
+++ b/plugin-sdk/pluginruntime/metadata_handler.go
@@ -43,8 +43,8 @@ func (h *metadataHandler) GetStatus(_ context.Context, _ *connect.Request[pb.Get
 func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb.GetDefinitionRequest]) (*connect.Response[pb.GetDefinitionResponse], error) {
 	def := h.getDefinition()
 
-	orgMenu := make([]*pb.MenuEntry, len(def.Menu.Organization))
-	for i, entry := range def.Menu.Organization {
+	orgMenu := make([]*pb.MenuEntry, len(def.Spec.Menu.Organization))
+	for i, entry := range def.Spec.Menu.Organization {
 		orgMenu[i] = &pb.MenuEntry{
 			Crd:    ptr(entry.CRD),
 			List:   ptr(entry.List),
@@ -54,8 +54,8 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 		}
 	}
 
-	projectMenu := make([]*pb.MenuEntry, len(def.Menu.Project))
-	for i, entry := range def.Menu.Project {
+	projectMenu := make([]*pb.MenuEntry, len(def.Spec.Menu.Project))
+	for i, entry := range def.Spec.Menu.Project {
 		projectMenu[i] = &pb.MenuEntry{
 			Crd:    ptr(entry.CRD),
 			List:   ptr(entry.List),
@@ -65,8 +65,8 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 		}
 	}
 
-	rbacRules := make([]*pb.PolicyRule, len(def.Permissions.RBAC))
-	for i, rule := range def.Permissions.RBAC {
+	rbacRules := make([]*pb.PolicyRule, len(def.Spec.Permissions.RBAC))
+	for i, rule := range def.Spec.Permissions.RBAC {
 		rbacRules[i] = &pb.PolicyRule{
 			ApiGroups: rule.APIGroups,
 			Resources: rule.Resources,
@@ -74,16 +74,16 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 		}
 	}
 
-	customComponents := make(map[string]*pb.ComponentMapping, len(def.CustomComponents))
-	for k, v := range def.CustomComponents {
+	customComponents := make(map[string]*pb.ComponentMapping, len(def.Spec.CustomComponents))
+	for k, v := range def.Spec.CustomComponents {
 		customComponents[k] = &pb.ComponentMapping{
 			List:   ptr(v.List),
 			Detail: ptr(v.Detail),
 		}
 	}
 
-	uiHints := make(map[string]*pb.UIHint, len(def.UIHints))
-	for k, v := range def.UIHints {
+	uiHints := make(map[string]*pb.UIHint, len(def.Spec.UIHints))
+	for k, v := range def.Spec.UIHints {
 		formGroups := make([]*pb.FormGroup, len(v.FormGroups))
 		for i, fg := range v.FormGroups {
 			formGroups[i] = &pb.FormGroup{
@@ -124,7 +124,7 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 		},
 		Tags: def.Metadata.Tags,
 		Permissions: &pb.Permissions{
-			Capabilities: def.Permissions.Capabilities,
+			Capabilities: def.Spec.Permissions.Capabilities,
 			Rbac:         rbacRules,
 		},
 		Menu: &pb.MenuDefinition{
@@ -133,7 +133,7 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 		},
 		CustomComponents: customComponents,
 		UiHints:          uiHints,
-		Crds:             def.CRDs,
+		Crds:             def.Spec.CRDs,
 	}), nil
 }
 

--- a/plugin-sdk/pluginruntime/testing/harness_test.go
+++ b/plugin-sdk/pluginruntime/testing/harness_test.go
@@ -43,39 +43,41 @@ func (p *testPlugin) Definition() pluginruntime.PluginDefinition {
 			},
 			Tags: []string{"test", "example"},
 		},
-		Permissions: pluginruntime.Permissions{
-			Capabilities: []string{"internet_access", "cluster_scoped_resources"},
-			RBAC: []pluginruntime.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods", "services"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-			},
-		},
-		Menu: pluginruntime.MenuDefinition{
-			Organization: []pluginruntime.MenuEntry{
-				{CRD: "TestResource", List: true, Detail: true, Create: true, Icon: "puzzle"},
-			},
-		},
-		CustomComponents: map[string]pluginruntime.ComponentMapping{
-			"TestResource": {List: "TestResourceList", Detail: "TestResourceDetail"},
-		},
-		UIHints: map[string]pluginruntime.UIHint{
-			"TestResource": {
-				FormGroups: []pluginruntime.FormGroup{
-					{Name: "General", Fields: []string{"name", "namespace"}},
-				},
-				StatusMapping: pluginruntime.StatusMapping{
-					JSONPath: ".status.phase",
-					Values: map[string]pluginruntime.StatusValue{
-						"Running": {Badge: "success", Label: "Running"},
+		Spec: pluginruntime.PluginSpec{
+			Permissions: pluginruntime.Permissions{
+				Capabilities: []string{"internet_access", "cluster_scoped_resources"},
+				RBAC: []pluginruntime.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"pods", "services"},
+						Verbs:     []string{"get", "list", "watch"},
 					},
 				},
 			},
-		},
-		CRDs: []string{
-			"apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: testresources.test.example.com",
+			Menu: pluginruntime.MenuDefinition{
+				Organization: []pluginruntime.MenuEntry{
+					{CRD: "TestResource", List: true, Detail: true, Create: true, Icon: "puzzle"},
+				},
+			},
+			CustomComponents: map[string]pluginruntime.ComponentMapping{
+				"TestResource": {List: "TestResourceList", Detail: "TestResourceDetail"},
+			},
+			UIHints: map[string]pluginruntime.UIHint{
+				"TestResource": {
+					FormGroups: []pluginruntime.FormGroup{
+						{Name: "General", Fields: []string{"name", "namespace"}},
+					},
+					StatusMapping: pluginruntime.StatusMapping{
+						JSONPath: ".status.phase",
+						Values: map[string]pluginruntime.StatusValue{
+							"Running": {Badge: "success", Label: "Running"},
+						},
+					},
+				},
+			},
+			CRDs: []string{
+				"apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: testresources.test.example.com",
+			},
 		},
 	}
 }

--- a/plugins/cert-manager/definition.yaml
+++ b/plugins/cert-manager/definition.yaml
@@ -1,22 +1,22 @@
 apiVersion: fundament.io/v1
 kind: PluginDefinition
+metadata:
+  name: cert-manager
+  displayName: Cert Manager
+  version: v1.17.2
+  description: Automated TLS certificate management for Kubernetes using cert-manager.
+  author: Fundament
+  license: Apache-2.0
+  icon: shield-check
+  urls:
+    homepage: https://cert-manager.io
+    repository: https://github.com/cert-manager/cert-manager
+    documentation: https://cert-manager.io/docs
+  tags:
+    - certificates
+    - tls
+    - security
 spec:
-  metadata:
-    name: cert-manager
-    displayName: Cert Manager
-    version: v1.17.2
-    description: Automated TLS certificate management for Kubernetes using cert-manager.
-    author: Fundament
-    license: Apache-2.0
-    icon: shield-check
-    urls:
-      homepage: https://cert-manager.io
-      repository: https://github.com/cert-manager/cert-manager
-      documentation: https://cert-manager.io/docs
-    tags:
-      - certificates
-      - tls
-      - security
   permissions:
     capabilities:
       - internet_access

--- a/plugins/cert-manager/plugin_test.go
+++ b/plugins/cert-manager/plugin_test.go
@@ -20,10 +20,10 @@ func TestLoadDefinition(t *testing.T) {
 	assert.Equal(t, "Apache-2.0", def.Metadata.License)
 	assert.Equal(t, "shield-check", def.Metadata.Icon)
 	assert.Equal(t, "https://cert-manager.io", def.Metadata.URLs.Homepage)
-	assert.NotEmpty(t, def.Permissions.Capabilities)
-	assert.NotEmpty(t, def.Permissions.RBAC)
-	assert.Len(t, def.Menu.Organization, 1)
-	assert.Len(t, def.Menu.Project, 2)
+	assert.NotEmpty(t, def.Spec.Permissions.Capabilities)
+	assert.NotEmpty(t, def.Spec.Permissions.RBAC)
+	assert.Len(t, def.Spec.Menu.Organization, 1)
+	assert.Len(t, def.Spec.Menu.Project, 2)
 }
 
 func TestNewCertManagerPlugin(t *testing.T) {

--- a/plugins/external-dns/definition.yaml
+++ b/plugins/external-dns/definition.yaml
@@ -1,21 +1,21 @@
 apiVersion: fundament.io/v1
 kind: PluginDefinition
+metadata:
+  name: external-dns
+  displayName: External DNS
+  version: v1.16.1
+  description: Automatic DNS record management for Kubernetes resources using ExternalDNS.
+  author: Fundament
+  license: Apache-2.0
+  icon: world
+  urls:
+    homepage: https://kubernetes-sigs.github.io/external-dns/
+    repository: https://github.com/kubernetes-sigs/external-dns
+    documentation: https://kubernetes-sigs.github.io/external-dns/latest/
+  tags:
+    - dns
+    - networking
 spec:
-  metadata:
-    name: external-dns
-    displayName: External DNS
-    version: v1.16.1
-    description: Automatic DNS record management for Kubernetes resources using ExternalDNS.
-    author: Fundament
-    license: Apache-2.0
-    icon: world
-    urls:
-      homepage: https://kubernetes-sigs.github.io/external-dns/
-      repository: https://github.com/kubernetes-sigs/external-dns
-      documentation: https://kubernetes-sigs.github.io/external-dns/latest/
-    tags:
-      - dns
-      - networking
   permissions:
     capabilities:
       - internet_access

--- a/plugins/external-dns/plugin_test.go
+++ b/plugins/external-dns/plugin_test.go
@@ -20,10 +20,10 @@ func TestLoadDefinition(t *testing.T) {
 	assert.Equal(t, "Apache-2.0", def.Metadata.License)
 	assert.Equal(t, "world", def.Metadata.Icon)
 	assert.Equal(t, "https://kubernetes-sigs.github.io/external-dns/", def.Metadata.URLs.Homepage)
-	assert.NotEmpty(t, def.Permissions.Capabilities)
-	assert.NotEmpty(t, def.Permissions.RBAC)
-	assert.Empty(t, def.Menu.Organization)
-	assert.Len(t, def.Menu.Project, 1)
+	assert.NotEmpty(t, def.Spec.Permissions.Capabilities)
+	assert.NotEmpty(t, def.Spec.Permissions.RBAC)
+	assert.Empty(t, def.Spec.Menu.Organization)
+	assert.Len(t, def.Spec.Menu.Project, 1)
 }
 
 func TestNewExternalDNSPlugin(t *testing.T) {


### PR DESCRIPTION
The plugin definition format advertises a Kubernetes-style structure with apiVersion and kind, but nested metadata under spec — confusing for plugin developers who arrive with K8s intuition. Move metadata to the top level alongside spec, matching real K8s resources.

Splits PluginDefinition into a top-level manifest type and a new PluginSpec for the body; migrates in-tree plugin YAML files and FUN-11 documentation to the new shape.