### PR TITLE
feat: support annotations on HTTPRoutes and set external-dns target f…

### DIFF
--- a/charts/fundament/pr-overlay.yaml
+++ b/charts/fundament/pr-overlay.yaml
@@ -118,6 +118,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - authn.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     organizationApi:
       replicas: 1
@@ -131,6 +134,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - organization.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     consoleFrontend:
       replicas: 1
@@ -144,6 +150,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - console.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     docsFrontend:
       replicas: 1
@@ -157,6 +166,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - docs.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     db:
       instances: 1
@@ -195,6 +207,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - dex.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
       staticClients:
         - id: fundament
           name: Fundament
@@ -216,6 +231,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - dcim-api.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     dcimFrontend:
       enabled: true
@@ -230,6 +248,9 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - dcim.pr${PR_NUM}.${DOMAIN}
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "86.105.162.209,2a0f:dc40:14:e0::"
+          external-dns.alpha.kubernetes.io/ttl: "300"
 
     ingress:
       enabled: false

--- a/charts/fundament/templates/authn-api-httproute.yaml
+++ b/charts/fundament/templates/authn-api-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-authn-api
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "authn-api" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.authnApi.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.authnApi.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/console-frontend-httproute.yaml
+++ b/charts/fundament/templates/console-frontend-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-console-frontend
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "console-frontend" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.consoleFrontend.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.consoleFrontend.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/dcim-api-httproute.yaml
+++ b/charts/fundament/templates/dcim-api-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-dcim-api
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "dcim-api" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.dcimApi.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.dcimApi.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/dcim-frontend-httproute.yaml
+++ b/charts/fundament/templates/dcim-frontend-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-dcim-frontend
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "dcim-frontend" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.dcimFrontend.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.dcimFrontend.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/dex-httproute.yaml
+++ b/charts/fundament/templates/dex-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-dex
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "dex" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.dex.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.dex.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/docs-frontend-httproute.yaml
+++ b/charts/fundament/templates/docs-frontend-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-docs-frontend
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "docs-frontend" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.docsFrontend.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.docsFrontend.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/templates/organization-api-httproute.yaml
+++ b/charts/fundament/templates/organization-api-httproute.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ $.Release.Name }}-organization-api
   labels:
     {{- include "fundament.labels" (dict "root" $ "name" "organization-api" "component" "gateway") | nindent 4 }}
+  {{- with $.Values.organizationApi.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml $.Values.organizationApi.httproute.parentRefs | nindent 4 }}

--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -54,6 +54,8 @@ authnApi:
     #    namespace: gateway-ns
     hostnames: []
     #  - authn.example.com
+    annotations: {}
+    #  external-dns.alpha.kubernetes.io/target: "1.2.3.4"
 
 # Organization API
 organizationApi:
@@ -68,6 +70,7 @@ organizationApi:
     #    namespace: gateway-ns
     hostnames: []
     #  - organization.example.com
+    annotations: {}
 
 # Kube Proxy (Kubernetes API proxy for frontend)
 kubeApiProxy:
@@ -96,6 +99,7 @@ consoleFrontend:
     #    namespace: gateway-ns
     hostnames: []
     #  - console.example.com
+    annotations: {}
 
 # Docs frontend
 docsFrontend:
@@ -108,6 +112,7 @@ docsFrontend:
     #    namespace: gateway-ns
     hostnames: []
     #  - docs.example.com
+    annotations: {}
 
 # Authz Worker (outbox pattern for OpenFGA tuple sync)
 authzWorker:
@@ -140,6 +145,7 @@ dcimApi:
     enabled: false
     parentRefs: []
     hostnames: []
+    annotations: {}
 
 # DCIM Frontend
 dcimFrontend:
@@ -149,6 +155,7 @@ dcimFrontend:
     enabled: false
     parentRefs: []
     hostnames: []
+    annotations: {}
 
 # Dex (OIDC Identity Provider)
 dex:
@@ -164,6 +171,7 @@ dex:
     #    namespace: gateway-ns
     hostnames: []
     #  - dex.example.com
+    annotations: {}
 
 # Host aliases for pods (useful for local development to resolve external URLs to internal services)
 hostAliases: []


### PR DESCRIPTION
…or PR envs

Adds an `<component>.httproute.annotations` value to each httproute-emitting component so external-dns annotations (or any other) can be set per route, and populates them in the PR-overlay template. external-dns can't derive a target from an XListenerSet parentRef, so annotate the routes directly.