### PR TITLE
Cleanup the Plugins generated UIs + update documentation #1013

### DIFF
--- a/console-frontend/src/app/plugin-resources/crd-schema.utils.ts
+++ b/console-frontend/src/app/plugin-resources/crd-schema.utils.ts
@@ -182,18 +182,6 @@ export function kindToLabel(kind: string): string {
 }
 
 /**
- * Convert a CRD kind (PascalCase) to a human-readable singular label in all lowercase.
- * Intended for use mid-sentence: "Create cluster issuer", "Delete database".
- * Examples: "Certificate" → "certificate", "ClusterIssuer" → "cluster issuer"
- */
-export function kindToSingularLabel(kind: string): string {
-  return kind
-    .replace(/([A-Z])/g, ' $1')
-    .trim()
-    .toLowerCase();
-}
-
-/**
  * Convert a CRD property name to a human-readable label.
  */
 export function fieldNameToLabel(name: string): string {
@@ -201,11 +189,4 @@ export function fieldNameToLabel(name: string): string {
     .replace(/([A-Z])/g, ' $1')
     .replace(/^./, (s) => s.toUpperCase())
     .trim();
-}
-
-/**
- * Check if a field is required in the schema.
- */
-export function isFieldRequired(fieldName: string, schema: CrdObjectSchema): boolean {
-  return schema.required?.includes(fieldName) ?? false;
 }

--- a/console-frontend/src/app/plugin-resources/iframe/plugin-iframe.component.ts
+++ b/console-frontend/src/app/plugin-resources/iframe/plugin-iframe.component.ts
@@ -19,6 +19,7 @@ import type {
   PluginMessage,
 } from './postmessage-types';
 import type { AllowedResource, KubeResource } from '../types';
+import buildResourceUrl from '../kube-url.utils';
 import { ConfigService } from '../../config.service';
 
 function getCurrentTheme(): 'light' | 'dark' {
@@ -54,18 +55,6 @@ function isVerbAllowed(
       a.resource === resource &&
       (a.verbs ?? []).includes(verb),
   );
-}
-
-function buildResourceUrl(
-  base: string,
-  clusterId: string,
-  args: { group: string; version: string; resource: string; namespace?: string; name?: string },
-): string {
-  const groupPart =
-    args.group === '' ? `api/${args.version}` : `apis/${args.group}/${args.version}`;
-  const nsPart = args.namespace ? `/namespaces/${encodeURIComponent(args.namespace)}` : '';
-  const namePart = args.name ? `/${encodeURIComponent(args.name)}` : '';
-  return `${base}/clusters/${encodeURIComponent(clusterId)}/${groupPart}${nsPart}/${encodeURIComponent(args.resource)}${namePart}`;
 }
 
 function replyForbidden(iframe: HTMLIFrameElement, requestId: string): void {

--- a/console-frontend/src/app/plugin-resources/kube-plugin-loader.service.ts
+++ b/console-frontend/src/app/plugin-resources/kube-plugin-loader.service.ts
@@ -31,4 +31,28 @@ export default class KubePluginLoaderService {
     );
     return { crd, resources };
   }
+
+  async loadCrdAndResource(
+    pluginName: string,
+    resourceKind: string,
+    clusterId: string,
+    name: string,
+    namespace: string | undefined,
+  ): Promise<{ crd: ParsedCrd | undefined; resource: KubeResource | undefined }> {
+    const kubeApiProxyUrl = this.configService.getConfig().kubeApiProxyUrl;
+    await this.registry.loadPlugins(clusterId);
+    await this.registry.loadCrdsForPlugin(pluginName, clusterId, kubeApiProxyUrl);
+    const crd = this.registry.getCrd(pluginName, resourceKind, clusterId);
+    if (!crd) return { crd: undefined, resource: undefined };
+
+    const resource = await this.pluginStore.loadResource(
+      crd,
+      clusterId,
+      kubeApiProxyUrl,
+      pluginName,
+      name,
+      namespace,
+    );
+    return { crd, resource };
+  }
 }

