### PR TITLE
Use idempotency mechanism when creating resources in the Console

### DIFF
--- a/console-frontend/src/app/add-cluster-summary/add-cluster-summary.component.ts
+++ b/console-frontend/src/app/add-cluster-summary/add-cluster-summary.component.ts
@@ -16,7 +16,7 @@ import { firstValueFrom } from 'rxjs';
 import { TitleService } from '../title.service';
 import { ClusterWizardStateService } from '../add-cluster-wizard-layout/cluster-wizard-state.service';
 import { OrganizationDataService } from '../organization-data.service';
-import { withIdempotency } from '../../connect/idempotency';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { CLUSTER, PLUGIN } from '../../connect/tokens';
 import {
   CreateClusterRequestSchema,
@@ -129,7 +129,7 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
 
   private pollInterval?: ReturnType<typeof setInterval>;
 
-  private idempotencyAbortController?: AbortController;
+  private idempotency = createIdempotencyRef();
 
   constructor() {
     this.titleService.setTitle('Cluster summary');
@@ -137,7 +137,6 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.stopPolling();
-    this.idempotencyAbortController?.abort();
   }
 
   async ngOnInit() {
@@ -265,12 +264,9 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
         kubernetesVersion: this.clusterConfig.kubernetesVersion,
       });
 
-      this.idempotencyAbortController?.abort();
-      this.idempotencyAbortController = new AbortController();
-
       const response = await withIdempotency(
         (opts) => this.client.createCluster(request, opts),
-        { signal: this.idempotencyAbortController.signal },
+        { signal: this.idempotency.reset() },
       );
       this.clusterId.set(response.clusterId);
       this.updateItem('cluster', {
@@ -301,9 +297,11 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
       (item) => item.type === 'plugin' && item.pluginId,
     );
 
+    const abortSignal = this.idempotency.reset();
+
     await Promise.allSettled([
-      ...nodePoolItems.map((item) => this.createNodePool(item.key, item.nodePoolConfig!, cid)),
-      ...pluginItems.map((item) => this.installPlugin(item.key, item.pluginId!, cid)),
+      ...nodePoolItems.map((item) => this.createNodePool(item.key, item.nodePoolConfig!, cid, abortSignal)),
+      ...pluginItems.map((item) => this.installPlugin(item.key, item.pluginId!, cid, abortSignal)),
     ]);
 
     // Start polling for sync status
@@ -315,6 +313,7 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
     key: string,
     config: { name: string; machineType: string; autoscaleMin: number; autoscaleMax: number },
     clusterId?: string,
+    abortSignal?: AbortSignal,
   ) {
     const cid = clusterId || this.clusterId();
     if (!cid) return;
@@ -330,7 +329,10 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
         autoscaleMax: config.autoscaleMax,
       });
 
