### PR TITLE
feat(charts): add startupProbe for hotreload Go services

### DIFF
--- a/charts/fundament/templates/_helpers.tpl
+++ b/charts/fundament/templates/_helpers.tpl
@@ -78,3 +78,44 @@ Ingress controller service for internal access
 {{- define "fundament.ingressService" -}}
 ingress-nginx-controller.ingress-nginx.svc.cluster.local
 {{- end }}
+
+{{/*
+livenessProbe rendered with Air-friendly cadence in hotreload mode and
+production-tight cadence otherwise. In hotreload mode, failureThreshold *
+periodSeconds gives ~5 minutes for any `go build` (initial *or* mid-life
+rebuild after a source change) to finish before kubelet kills the pod —
+a startupProbe wouldn't help here because it only covers the first start.
+
+Usage: {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+*/}}
+{{- define "fundament.livenessProbe" -}}
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: {{ .port }}
+  initialDelaySeconds: 5
+{{- if .root.Values.hotreload.enabled }}
+  periodSeconds: 5
+  failureThreshold: 60
+{{- else }}
+  periodSeconds: 10
+{{- end }}
+{{- end }}
+
+{{/*
+readinessProbe rendered with the same hotreload tolerance as liveness so
+the pod isn't yanked out of Service endpoints mid-rebuild either.
+
+Usage: {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+*/}}
+{{- define "fundament.readinessProbe" -}}
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: {{ .port }}
+  initialDelaySeconds: 5
+  periodSeconds: 5
+{{- if .root.Values.hotreload.enabled }}
+  failureThreshold: 60
+{{- end }}
+{{- end }}

--- a/charts/fundament/templates/authn-api.yaml
+++ b/charts/fundament/templates/authn-api.yaml
@@ -71,18 +71,8 @@ spec:
                 configMapKeyRef:
                   name: openfga-config
                   key: authorization-model-id
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
           {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}
           volumeMounts:
             - name: gardener-kubeconfig

--- a/charts/fundament/templates/authz-worker.yaml
+++ b/charts/fundament/templates/authz-worker.yaml
@@ -50,16 +50,6 @@ spec:
                 configMapKeyRef:
                   name: openfga-config
                   key: authorization-model-id
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: health
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "health") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "health") | nindent 10 }}
 {{- end }}

--- a/charts/fundament/templates/cluster-worker.yaml
+++ b/charts/fundament/templates/cluster-worker.yaml
@@ -48,18 +48,8 @@ spec:
               mountPath: /etc/gardener
               readOnly: true
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: health
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "health") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "health") | nindent 10 }}
       {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}
       volumes:
         - name: gardener-kubeconfig

--- a/charts/fundament/templates/dcim-api.yaml
+++ b/charts/fundament/templates/dcim-api.yaml
@@ -36,18 +36,8 @@ spec:
             - name: CORS_ALLOWED_ORIGINS
               value: {{ $.Values.externalUrls.corsAllowedOrigins }}
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
 
 ---
 apiVersion: v1

--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -63,18 +63,8 @@ spec:
               mountPath: /etc/gardener
               readOnly: true
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 3
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/fundament/templates/organization-api.yaml
+++ b/charts/fundament/templates/organization-api.yaml
@@ -69,18 +69,8 @@ spec:
               mountPath: /etc/gardener
               readOnly: true
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /livez
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
       {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}
       volumes:
         - name: gardener-kubeconfig

--- a/charts/fundament/values-hotreload.yaml
+++ b/charts/fundament/values-hotreload.yaml
@@ -1,0 +1,5 @@
+# Overlay for `just dev-hotreload` (skaffold --profile hotreload).
+# Toggles a startupProbe on each Air-driven Go service so the first cold
+# build doesn't trip the liveness probe and put us in a rebuild loop.
+hotreload:
+  enabled: true

--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -1,5 +1,12 @@
 # Fundament Helm Chart - Default Values
 
+# Hot-reload (Air) mode for local development. When true, a startupProbe
+# absorbs the first cold `go build` so the liveness probe doesn't kill the
+# pod mid-build and put skaffold in a rebuild loop. Production-tight
+# liveness/readiness are unchanged once startup completes.
+hotreload:
+  enabled: false
+
 # JWT Secret - required for token signing/validation across services
 jwtSecret: ""
 jwtSecretRef:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -138,6 +138,9 @@ profiles:
   # Hot reload profile for local development
   - name: hotreload
     patches:
+      - op: add
+        path: /deploy/helm/releases/0/valuesFiles/-
+        value: charts/fundament/values-hotreload.yaml
       - op: replace
         path: /build/artifacts/0/docker/dockerfile
         value: authn-api/hotreload/Dockerfile


### PR DESCRIPTION
Air's first cold `go build` inside a pod regularly exceeds the liveness probe window (~35s with the current settings), so kubelet kills the pod mid-build and skaffold loops on rebuilds. Add a hotreload.enabled toggle that renders a startupProbe (5min window) on each Air-driven service. Production probes are unchanged.

The new values-hotreload.yaml overlay is wired into skaffold's hotreload profile, so `just dev-hotreload` picks it up automatically.