--- a/console-frontend/src/app/plugin-resources/kube-url.utils.ts
+++ b/console-frontend/src/app/plugin-resources/kube-url.utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Builds the absolute URL for a Kubernetes resource collection or object,
+ * routed through kube-api-proxy.
+ *
+ * Handles the core group (served under `api/<version>`) vs. named API groups
+ * (`apis/<group>/<version>`), an optional namespace segment for namespaced
+ * resources, and an optional object name for single-object (get) requests.
+ *
+ * Shared by the host-mediated iframe broker (custom plugin UIs) and the
+ * generated read-only UI store, so resource URLs have one source of truth.
+ */
+export default function buildResourceUrl(
+  base: string,
+  clusterId: string,
+  args: { group: string; version: string; resource: string; namespace?: string; name?: string },
+): string {
+  const groupPart =
+    args.group === '' ? `api/${args.version}` : `apis/${args.group}/${args.version}`;
+  const nsPart = args.namespace ? `/namespaces/${encodeURIComponent(args.namespace)}` : '';
+  const namePart = args.name ? `/${encodeURIComponent(args.name)}` : '';
+  return `${base}/clusters/${encodeURIComponent(clusterId)}/${groupPart}${nsPart}/${encodeURIComponent(args.resource)}${namePart}`;
+}

