### PR TITLE
Use idempotency mechanism in the E2E tests

### DIFF
--- a/e2e/bun.lock
+++ b/e2e/bun.lock
@@ -8,7 +8,6 @@
         "@bufbuild/protobuf": "2.11.0",
         "@connectrpc/connect": "2.1.1",
         "@connectrpc/connect-node": "2.1.1",
-        "p-retry": "7.1.1",
       },
       "devDependencies": {
         "@cucumber/cucumber": "11.3.0",
@@ -200,8 +199,6 @@
 
     "is-installed-globally": ["is-installed-globally@0.4.0", "", { "dependencies": { "global-dirs": "^3.0.0", "is-path-inside": "^3.0.2" } }, "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ=="],
 
-    "is-network-error": ["is-network-error@1.3.1", "", {}, "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw=="],
-
     "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
@@ -243,8 +240,6 @@
     "normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "p-retry": ["p-retry@7.1.1", "", { "dependencies": { "is-network-error": "^1.1.0" } }, "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "2.11.0",
     "@connectrpc/connect": "2.1.1",
-    "@connectrpc/connect-node": "2.1.1",
-    "p-retry": "7.1.1"
+    "@connectrpc/connect-node": "2.1.1"
   },
   "devDependencies": {
     "@cucumber/cucumber": "11.3.0",

--- a/e2e/steps/common.steps.ts
+++ b/e2e/steps/common.steps.ts
@@ -3,7 +3,6 @@ import { expect } from '@playwright/test';
 import { ICustomWorld } from '../support/world.ts';
 import { APIKeyService, type CreateAPIKeyResponse } from '../support/api/apikey-service.ts';
 import { ConnectRpcError } from '../support/api/client.ts';
-import pRetry from 'p-retry';
 
 // API token format constants (must match Go apitoken package)
 export const API_TOKEN_PREFIX = 'fun_';
@@ -97,17 +96,6 @@ Given('I have created an API key named {string}', async function (this: ICustomW
   if (this.currentUserEmail) {
     this.createdApiKeysByUser.get(this.currentUserEmail)?.set(name, response);
   }
-
-  // wait until the permissions have settled. So until we can retrieve the API key without permission_denied error
-  const retrieveAPIKey = async () => {
-    return this.apiKeyService?.getAPIKey(response.id)
-  }
-
-  await pRetry(retrieveAPIKey, {
-    shouldRetry: ({error}) => {
-      return ((error instanceof ConnectRpcError) && error.code == 'permission_denied')
-    }
-  })
 });
 
 Given('I have created an API key named {string} with expiry {string}', async function (this: ICustomWorld, name: string, expiresIn: string) {
@@ -132,17 +120,6 @@ Given('I have created an API key named {string} with expiry {string}', async fun
   if (this.currentUserEmail) {
     this.createdApiKeysByUser.get(this.currentUserEmail)?.set(name, response);
   }
-
-  // wait until the permissions have settled
-  const retrieveAPIKey = async () => {
-    return this.apiKeyService?.getAPIKey(response.id);
-  };
-
-  await pRetry(retrieveAPIKey, {
-    shouldRetry: ({error}) => {
-      return ((error instanceof ConnectRpcError) && error.code == 'permission_denied');
-    }
-  });
 });
 
 Given('I have revoked the API key', async function (this: ICustomWorld) {

--- a/e2e/support/api/apikey-service.ts
+++ b/e2e/support/api/apikey-service.ts
@@ -4,7 +4,13 @@
  */
 
 import { type Client, ConnectError } from '@connectrpc/connect';
-import { createServiceClient, ConnectRpcError } from './client.ts';
+import {
+  createServiceClient,
+  createWithIdempotency,
+  ConnectRpcError,
+  IDEMPOTENCY_KEY_HEADER,
+  IDEMPOTENCY_STATUS_HEADER,
+} from './client.ts';
 import {
   APIKeyService as APIKeyServiceDesc,
   type APIKey,
@@ -24,14 +30,22 @@ export class APIKeyService {
 
   async createAPIKey(request: { name: string; expiresIn?: string }): Promise<CreateAPIKeyResponse> {
     try {
-      return await this.client.createAPIKey({
-        name: request.name,
-        expiresIn: request.expiresIn ? request.expiresIn : undefined,
+      return await createWithIdempotency(async (idempotencyKey) => {
+        let status = '';
+        const response = await this.client.createAPIKey(
+          { name: request.name, expiresIn: request.expiresIn ?? undefined },
+          {
+            headers: { [IDEMPOTENCY_KEY_HEADER]: idempotencyKey },
+            onHeader(headers) { status = headers.get(IDEMPOTENCY_STATUS_HEADER) ?? ''; },
+          }
+        );
+        return { response, status };
       });
     } catch (err) {
       if (err instanceof ConnectError) {
         throw ConnectRpcError.fromConnectError(err);
       }
+
       throw err;
     }
   }

--- a/e2e/support/api/client.ts
+++ b/e2e/support/api/client.ts
@@ -6,6 +6,49 @@
 import { createClient, type Client, type DescService, ConnectError, Code } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-node';
 
+export const IDEMPOTENCY_KEY_HEADER = 'Idempotency-Key';
+export const IDEMPOTENCY_STATUS_HEADER = 'Idempotency-Status';
+
+const IDEMPOTENCY_INITIAL_BACKOFF_MS = 100;
+const IDEMPOTENCY_MAX_BACKOFF_MS = 2000;
+const IDEMPOTENCY_TOTAL_BUDGET_MS = 30000;
+
+/**
+ * Wraps a Create RPC call with idempotency and polling.
+ *
+ * Generates a UUID key and passes it to `caller`, which must inject it as the
+ * `Idempotency-Key` request header and capture `Idempotency-Status` from the
+ * response headers. Polls until the server reports `completed` or `failed`.
+ *
+ * Any error thrown by `caller` (e.g. a ConnectError) propagates as-is.
+ */
+export async function createWithIdempotency<Resp>(
+  caller: (idempotencyKey: string) => Promise<{ response: Resp; status: string }>
+): Promise<Resp> {
+  const key = crypto.randomUUID();
+  const deadline = Date.now() + IDEMPOTENCY_TOTAL_BUDGET_MS;
+  let backoff = IDEMPOTENCY_INITIAL_BACKOFF_MS;
+
+  while (true) {
+    const { response, status } = await caller(key);
+
+    if (status === 'completed') {
+      return response;
+    }
+    if (status === 'failed') {
+      throw new Error('Server reported idempotent operation failed');
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error('Idempotency polling timed out after 30s');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, Math.min(backoff, remaining)));
+    backoff = Math.min(backoff * 2, IDEMPOTENCY_MAX_BACKOFF_MS);
+  }
+}
+
 export { ConnectError, Code };
 
 /**


### PR DESCRIPTION
Introduce the `createWithIdempotency` helper to replace the retry logic when creating an API key.