### PR TITLE
refactor: migrate PR overlay from XListenerSet to graduated ListenerSet

### DIFF
--- a/charts/fundament/pr-overlay.yaml
+++ b/charts/fundament/pr-overlay.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: tn-fundament-pr-${PR_NUM}
 ---
-# we have to create this Certificate ourselves as XListenerSet is not supported by cert-manager
+# we have to create this Certificate ourselves as ListenerSet is not supported by cert-manager
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -17,8 +17,8 @@ spec:
   dnsNames:
     - "*.pr${PR_NUM}.${DOMAIN}"
 ---
-apiVersion: gateway.networking.x-k8s.io/v1alpha1
-kind: XListenerSet
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
 metadata:
   name: tn-fundament-pr-${PR_NUM}
   namespace: istio-gateway
@@ -113,8 +113,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -126,8 +126,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -139,8 +139,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -152,8 +152,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -190,8 +190,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -212,8 +212,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -233,8 +233,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -247,8 +247,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}
@@ -262,8 +262,8 @@ spec:
       httproute:
         enabled: true
         parentRefs:
-          - group: gateway.networking.x-k8s.io
-            kind: XListenerSet
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
             name: tn-fundament-pr-${PR_NUM}
             namespace: istio-gateway
             sectionName: tn-fundament-pr-${PR_NUM}

--- a/charts/fundament/pr-overlay.yaml
+++ b/charts/fundament/pr-overlay.yaml
@@ -3,23 +3,14 @@ kind: Namespace
 metadata:
   name: tn-fundament-pr-${PR_NUM}
 ---
-# we have to create this Certificate ourselves as ListenerSet is not supported by cert-manager
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: tn-fundament-pr-${PR_NUM}-wildcard-tls
-  namespace: istio-gateway
-spec:
-  secretName: tn-fundament-pr-${PR_NUM}-wildcard-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  dnsNames:
-    - "*.pr${PR_NUM}.${DOMAIN}"
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
 metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/private-key-algorithm: ECDSA
+    cert-manager.io/private-key-size: "256"
+    cert-manager.io/private-key-rotation-policy: Always
   name: tn-fundament-pr-${PR_NUM}
   namespace: istio-gateway
 spec:


### PR DESCRIPTION
## What

Two related changes to `charts/fundament/pr-overlay.yaml`:

1. Migrate from the experimental `XListenerSet` to the graduated standard `ListenerSet`.
2. Remove the hand-written `Certificate` and let cert-manager's gateway-shim provision the wildcard cert directly from `ListenerSet` annotations.

## Why

The Gateway API `ListenerSet` (GEP-1713) has graduated from the experimental channel. Once on the standard `ListenerSet`, cert-manager's gateway-shim can watch the resource and issue the listener certificate from annotations — so the manual `Certificate` (previously needed because `XListenerSet` was unsupported) is no longer required.

## Changes

- `kind: XListenerSet` -> `kind: ListenerSet`
- `apiVersion: gateway.networking.x-k8s.io/v1alpha1` -> `gateway.networking.k8s.io/v1`
- HTTPRoute `parentRefs[].group` -> `gateway.networking.k8s.io`, `kind` -> `ListenerSet`
- Removed the standalone `cert-manager.io/v1` `Certificate`
- Annotated the `ListenerSet` so cert-manager provisions the cert from the listener's `tls.certificateRefs` secret, using an ECDSA P-256 key with `rotationPolicy: Always`:
  - `cert-manager.io/cluster-issuer: letsencrypt-prod`
  - `cert-manager.io/private-key-algorithm: ECDSA`
  - `cert-manager.io/private-key-size: "256"`
  - `cert-manager.io/private-key-rotation-policy: Always`

Mirrors the pattern already in use in the Digilab platform repo (`tenants/digikluster/ftv/listener-set-v1.yaml`).

## Caveat for reviewer

Assumes the target cluster's Istio + Gateway API install ships the **graduated standard** `ListenerSet` (`gateway.networking.k8s.io/v1`) and a cert-manager version whose gateway-shim supports `ListenerSet` annotations. If the cluster only has the experimental CRD, this needs the experimental group/version and the manual Certificate instead.