--- a/console-frontend/src/app/plugin-resources/plugin-resource-store.service.ts
+++ b/console-frontend/src/app/plugin-resources/plugin-resource-store.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import type { KubeResource, ParsedCrd } from './types';
+import buildResourceUrl from './kube-url.utils';
 
 @Injectable({ providedIn: 'root' })
 export default class PluginResourceStoreService {
@@ -13,9 +14,14 @@ export default class PluginResourceStoreService {
     pluginName: string,
   ): Promise<KubeResource[]> {
     const base = kubeApiProxyUrl.replace(/\/$/, '');
-    // TODO: Support namespaced resources by adding /namespaces/{ns}/ when crd.scope === 'Namespaced'.
-    // Currently fetches cluster-scoped list; real mode will return 404 for namespaced CRDs.
-    const url = `${base}/clusters/${clusterId}/apis/${crd.group}/${crd.version}/${crd.plural}`;
+    // List across all namespaces via the collection endpoint (the same call custom plugin UIs
+    // use). For namespaced CRDs this returns items from every namespace; the detail view
+    // disambiguates by name + namespace.
+    const url = buildResourceUrl(base, clusterId, {
+      group: crd.group,
+      version: crd.version,
+      resource: crd.plural,
+    });
 
     const response = await fetch(url, {
       credentials: 'include',
@@ -29,6 +35,46 @@ export default class PluginResourceStoreService {
     const resources = data.items ?? [];
     this.cache.set(`${pluginName}/${crd.kind}/${clusterId}`, resources);
     return resources;
+  }
+
+  async loadResource(
+    crd: ParsedCrd,
+    clusterId: string,
+    kubeApiProxyUrl: string,
+    pluginName: string,
+    name: string,
+    namespace: string | undefined,
+  ): Promise<KubeResource | undefined> {
+    // A namespaced object cannot be fetched by name alone; without a namespace
+    // (e.g. a deep link missing ?ns=) fall back to listing and matching by name.
+    if (crd.scope === 'Namespaced' && !namespace) {
+      const all = await this.loadResources(crd, clusterId, kubeApiProxyUrl, pluginName);
+      return all.find((r) => r.metadata.name === name);
+    }
+
+    // Cluster-scoped resources have no namespace segment; drop a stray ?ns=
+    // (e.g. from a hand-crafted deep link) so we don't build an invalid URL.
+    const ns = crd.scope === 'Namespaced' ? namespace : undefined;
+
+    const base = kubeApiProxyUrl.replace(/\/$/, '');
+    const url = buildResourceUrl(base, clusterId, {
+      group: crd.group,
+      version: crd.version,
+      resource: crd.plural,
+      namespace: ns,
+      name,
+    });
+
+    const response = await fetch(url, {
+      credentials: 'include',
+    });
+
+    if (response.status === 404) return undefined;
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${crd.kind} ${name}: ${response.status}`);
+    }
+
+    return (await response.json()) as KubeResource;
   }
 
   getResource(

--- a/console-frontend/src/app/plugin-resources/resource-detail/resource-detail.component.ts
+++ b/console-frontend/src/app/plugin-resources/resource-detail/resource-detail.component.ts
@@ -78,7 +78,7 @@ export default class ResourceDetailComponent implements OnInit {
 
   protected resourceId = computed(() => this.routeParams().get('resourceId') ?? '');
 
-  protected resourceNamespace = computed(() => this.routeQuery().get('ns') ?? undefined);
+  protected resourceNamespace = computed(() => this.routeQuery().get('ns') || undefined);
 
   private plugin = computed(() => this.registry.getPlugin(this.pluginName()));
 
@@ -149,15 +149,15 @@ export default class ResourceDetailComponent implements OnInit {
     this.errorMessage.set(null);
 
     try {
-      const { crd, resources } = await this.loader.loadCrdAndResources(
+      const { crd, resource } = await this.loader.loadCrdAndResource(
         this.pluginName(),
         this.resourceKind(),
         clusterId,
+        this.resourceId(),
+        this.resourceNamespace(),
       );
       this.crdDef.set(crd);
-      if (crd) {
-        this.resource.set(resources.find((r) => r.metadata.name === this.resourceId()));
-      }
+      this.resource.set(resource);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[ResourceDetail] Failed to load resource:', err);
@@ -186,6 +186,6 @@ export default class ResourceDetailComponent implements OnInit {
   asRecord = toRecord;
 
   getSpecValue(fieldName: string): unknown {
-    return this.resource()?.spec[fieldName] ?? null;
+    return this.resource()?.spec?.[fieldName] ?? null;
   }
 }

--- a/console-frontend/src/app/plugin-resources/resource-list/resource-list.component.html
+++ b/console-frontend/src/app/plugin-resources/resource-list/resource-list.component.html
@@ -23,10 +23,10 @@
         </p>
       }
 
-      <!-- Cluster select + refresh -->
-      <div class="mt-2 flex items-center gap-3">
+      <!-- Cluster select -->
+      <div class="mt-2 flex items-end gap-3">
         @if (clusterContext.isLoadingClusters()) {
-          <nldd-form-field label="Cluster">
+          <nldd-form-field label="Cluster" class="w-60">
             <div class="select animate-pulse bg-gray-100 dark:bg-gray-800">&nbsp;</div>
           </nldd-form-field>
         } @else if (clusterContext.clusters().length === 0) {
@@ -36,7 +36,7 @@
             plugin.
           </p>
         } @else {
-          <nldd-form-field label="Cluster">
+          <nldd-form-field label="Cluster" class="w-60">
             <nldd-dropdown>
               <select
                 id="cluster-select"
@@ -49,13 +49,6 @@
               </select>
             </nldd-dropdown>
           </nldd-form-field>
-          <nldd-button
-            (click)="onRefresh()"
-            text="Refresh"
-            start-icon="arrow-2-counter-clockwise"
-            variant="secondary"
-            size="sm"
-          ></nldd-button>
         }
       </div>
     </div>
@@ -94,9 +87,7 @@
                     <td class="whitespace-normal">
                       <a
                         [routerLink]="detailLink(resource)"
-                        [queryParams]="
-                          resource.metadata.namespace ? { ns: resource.metadata.namespace } : null
-                        "
+                        [queryParams]="detailQueryParams(resource)"
                         class="font-medium hover:underline"
                         >{{ resource.metadata.name }}</a
                       >
@@ -119,9 +110,7 @@
                       <div class="flex gap-1">
                         <nldd-button
                           [routerLink]="detailLink(resource)"
-                          [queryParams]="
-                            resource.metadata.namespace ? { ns: resource.metadata.namespace } : null
-                          "
+                          [queryParams]="detailQueryParams(resource)"
                           text="View"
                           start-icon="eye"
                           variant="secondary"

--- a/console-frontend/src/app/plugin-resources/resource-list/resource-list.component.ts
+++ b/console-frontend/src/app/plugin-resources/resource-list/resource-list.component.ts
@@ -31,6 +31,10 @@ function buildDetailLink(resource: KubeResource): string[] {
   return ['.', resource.metadata.name];
 }
 
+function buildDetailQueryParams(resource: KubeResource): { ns: string } | null {
+  return resource.metadata.namespace ? { ns: resource.metadata.namespace } : null;
+}
+
 function buildCellValue(resource: KubeResource, col: AdditionalPrinterColumn): string {
   const fullObj = {
     metadata: resource.metadata,
@@ -146,14 +150,6 @@ export default class ResourceListComponent implements OnInit {
     this.clusterContext.onClusterChange(clusterId);
   }
 
-  async onRefresh(): Promise<void> {
-    const clusterId = this.clusterContext.selectedClusterId();
-    const pluginName = this.pluginName();
-    if (pluginName && this.resourceKind() && clusterId !== null) {
-      await this.loadCrdsAndResources(pluginName, this.resourceKind(), clusterId);
-    }
-  }
-
   private async loadCrdsAndResources(
     pluginName: string,
     resourceKind: string,
@@ -182,6 +178,8 @@ export default class ResourceListComponent implements OnInit {
   }
 
   detailLink = buildDetailLink;
+
+  detailQueryParams = buildDetailQueryParams;
 
   formatCell = buildCellValue;
 }

--- a/docs/plugins/console-integration.md
+++ b/docs/plugins/console-integration.md
@@ -55,9 +55,8 @@ The definition advertises:
 
 - `menu` — which CRDs appear at organization and project level.
 - `customComponents` — a `Kind` → `{ list?, detail? }` map of relative paths
-  (e.g. `Certificate` → `certificates-list.html`). Plugins are expected to
-  provide custom components for every CRD they expose in the menu; the
-  console does not generate fallback views.
+  (e.g. `Certificate` → `certificates-list.html`). Optional: any CRD without an
+  entry falls back to the generated read-only UI described below.
 - `allowedResources` — the Kubernetes resources the plugin's iframe may read,
   with explicit verbs (`get`, `list`). This is the authoritative list the host
   enforces on every K8s broker call.
@@ -74,11 +73,24 @@ The plugin routes live under `/plugin-resources/` (also mirrored under
 | `/plugin-resources/:pluginName/:resourceKind/:resourceId` | `ResourceDetailComponent` |
 
 Each component looks up the matching `customComponents.<Kind>.list` or
-`.detail` entry in the plugin definition, builds the iframe URL, and
-mounts the iframe component pointed at it. A plugin that omits a custom
-component for one of its CRDs will render an empty page — the console
-does not generate a fallback view from the CRD schema, so every CRD
-exposed in the menu needs its own `list` and `detail` HTML.
+`.detail` entry in the plugin definition. If present, it builds the iframe URL
+and mounts the iframe component pointed at it. If absent, it renders the
+generated fallback view instead.
+
+### Generated fallback UI
+
+When a plugin provides no `customComponents` entry for a CRD kind, the console
+renders a generated, **read-only** view from the CRD's OpenAPI v3 schema (loaded
+from `apiextensions.k8s.io/v1/customresourcedefinitions`):
+
+- **List** — a table whose columns come from the CRD's
+  `additionalPrinterColumns` (falling back to Name + Age), with a row per object
+  and a link to the detail view.
+- **Detail** — object metadata, the `spec` fields rendered from the schema, and
+  a `status` section (including a conditions table when present).
+
+The generated UI is read-only: it never creates, edits, or deletes resources.
+Reach for a custom UI (above) when you need write actions or a bespoke layout.
 
 ## The iframe boundary
 

--- a/docs/plugins/custom-ui.md
+++ b/docs/plugins/custom-ui.md
@@ -4,9 +4,11 @@ sidebar:
   order: 3
 ---
 
-Plugins are responsible for shipping their own UI. For every CRD a plugin
-exposes in the sidebar, the plugin must provide custom list and detail
-views — the console does not generate fallback views from the CRD schema.
+Custom UI is optional. When a plugin omits `customComponents` for a CRD it
+exposes in the sidebar, the console renders a generated, **read-only** list and
+detail view from the CRD's OpenAPI schema (see
+[Console integration](console-integration#generated-fallback-ui)). Ship a custom
+UI when you need write actions or a bespoke layout — this page covers that case.
 
 Plugin UIs run inside sandboxed iframes in the Fundament console. Each
 plugin embeds its own HTML pages alongside the plugin binary and uses the

--- a/docs/plugins/writing-a-plugin.md
+++ b/docs/plugins/writing-a-plugin.md
@@ -35,7 +35,6 @@ spec:
       - crd: myresources.my-api.io
         list: true
         detail: true
-        create: true
         icon: pencil-on-square
 
   customComponents:
@@ -62,13 +61,14 @@ spec:
             label: Failed
 ```
 
-`customComponents` maps every CRD kind that appears in the menu to the
-HTML files your plugin ships under `console/`. The console does not
-generate fallback views from the CRD schema, so every menu entry needs
-its own `list` and `detail` page. `allowedResources` is the allowlist the
-console host enforces on every `fundament.k8s.list` / `.get` call the
-plugin makes — see [Custom UI](custom-ui) and
-[Console integration](console-integration) for the full story.
+`customComponents` maps a CRD kind to the HTML files your plugin ships under
+`console/`. It is optional: any menu entry without a custom component renders the
+console's generated read-only list and detail views from the CRD schema, so add
+`customComponents` only for kinds that need write actions or a bespoke layout.
+`allowedResources` is the allowlist the console host enforces on every
+`fundament.k8s.list` / `.get` call the plugin makes — see
+[Custom UI](custom-ui) and [Console integration](console-integration) for the
+full story.
 
 ### 2. Implement the plugin
 

--- a/kube-api-proxy/pkg/kube/mock_client.go
+++ b/kube-api-proxy/pkg/kube/mock_client.go
@@ -131,27 +131,35 @@ func (m *MockClient) Do(ctx context.Context, method, path string, body io.Reader
 	case isResourceList(path, "cert-manager.io", "v1", "certificates"):
 		return 200, r(mockCertificateListJSON), nil
 	case isResourceGet(path, "cert-manager.io", "v1", "certificates"):
-		return resourceGetResponse(mockCertificateListJSON, resourceNameFromPath(path), r)
+		return resourceGetResponse(mockCertificateListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "cert-manager.io", "v1", "certificaterequests"):
 		return 200, r(mockCertificateRequestListJSON), nil
 	case isResourceGet(path, "cert-manager.io", "v1", "certificaterequests"):
-		return resourceGetResponse(mockCertificateRequestListJSON, resourceNameFromPath(path), r)
+		return resourceGetResponse(mockCertificateRequestListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "cert-manager.io", "v1", "clusterissuers"):
 		return 200, r(mockClusterIssuerListJSON), nil
 	case isResourceGet(path, "cert-manager.io", "v1", "clusterissuers"):
-		return resourceGetResponse(mockClusterIssuerListJSON, resourceNameFromPath(path), r)
+		return resourceGetResponse(mockClusterIssuerListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "cert-manager.io", "v1", "issuers"):
 		return 200, r(mockIssuerListJSON), nil
 	case isResourceGet(path, "cert-manager.io", "v1", "issuers"):
-		return resourceGetResponse(mockIssuerListJSON, resourceNameFromPath(path), r)
+		return resourceGetResponse(mockIssuerListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "postgresql.cnpg.io", "v1", "databases"):
 		return 200, r(mockDatabaseListJSON), nil
+	case isResourceGet(path, "postgresql.cnpg.io", "v1", "databases"):
+		return resourceGetResponse(mockDatabaseListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "postgresql.cnpg.io", "v1", "backups"):
 		return 200, r(mockBackupListJSON), nil
+	case isResourceGet(path, "postgresql.cnpg.io", "v1", "backups"):
+		return resourceGetResponse(mockBackupListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "postgresql.cnpg.io", "v1", "subscriptions"):
 		return 200, r(mockSubscriptionListJSON), nil
+	case isResourceGet(path, "postgresql.cnpg.io", "v1", "subscriptions"):
+		return resourceGetResponse(mockSubscriptionListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "demo.fundament.io", "v1", "demoitems"):
 		return 200, r(mockDemoItemListJSON), nil
+	case isResourceGet(path, "demo.fundament.io", "v1", "demoitems"):
+		return resourceGetResponse(mockDemoItemListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	case isResourceList(path, "openfsc.fundament.io", "v1", "fscinstallations"):
 		return 200, r(mockFSCInstallationListJSON), nil
 	case isResourceGet(path, "openfsc.fundament.io", "v1", "fscinstallations"):
@@ -288,10 +296,25 @@ func resourceNameFromPath(path string) string {
 	return parts[len(parts)-1]
 }
 
-// resourceGetResponse extracts the single item with the given name from a list
-// JSON document and returns it as the body of a 200 response. Returns 404 if
-// no such item exists. The list document must have shape {"items": [...]}.
-func resourceGetResponse(listJSON, name string, r func(string) io.ReadCloser) (int, io.ReadCloser, error) {
+// resourceNamespaceFromPath returns the namespace segment from a namespaced
+// single-object path (.../namespaces/{ns}/{plural}/{name}). Returns "" for
+// cluster-scoped paths.
+func resourceNamespaceFromPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "namespaces" {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+// resourceGetResponse extracts the single item matching name (and namespace, when
+// the path is namespaced) from a list JSON document and returns it as the body of
+// a 200 response. Returns 404 if no such item exists. Matching on namespace
+// disambiguates objects that share a name across namespaces. The list document
+// must have shape {"items": [...]}.
+func resourceGetResponse(listJSON, name, namespace string, r func(string) io.ReadCloser) (int, io.ReadCloser, error) {
 	var data struct {
 		Items []map[string]any `json:"items"`
 	}
@@ -300,13 +323,17 @@ func resourceGetResponse(listJSON, name string, r func(string) io.ReadCloser) (i
 	}
 	for _, item := range data.Items {
 		meta, _ := item["metadata"].(map[string]any)
-		if meta != nil && meta["name"] == name {
-			b, err := json.Marshal(item)
-			if err != nil {
-				return 500, r(`{"message":"mock item marshal error"}`), nil
-			}
-			return 200, r(string(b)), nil
+		if meta == nil || meta["name"] != name {
+			continue
 		}
+		if namespace != "" && meta["namespace"] != namespace {
+			continue
+		}
+		b, err := json.Marshal(item)
+		if err != nil {
+			return 500, r(`{"message":"mock item marshal error"}`), nil
+		}
+		return 200, r(string(b)), nil
 	}
 	return 404, r(`{"message":"not found"}`), nil
 }

--- a/kube-api-proxy/pkg/kube/mock_client.go
+++ b/kube-api-proxy/pkg/kube/mock_client.go
@@ -163,7 +163,7 @@ func (m *MockClient) Do(ctx context.Context, method, path string, body io.Reader
 	case isResourceList(path, "openfsc.fundament.io", "v1", "fscinstallations"):
 		return 200, r(mockFSCInstallationListJSON), nil
 	case isResourceGet(path, "openfsc.fundament.io", "v1", "fscinstallations"):
-		return resourceGetResponse(mockFSCInstallationListJSON, resourceNameFromPath(path), r)
+		return resourceGetResponse(mockFSCInstallationListJSON, resourceNameFromPath(path), resourceNamespaceFromPath(path), r)
 	default:
 		return 200, r(mockEmptyList), nil
 	}

--- a/kube-api-proxy/pkg/kube/mock_client_test.go
+++ b/kube-api-proxy/pkg/kube/mock_client_test.go
@@ -81,7 +81,7 @@ func TestIsResourceGet(t *testing.T) {
 func TestResourceGetResponse(t *testing.T) {
 	r := func(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
 
-	status, body, err := resourceGetResponse(mockCertificateListJSON, "web-tls-cert", r)
+	status, body, err := resourceGetResponse(mockCertificateListJSON, "web-tls-cert", "", r)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -99,11 +99,69 @@ func TestResourceGetResponse(t *testing.T) {
 		t.Fatalf("wrong name: %v", meta["name"])
 	}
 
-	status, body, _ = resourceGetResponse(mockCertificateListJSON, "missing", r)
+	status, body, _ = resourceGetResponse(mockCertificateListJSON, "missing", "", r)
 	if status != 404 {
 		t.Fatalf("expected 404, got %d", status)
 	}
 	body.Close()
+}
+
+func TestResourceGetResponseNamespaceDisambiguation(t *testing.T) {
+	r := func(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+	// mockDatabaseListJSON has two "app-db" objects, in "default" and "analytics".
+	// A namespaced get must return the object from the requested namespace.
+	for _, ns := range []string{"default", "analytics"} {
+		status, body, err := resourceGetResponse(mockDatabaseListJSON, "app-db", ns, r)
+		if err != nil {
+			t.Fatalf("ns %q: err: %v", ns, err)
+		}
+		if status != 200 {
+			t.Fatalf("ns %q: status = %d", ns, status)
+		}
+		b, _ := io.ReadAll(body)
+		body.Close()
+		var item map[string]any
+		if err := json.Unmarshal(b, &item); err != nil {
+			t.Fatalf("ns %q: unmarshal: %v", ns, err)
+		}
+		meta, _ := item["metadata"].(map[string]any)
+		if meta["name"] != "app-db" || meta["namespace"] != ns {
+			t.Fatalf("ns %q: got name=%v namespace=%v", ns, meta["name"], meta["namespace"])
+		}
+	}
+}
+
+func TestMockClientDoResourceGet(t *testing.T) {
+	m := &MockClient{}
+	ctx := context.Background()
+
+	// Namespaced single-object get must return the object (with spec) from the
+	// requested namespace — the path the generated detail view now uses.
+	status, body, err := m.Do(ctx, http.MethodGet,
+		"/apis/postgresql.cnpg.io/v1/namespaces/analytics/databases/app-db", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("status = %d", status)
+	}
+	defer body.Close()
+	b, _ := io.ReadAll(body)
+	var obj map[string]any
+	if err := json.Unmarshal(b, &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if obj["kind"] != "Database" {
+		t.Fatalf("expected a single Database object, got kind=%v", obj["kind"])
+	}
+	meta, _ := obj["metadata"].(map[string]any)
+	if meta["namespace"] != "analytics" {
+		t.Fatalf("wrong namespace: %v", meta["namespace"])
+	}
+	if _, ok := obj["spec"].(map[string]any); !ok {
+		t.Fatalf("returned object has no spec: %s", b)
+	}
 }
 
 func TestCertManagerDefinitionShape(t *testing.T) {

--- a/kube-api-proxy/pkg/kube/mock_resources.go
+++ b/kube-api-proxy/pkg/kube/mock_resources.go
@@ -361,6 +361,22 @@ const mockDatabaseListJSON = `{
         "connectionLimit": -1
       },
       "status": {"applied": false, "message": "Cluster pg-cluster-staging not found", "observedGeneration": 1}
+    },
+    {
+      "apiVersion": "postgresql.cnpg.io/v1",
+      "kind": "Database",
+      "metadata": {"name": "app-db", "namespace": "analytics", "uid": "db-4", "creationTimestamp": "2026-02-18T16:45:00Z"},
+      "spec": {
+        "name": "app_database",
+        "cluster": {"name": "pg-cluster-analytics"},
+        "owner": "analytics_app_user",
+        "encoding": "UTF8",
+        "ensure": "present",
+        "databaseReclaimPolicy": "retain",
+        "allowConnections": true,
+        "connectionLimit": 25
+      },
+      "status": {"applied": true, "message": "Database is up to date", "observedGeneration": 1}
     }
   ]
 }`

--- a/plugin-sdk/pluginruntime/definition.go
+++ b/plugin-sdk/pluginruntime/definition.go
@@ -82,7 +82,6 @@ type MenuEntry struct {
 	CRD    string `yaml:"crd"`
 	List   bool   `yaml:"list"`
 	Detail bool   `yaml:"detail"`
-	Create bool   `yaml:"create"`
 	Icon   string `yaml:"icon"`
 }
 

--- a/plugin-sdk/pluginruntime/metadata/proto/gen/v1/metadata.pb.go
+++ b/plugin-sdk/pluginruntime/metadata/proto/gen/v1/metadata.pb.go
@@ -322,7 +322,6 @@ type MenuEntry struct {
 	Crd           *string                `protobuf:"bytes,1,opt,name=crd" json:"crd,omitempty"`
 	List          *bool                  `protobuf:"varint,2,opt,name=list" json:"list,omitempty"`
 	Detail        *bool                  `protobuf:"varint,3,opt,name=detail" json:"detail,omitempty"`
-	Create        *bool                  `protobuf:"varint,4,opt,name=create" json:"create,omitempty"`
 	Icon          *string                `protobuf:"bytes,5,opt,name=icon" json:"icon,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -375,13 +374,6 @@ func (x *MenuEntry) GetList() bool {
 func (x *MenuEntry) GetDetail() bool {
 	if x != nil && x.Detail != nil {
 		return *x.Detail
-	}
-	return false
-}
-
-func (x *MenuEntry) GetCreate() bool {
-	if x != nil && x.Create != nil {
-		return *x.Create
 	}
 	return false
 }
@@ -1036,13 +1028,12 @@ const file_v1_metadata_proto_rawDesc = "" +
 	"\x05verbs\x18\x03 \x03(\tR\x05verbs\"d\n" +
 	"\vPermissions\x12\"\n" +
 	"\fcapabilities\x18\x01 \x03(\tR\fcapabilities\x121\n" +
-	"\x04rbac\x18\x02 \x03(\v2\x1d.pluginmetadata.v1.PolicyRuleR\x04rbac\"u\n" +
+	"\x04rbac\x18\x02 \x03(\v2\x1d.pluginmetadata.v1.PolicyRuleR\x04rbac\"k\n" +
 	"\tMenuEntry\x12\x10\n" +
 	"\x03crd\x18\x01 \x01(\tR\x03crd\x12\x12\n" +
 	"\x04list\x18\x02 \x01(\bR\x04list\x12\x16\n" +
-	"\x06detail\x18\x03 \x01(\bR\x06detail\x12\x16\n" +
-	"\x06create\x18\x04 \x01(\bR\x06create\x12\x12\n" +
-	"\x04icon\x18\x05 \x01(\tR\x04icon\"\x8a\x01\n" +
+	"\x06detail\x18\x03 \x01(\bR\x06detail\x12\x12\n" +
+	"\x04icon\x18\x05 \x01(\tR\x04iconJ\x04\b\x04\x10\x05R\x06create\"\x8a\x01\n" +
 	"\x0eMenuDefinition\x12@\n" +
 	"\forganization\x18\x01 \x03(\v2\x1c.pluginmetadata.v1.MenuEntryR\forganization\x126\n" +
 	"\aproject\x18\x02 \x03(\v2\x1c.pluginmetadata.v1.MenuEntryR\aproject\">\n" +

--- a/plugin-sdk/pluginruntime/metadata/proto/v1/metadata.proto
+++ b/plugin-sdk/pluginruntime/metadata/proto/v1/metadata.proto
@@ -34,7 +34,8 @@ message MenuEntry {
   string crd = 1;
   bool list = 2;
   bool detail = 3;
-  bool create = 4;
+  reserved 4;
+  reserved create;
   string icon = 5;
 }
 

--- a/plugin-sdk/pluginruntime/metadata_handler.go
+++ b/plugin-sdk/pluginruntime/metadata_handler.go
@@ -47,7 +47,6 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 			Crd:    ptr(entry.CRD),
 			List:   ptr(entry.List),
 			Detail: ptr(entry.Detail),
-			Create: ptr(entry.Create),
 			Icon:   ptr(entry.Icon),
 		}
 	}
@@ -58,7 +57,6 @@ func (h *metadataHandler) GetDefinition(_ context.Context, _ *connect.Request[pb
 			Crd:    ptr(entry.CRD),
 			List:   ptr(entry.List),
 			Detail: ptr(entry.Detail),
-			Create: ptr(entry.Create),
 			Icon:   ptr(entry.Icon),
 		}
 	}

--- a/plugin-sdk/pluginruntime/testing/harness_test.go
+++ b/plugin-sdk/pluginruntime/testing/harness_test.go
@@ -56,7 +56,7 @@ func (p *testPlugin) Definition() pluginruntime.PluginDefinition {
 			},
 			Menu: pluginruntime.MenuDefinition{
 				Organization: []pluginruntime.MenuEntry{
-					{CRD: "TestResource", List: true, Detail: true, Create: true, Icon: "puzzle"},
+					{CRD: "TestResource", List: true, Detail: true, Icon: "puzzle"},
 				},
 			},
 			CustomComponents: map[string]pluginruntime.ComponentMapping{
@@ -152,7 +152,6 @@ func TestRunInProcess(t *testing.T) {
 	require.Len(t, defResp.Msg.GetMenu().GetOrganization(), 1)
 	orgEntry := defResp.Msg.GetMenu().GetOrganization()[0]
 	assert.Equal(t, "TestResource", orgEntry.GetCrd())
-	assert.True(t, orgEntry.GetCreate())
 	assert.Equal(t, "puzzle", orgEntry.GetIcon())
 
 	// Verify custom components

--- a/plugins/cert-manager/definition.yaml
+++ b/plugins/cert-manager/definition.yaml
@@ -50,23 +50,19 @@ spec:
       - crd: clusterissuers.cert-manager.io
         list: true
         detail: true
-        create: true
         icon: rectangle-stack
     project:
       - crd: certificates.cert-manager.io
         list: true
         detail: true
-        create: true
         icon: file-text
       - crd: issuers.cert-manager.io
         list: true
         detail: true
-        create: true
         icon: rectangle-stack
       - crd: certificaterequests.cert-manager.io
         list: true
         detail: true
-        create: false
         icon: magnifier
   crds:
     - certificates.cert-manager.io

--- a/plugins/external-dns/definition.yaml
+++ b/plugins/external-dns/definition.yaml
@@ -45,7 +45,6 @@ spec:
       - crd: dnsendpoints.externaldns.k8s.io
         list: true
         detail: true
-        create: true
         icon: rectangle-stack
   uiHints:
     dnsendpoints.externaldns.k8s.io:

--- a/plugins/gateway-api/definition.yaml
+++ b/plugins/gateway-api/definition.yaml
@@ -78,33 +78,27 @@ spec:
       - crd: gateways.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: server
       - crd: httproutes.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: globe
       - crd: grpcroutes.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: zap
       - crd: tcproutes.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: cable
       - crd: tlsroutes.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: lock
     organization:
       - crd: gateways.gateway.networking.k8s.io
         list: true
         detail: true
-        create: true
         icon: server
   uiHints:
     gateways.gateway.networking.k8s.io:

--- a/plugins/openfsc/definition.yaml
+++ b/plugins/openfsc/definition.yaml
@@ -51,7 +51,6 @@ spec:
       - crd: fscinstallations.openfsc.fundament.io
         list: true
         detail: true
-        create: false
         icon: cloud
 
   customComponents:


### PR DESCRIPTION
Plugins can choose to use the default UI for listing their Custom Resources. A list view and detail view is supported. These are read only. If a Plugin would like to add support for creating a Custom Resource, they have to provide their own Console UI template.

Tested with the CNPG plugin in the Console locally.

**📸 Screenshots**

<img width="2032" height="1161" alt="Screenshot 2026-06-17 at 14 53 18" src="https://github.com/user-attachments/assets/1d823d2f-6637-4f49-bad9-3f82116f783f" />
<img width="2032" height="1161" alt="Screenshot 2026-06-17 at 14 53 22" src="https://github.com/user-attachments/assets/c0ca5746-83b9-4fbd-881d-8fe6f58380ba" />