-      const response = await firstValueFrom(this.client.createNodePool(request));
+      const response = await withIdempotency(
+        (opts) => this.client.createNodePool(request, opts),
+        { signal: abortSignal },
+      );
       this.updateItem(key, {
         requestStatus: 'succeeded',
         syncStatus: 'none',
@@ -344,7 +346,7 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async installPlugin(key: string, _pluginId: string, clusterId?: string) {
+  private async installPlugin(key: string, _pluginId: string, clusterId?: string, abortSignal?: AbortSignal) {
     const cid = clusterId || this.clusterId();
     if (!cid) return;
 
@@ -462,12 +464,12 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
       this.isCreating.set(true);
       await this.executeCreation();
     } else if (item.type === 'nodepool' && item.nodePoolConfig) {
-      await this.createNodePool(key, item.nodePoolConfig);
+      await this.createNodePool(key, item.nodePoolConfig, undefined, this.idempotency.reset());
       if (!this.pollInterval && this.progressItems().some((i) => i.syncStatus === 'syncing')) {
         this.startPolling();
       }
     } else if (item.type === 'plugin' && item.pluginId) {
-      await this.installPlugin(key, item.pluginId);
+      await this.installPlugin(key, item.pluginId, undefined, this.idempotency.reset());
     }
   }
 

--- a/console-frontend/src/app/add-cluster-summary/add-cluster-summary.component.ts
+++ b/console-frontend/src/app/add-cluster-summary/add-cluster-summary.component.ts
@@ -16,6 +16,7 @@ import { firstValueFrom } from 'rxjs';
 import { TitleService } from '../title.service';
 import { ClusterWizardStateService } from '../add-cluster-wizard-layout/cluster-wizard-state.service';
 import { OrganizationDataService } from '../organization-data.service';
+import { withIdempotency } from '../../connect/idempotency';
 import { CLUSTER, PLUGIN } from '../../connect/tokens';
 import {
   CreateClusterRequestSchema,
@@ -128,12 +129,15 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
 
   private pollInterval?: ReturnType<typeof setInterval>;
 
+  private idempotencyAbortController?: AbortController;
+
   constructor() {
     this.titleService.setTitle('Cluster summary');
   }
 
   ngOnDestroy() {
     this.stopPolling();
+    this.idempotencyAbortController?.abort();
   }
 
   async ngOnInit() {
@@ -261,7 +265,13 @@ export default class AddClusterSummaryComponent implements OnInit, OnDestroy {
         kubernetesVersion: this.clusterConfig.kubernetesVersion,
       });
 
-      const response = await firstValueFrom(this.client.createCluster(request));
+      this.idempotencyAbortController?.abort();
+      this.idempotencyAbortController = new AbortController();
+
+      const response = await withIdempotency(
+        (opts) => this.client.createCluster(request, opts),
+        { signal: this.idempotencyAbortController.signal },
+      );
       this.clusterId.set(response.clusterId);
       this.updateItem('cluster', {
         requestStatus: 'succeeded',

--- a/console-frontend/src/app/add-project/add-project.component.ts
+++ b/console-frontend/src/app/add-project/add-project.component.ts
@@ -12,6 +12,7 @@ import { Router, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
 import LoadingIndicatorComponent from '../icons/loading-indicator.component';
@@ -42,6 +43,8 @@ export default class AddProjectComponent implements AfterViewInit, OnInit {
   private titleService = inject(TitleService);
 
   private router = inject(Router);
+
+  private idempotency = createIdempotencyRef();
 
   private fb = inject(FormBuilder);
 
@@ -122,7 +125,10 @@ export default class AddProjectComponent implements AfterViewInit, OnInit {
         name: this.projectForm.value.name!,
       });
 
-      const response = await firstValueFrom(this.client.createProject(request));
+      const response = await withIdempotency(
+        (opts) => this.client.createProject(request, opts),
+        { signal: this.idempotency.reset() },
+      );
 
       this.toastService.success(`Project '${this.projectForm.value.name}' created successfully`);
 

--- a/console-frontend/src/app/api-keys/api-keys.component.ts
+++ b/console-frontend/src/app/api-keys/api-keys.component.ts
@@ -11,6 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { create } from '@bufbuild/protobuf';
 import { type Timestamp, timestampDate } from '@bufbuild/protobuf/wkt';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   tablerPlus,
@@ -78,6 +79,8 @@ export default class ApiKeysComponent implements OnInit {
   private titleService = inject(TitleService);
 
   private apiKeyClient = inject(APIKEY);
+
+  private idempotency = createIdempotencyRef();
 
   apiKeys = signal<APIKey[]>([]);
 
@@ -231,7 +234,10 @@ export default class ApiKeysComponent implements OnInit {
         expiresIn,
       });
 
-      const response = await firstValueFrom(this.apiKeyClient.createAPIKey(request));
+      const response = await withIdempotency(
+        (opts) => this.apiKeyClient.createAPIKey(request, opts),
+        { signal: this.idempotency.reset() },
+      );
 
       // Store the token to display to the user (only time it's shown)
       this.createdToken.set(response.token);

--- a/console-frontend/src/app/cluster-namespaces/cluster-namespaces.component.ts
+++ b/console-frontend/src/app/cluster-namespaces/cluster-namespaces.component.ts
@@ -6,6 +6,7 @@ import { tablerPlus, tablerTrash, tablerAlertTriangle } from '@ng-icons/tabler-i
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { TitleService } from '../title.service';
 import { ToastService } from '../toast.service';
 import { OrganizationDataService } from '../organization-data.service';
@@ -44,6 +45,8 @@ export default class ClusterNamespacesComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   private client = inject(CLUSTER);
+
+  private idempotency = createIdempotencyRef();
 
   private namespaceClient = inject(NAMESPACE);
 
@@ -167,7 +170,10 @@ export default class ClusterNamespacesComponent implements OnInit {
         name: this.namespaceForm.value.name!,
       });
 
-      await firstValueFrom(this.namespaceClient.createNamespace(request));
+      await withIdempotency(
+        (opts) => this.namespaceClient.createNamespace(request, opts),
+        { signal: this.idempotency.reset() },
+      );
 
       this.showAddNamespaceModal.set(false);
       this.toastService.success(`Namespace '${this.namespaceForm.value.name}' created`);

--- a/console-frontend/src/app/cluster-nodes/cluster-nodes.component.ts
+++ b/console-frontend/src/app/cluster-nodes/cluster-nodes.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, signal, OnInit, ChangeDetectionStrategy } from '@ang
 import { Router, ActivatedRoute } from '@angular/router';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
 import { TitleService } from '../title.service';
@@ -42,6 +43,8 @@ export default class ClusterNodesComponent implements OnInit {
   private clusterId = '';
 
   private existingNodePools: NodePool[] = [];
+
+  private idempotency = createIdempotencyRef();
 
   errorMessage = signal<string | null>(null);
 
@@ -118,6 +121,8 @@ export default class ClusterNodesComponent implements OnInit {
       );
 
       // Create or update pools
+      const signal = this.idempotency.reset();
+
       await Promise.all(
         newPools.map((newPool) => {
           const existingPool = existingPoolsMap.get(newPool.name);
@@ -144,7 +149,10 @@ export default class ClusterNodesComponent implements OnInit {
               autoscaleMin: newPool.autoscaleMin,
               autoscaleMax: newPool.autoscaleMax,
             });
-            return firstValueFrom(this.client.createNodePool(createRequest));
+            return withIdempotency(
+              (opts) => this.client.createNodePool(createRequest, opts),
+              { signal },
+            );
           }
           return undefined;
         }),

--- a/console-frontend/src/app/namespaces/namespaces.component.ts
+++ b/console-frontend/src/app/namespaces/namespaces.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { tablerPlus, tablerTrash, tablerAlertTriangle } from '@ng-icons/tabler-icons';
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
@@ -41,6 +42,8 @@ export default class NamespacesComponent implements OnInit {
   private fb = inject(FormBuilder);
 
   private namespaceClient = inject(NAMESPACE);
+
+  private idempotency = createIdempotencyRef();
 
   private toastService = inject(ToastService);
 
@@ -117,7 +120,10 @@ export default class NamespacesComponent implements OnInit {
         name: this.namespaceForm.value.name!,
       });
 
-      await firstValueFrom(this.namespaceClient.createNamespace(request));
+      await withIdempotency(
+        (opts) => this.namespaceClient.createNamespace(request, opts),
+        { signal: this.idempotency.reset() },
+      );
 
       this.showCreateNamespaceModal.set(false);
       this.toastService.success(`Namespace '${this.namespaceForm.value.name}' created`);

--- a/console-frontend/src/app/organization-members/organization-members.component.ts
+++ b/console-frontend/src/app/organization-members/organization-members.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { ConnectError, Code } from '@connectrpc/connect';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -86,6 +87,8 @@ export default class OrganizationMembersComponent implements OnInit {
   private memberClient = inject(MEMBER);
 
   private inviteClient = inject(INVITE);
+
+  private idempotency = createIdempotencyRef();
 
   private authnService = inject(AuthnApiService);
 
@@ -183,8 +186,9 @@ export default class OrganizationMembersComponent implements OnInit {
     this.inviteError.set(null);
 
     try {
-      await firstValueFrom(
-        this.inviteClient.inviteMember({ email, permission: this.invitePermission() }),
+      await withIdempotency(
+        (opts) => this.inviteClient.inviteMember({ email, permission: this.invitePermission() }, opts),
+        { signal: this.idempotency.reset() },
       );
       this.closeModal();
       await this.loadMembers();

--- a/console-frontend/src/app/plugin-details/plugin-details.component.ts
+++ b/console-frontend/src/app/plugin-details/plugin-details.component.ts
@@ -6,6 +6,7 @@ import { tablerChevronRight, tablerCheck } from '@ng-icons/tabler-icons';
 import { tablerCircleXFill } from '@ng-icons/tabler-icons/fill';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef } from '../../connect/idempotency';
 import { TitleService } from '../title.service';
 import InstallPluginModalComponent from '../install-plugin-modal/install-plugin-modal';
 import { LoadingIndicatorComponent } from '../icons';
@@ -54,6 +55,8 @@ export default class PluginDetailsComponent implements OnInit {
   private clusterClient = inject(CLUSTER);
 
   private toastService = inject(ToastService);
+
+  private idempotency = createIdempotencyRef();
 
   pluginId = signal<string>('');
 

--- a/console-frontend/src/app/project-members/project-members.component.ts
+++ b/console-frontend/src/app/project-members/project-members.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, signal, OnInit, ChangeDetectionStrategy } from '@ang
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { firstValueFrom } from 'rxjs';
+import { createIdempotencyRef, withIdempotency } from '../../connect/idempotency';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -75,6 +76,8 @@ export default class ProjectMembersComponent implements OnInit {
   private fb = inject(FormBuilder);
 
   private projectClient = inject(PROJECT);
+
+  private idempotency = createIdempotencyRef();
 
   private memberClient = inject(MEMBER);
 
@@ -197,12 +200,13 @@ export default class ProjectMembersComponent implements OnInit {
         );
       } else {
         const userId = this.memberForm.value.userId!;
-        await firstValueFrom(
-          this.projectClient.addProjectMember({
+        await withIdempotency(
+          (opts) => this.projectClient.addProjectMember({
             projectId: this.projectId(),
             userId,
             role,
-          }),
+          }, opts),
+          { signal: this.idempotency.reset() },
         );
       }
 

--- a/console-frontend/src/connect/idempotency.spec.ts
+++ b/console-frontend/src/connect/idempotency.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Observable } from 'rxjs';
+import { type CallOptions } from '@connectrpc/connect';
+import { withIdempotency } from './idempotency';
+
+interface FakeResponse {
+  clusterId: string;
+}
+
+function makeCall(statuses: string[], response: FakeResponse = { clusterId: 'abc' }) {
+  let callCount = 0;
+  return vi.fn((options: CallOptions) => {
+    const status = statuses[callCount++] ?? 'completed';
+    return new Observable<FakeResponse>((sub) => {
+      options.onHeader?.(new Headers({ 'Idempotency-Status': status }));
+      sub.next(response);
+      sub.complete();
+    });
+  });
+}
+
+describe('withIdempotency', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resolves immediately when status is completed on first call', async () => {
+    const call = makeCall(['completed']);
+    const result = await withIdempotency(call);
+    expect(result).toEqual({ clusterId: 'abc' });
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls until completed', async () => {
+    const call = makeCall(['processing', 'processing', 'completed']);
+    const promise = withIdempotency(call, { pollIntervalMs: 100 });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(await promise).toEqual({ clusterId: 'abc' });
+    expect(call).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects when status is failed', async () => {
+    const call = makeCall(['failed']);
+    await expect(withIdempotency(call)).rejects.toThrow('Idempotency processing failed');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects on timeout', async () => {
+    // pollIntervalMs: 100, timeoutMs: 150 — deadline is hit after the first delay,
+    // before a second attempt would return 'completed'.
+    const call = makeCall(['processing', 'processing', 'processing']);
+    const promise = withIdempotency(call, { pollIntervalMs: 100, timeoutMs: 150 });
+    const assertion = expect(promise).rejects.toThrow('timed out');
+    await vi.advanceTimersByTimeAsync(300);
+    await assertion;
+  });
+
+  it('propagates network errors out of the polling loop', async () => {
+    const networkError = new Error('Network failure');
+    const call = vi.fn(() => {
+      return new Observable<FakeResponse>((sub) => {
+        sub.error(networkError);
+      });
+    });
+    await expect(withIdempotency(call)).rejects.toThrow('Network failure');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when AbortSignal is triggered during polling delay', async () => {
+    const controller = new AbortController();
+    const call = makeCall(['processing']);
+    const promise = withIdempotency(call, { signal: controller.signal, pollIntervalMs: 1000 });
+    // Allow the first attempt to complete (status: processing), then abort during the delay.
+    // Attach .catch before aborting so the rejection is handled synchronously.
+    await vi.advanceTimersByTimeAsync(0);
+    const caught = promise.catch((err: unknown) => err);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await caught).toMatchObject({ name: 'AbortError' });
+  });
+
+  it('rejects when AbortSignal is already aborted before the loop starts', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const call = makeCall(['processing']);
+    await expect(
+      withIdempotency(call, { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('sends the same idempotency key on every retry', async () => {
+    const keys: string[] = [];
+    const call = vi.fn((options: CallOptions) => {
+      const headerMap = options.headers as Record<string, string>;
+      keys.push(headerMap['Idempotency-Key']);
+      const status = keys.length < 3 ? 'processing' : 'completed';
+      return new Observable<FakeResponse>((sub) => {
+        options.onHeader?.(new Headers({ 'Idempotency-Status': status }));
+        sub.next({ clusterId: 'abc' });
+        sub.complete();
+      });
+    });
+    const promise = withIdempotency(call, { pollIntervalMs: 100 });
+    await vi.advanceTimersByTimeAsync(300);
+    await promise;
+    expect(new Set(keys).size).toBe(1);
+    expect(keys).toHaveLength(3);
+  });
+});

--- a/console-frontend/src/connect/idempotency.ts
+++ b/console-frontend/src/connect/idempotency.ts
@@ -1,0 +1,70 @@
+import { type CallOptions } from '@connectrpc/connect';
+import { type Observable, firstValueFrom } from 'rxjs';
+
+export const IDEMPOTENCY_STATUS = {
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+} as const;
+
+
+export interface IdempotencyOptions {
+  /** Milliseconds between polling attempts. Default: 1000 */
+  pollIntervalMs?: number;
+  /** Max total wait time in ms before rejecting. Default: 300_000 (5 min) */
+  timeoutMs?: number;
+  /** AbortSignal to cancel polling early (e.g. on component destroy). */
+  signal?: AbortSignal;
+}
+
+export async function withIdempotency<T>(
+  call: (options: CallOptions) => Observable<T>,
+  options: IdempotencyOptions = {},
+): Promise<T> {
+  const { pollIntervalMs = 1000, timeoutMs = 300_000, signal } = options;
+  const key = crypto.randomUUID();
+  const deadline = Date.now() + timeoutMs;
+
+  const attempt = (): Promise<{ response: T; status: string }> =>
+    new Promise((resolve, reject) => {
+      let idempotencyStatus: string = IDEMPOTENCY_STATUS.PROCESSING;
+      firstValueFrom(
+        call({
+          headers: { 'Idempotency-Key': key },
+          onHeader: (headers) => {
+            idempotencyStatus =
+              headers.get('Idempotency-Status') ?? IDEMPOTENCY_STATUS.PROCESSING;
+          },
+          signal,
+        }),
+      ).then(
+        (response) => resolve({ response, status: idempotencyStatus }),
+        reject,
+      );
+    });
+
+  while (true) {
+    if (signal?.aborted) throw new DOMException('Idempotency polling aborted', 'AbortError');
+    if (Date.now() >= deadline) throw new Error(`Idempotency timed out after ${timeoutMs}ms`);
+
+    // Sequential polling: each attempt must complete before the next begins.
+    // eslint-disable-next-line no-await-in-loop
+    const { response, status } = await attempt();
+
+    if (status === IDEMPOTENCY_STATUS.COMPLETED) return response;
+    if (status === IDEMPOTENCY_STATUS.FAILED) throw new Error('Idempotency processing failed');
+
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, pollIntervalMs);
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          reject(new DOMException('Idempotency polling aborted', 'AbortError'));
+        },
+        { once: true },
+      );
+    });
+  }
+}

--- a/console-frontend/src/connect/idempotency.ts
+++ b/console-frontend/src/connect/idempotency.ts
@@ -1,3 +1,4 @@
+import { DestroyRef, inject } from '@angular/core';
 import { type CallOptions } from '@connectrpc/connect';
 import { type Observable, firstValueFrom } from 'rxjs';
 
@@ -17,6 +18,29 @@ export interface IdempotencyOptions {
   signal?: AbortSignal;
 }
 
+export interface IdempotencyRef {
+  /** Aborts any in-flight call and returns a fresh AbortSignal for the next one. */
+  reset(): AbortSignal;
+}
+
+/**
+ * Creates an idempotency controller tied to the current injection context.
+ * The active AbortController is automatically aborted on component/directive destroy.
+ * Must be called inside an injection context (e.g. a field initializer or constructor).
+ */
+export function createIdempotencyRef(): IdempotencyRef {
+  const destroyRef = inject(DestroyRef);
+  let controller = new AbortController();
+  destroyRef.onDestroy(() => controller.abort());
+  return {
+    reset(): AbortSignal {
+      controller.abort();
+      controller = new AbortController();
+      return controller.signal;
+    },
+  };
+}
+
 export async function withIdempotency<T>(
   call: (options: CallOptions) => Observable<T>,
   options: IdempotencyOptions = {},
@@ -25,23 +49,20 @@ export async function withIdempotency<T>(
   const key = crypto.randomUUID();
   const deadline = Date.now() + timeoutMs;
 
-  const attempt = (): Promise<{ response: T; status: string }> =>
-    new Promise((resolve, reject) => {
-      let idempotencyStatus: string = IDEMPOTENCY_STATUS.PROCESSING;
-      firstValueFrom(
-        call({
-          headers: { 'Idempotency-Key': key },
-          onHeader: (headers) => {
-            idempotencyStatus =
-              headers.get('Idempotency-Status') ?? IDEMPOTENCY_STATUS.PROCESSING;
-          },
-          signal,
-        }),
-      ).then(
-        (response) => resolve({ response, status: idempotencyStatus }),
-        reject,
-      );
-    });
+  const attempt = async (): Promise<{ response: T; status: string }> => {
+    let idempotencyStatus: string = IDEMPOTENCY_STATUS.PROCESSING;
+    const response = await firstValueFrom(
+      call({
+        headers: { 'Idempotency-Key': key },
+        onHeader: (headers) => {
+          idempotencyStatus =
+            headers.get('Idempotency-Status') ?? IDEMPOTENCY_STATUS.PROCESSING;
+        },
+        signal,
+      }),
+    );
+    return { response, status: idempotencyStatus };
+  };
 
   while (true) {
     if (signal?.aborted) throw new DOMException('Idempotency polling aborted', 'AbortError');

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ opentofu = "1.11.3"
 # Go
 go = "1.26.2"
 "go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "0.20.1"
-golangci-lint = "2.7.2"
+golangci-lint = "2.11.4"
 "aqua:sqlc-dev/sqlc" = "1.30.0"
 "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" = "2.4.1"
 "go:google.golang.org/open2opaque" = "0.1.7"


### PR DESCRIPTION
Implements FUN-15 (idempotency support) across all resource-creation operations in the Console frontend.

The `withIdempotency` helper:
- Generates a UUID `Idempotency-Key` per call and reuses it on every retry
- Polls the `Idempotency-Status` response header until the backend reports `completed`
- Rejects on `failed` status, configurable timeout (default 5 min), or `AbortSignal`