### PR TITLE
chore: default functl to https:8443 and wire up kubeconfig download

### DIFF
--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -51,7 +51,8 @@
           <nldd-button
             type="button"
             (click)="downloadKubeconfig()"
-            text="Download kubeconfig"
+            [disabled]="isDownloadingKubeconfig()"
+            [text]="isDownloadingKubeconfig() ? 'Downloading…' : 'Download kubeconfig'"
             start-icon="arrow-down-in-bucket"
             variant="primary"
             size="sm"

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -21,6 +21,7 @@ import {
   ListNodePoolsRequestSchema,
   DeleteClusterRequestSchema,
   GetClusterActivityRequestSchema,
+  GetKubeconfigRequestSchema,
   NodePool,
   type ClusterEvent,
   type SyncState,
@@ -345,10 +346,37 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
     console.log('Opening terminal for cluster:', this.clusterData.basics.name);
   }
 
-  downloadKubeconfig(): void {
-    // Mock implementation - would download kubeconfig in real app
-    // eslint-disable-next-line no-console
-    console.log('Downloading kubeconfig for cluster:', this.clusterData.basics.name);
+  isDownloadingKubeconfig = signal<boolean>(false);
+
+  async downloadKubeconfig(): Promise<void> {
+    if (this.isDownloadingKubeconfig()) {
+      return;
+    }
+    this.isDownloadingKubeconfig.set(true);
+    try {
+      const request = create(GetKubeconfigRequestSchema, {
+        clusterId: this.clusterData.basics.id,
+      });
+      const response = await firstValueFrom(this.client.getKubeconfig(request));
+
+      const blob = new Blob([response.kubeconfigContent], { type: 'application/yaml' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `kubeconfig-${this.clusterData.basics.name}.yaml`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      this.toastService.error(
+        error instanceof Error
+          ? `Failed to download kubeconfig: ${error.message}`
+          : 'Failed to download kubeconfig',
+      );
+    } finally {
+      this.isDownloadingKubeconfig.set(false);
+    }
   }
 
   getNodePoolStatusLabel = getNodePoolStatusLabel;

--- a/functl/README.md
+++ b/functl/README.md
@@ -45,8 +45,8 @@ Use `functl config dir` to see the resolved directory, or `functl config path` f
 Create `~/.config/fundament/config.yaml` to override defaults:
 
 ```yaml
-api_endpoint: http://organization.fundament.localhost:8080
-authn_url: http://authn.fundament.localhost:8080
+api_endpoint: https://organization.fundament.localhost:8443
+authn_url: https://authn.fundament.localhost:8443
 output: table
 ```
 

--- a/functl/pkg/config/config.go
+++ b/functl/pkg/config/config.go
@@ -27,8 +27,8 @@ type Credentials struct {
 // DefaultConfig returns the default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		APIEndpoint: "http://organization.fundament.localhost:8080",
-		AuthnURL:    "http://authn.fundament.localhost:8080",
+		APIEndpoint: "https://organization.fundament.localhost:8443",
+		AuthnURL:    "https://authn.fundament.localhost:8443",
 		Output:      "table",
 	}
 }


### PR DESCRIPTION
Switch functl's default API and authn URLs to the local TLS endpoints on port 8443, matching the dev chart and e2e setup.

Hook the cluster details "Download kubeconfig" button up to the ClusterService.GetKubeconfig RPC (the same call functl uses) and save the response as a yaml file in the browser.