### PR TITLE
fix(authz-worker): make outbox dispatch idempotent and crash-safe

### DIFF
--- a/authz-worker/pkg/worker/handler/handler.go
+++ b/authz-worker/pkg/worker/handler/handler.go
@@ -22,17 +22,10 @@ func New(fga *client.OpenFgaClient, logger *slog.Logger) *Handler {
 	return &Handler{fga: fga, logger: logger}
 }
 
-func (h *Handler) writeTuples(ctx context.Context, tuples ...openfga.TupleKey) error {
-	if len(tuples) == 0 {
-		return nil
-	}
-	if _, err := h.fga.WriteTuples(ctx).Body(tuples).Execute(); err != nil {
-		return fmt.Errorf("write tuples: %w", err)
-	}
-	return nil
-}
-
-// writeTuplesIfNotExist writes tuples, ignoring errors if the tuples already exist.
+// writeTuplesIfNotExist writes tuples, ignoring errors if the tuples already
+// exist. The outbox is at-least-once in the face of ungraceful pod kills
+// (SIGKILL/OOM/node-loss) — a worker may write the tuple successfully and die
+// before committing the outbox row, so the next attempt must be idempotent.
 func (h *Handler) writeTuplesIfNotExist(ctx context.Context, tuples ...openfga.TupleKey) error {
 	if len(tuples) == 0 {
 		return nil
@@ -48,17 +41,8 @@ func (h *Handler) writeTuplesIfNotExist(ctx context.Context, tuples ...openfga.T
 	return nil
 }
 
-func (h *Handler) deleteTuples(ctx context.Context, tuples ...openfga.TupleKeyWithoutCondition) error {
-	if len(tuples) == 0 {
-		return nil
-	}
-	if _, err := h.fga.DeleteTuples(ctx).Body(tuples).Execute(); err != nil {
-		return fmt.Errorf("delete tuples: %w", err)
-	}
-	return nil
-}
-
-// deleteTuplesIfExist deletes tuples, ignoring errors if the tuples don't exist.
+// deleteTuplesIfExist deletes tuples, ignoring errors if the tuples don't
+// exist. Same at-least-once reasoning as writeTuplesIfNotExist.
 func (h *Handler) deleteTuplesIfExist(ctx context.Context, tuples ...openfga.TupleKeyWithoutCondition) error {
 	if len(tuples) == 0 {
 		return nil

--- a/authz-worker/pkg/worker/handler/namespace.go
+++ b/authz-worker/pkg/worker/handler/namespace.go
@@ -34,5 +34,5 @@ func (h *Handler) Namespace(ctx context.Context, qtx *db.Queries, namespaceID uu
 		)
 	}
 
-	return h.writeTuples(ctx, tuple(projectObj, authz.ActionParent, namespaceObj))
+	return h.writeTuplesIfNotExist(ctx, tuple(projectObj, authz.ActionParent, namespaceObj))
 }

--- a/authz-worker/pkg/worker/handler/node_pool.go
+++ b/authz-worker/pkg/worker/handler/node_pool.go
@@ -34,5 +34,5 @@ func (h *Handler) NodePool(ctx context.Context, qtx *db.Queries, nodePoolID uuid
 		)
 	}
 
-	return h.writeTuples(ctx, tuple(clusterObj, authz.ActionParent, nodePoolObj))
+	return h.writeTuplesIfNotExist(ctx, tuple(clusterObj, authz.ActionParent, nodePoolObj))
 }

--- a/authz-worker/pkg/worker/handler/project.go
+++ b/authz-worker/pkg/worker/handler/project.go
@@ -34,5 +34,5 @@ func (h *Handler) Project(ctx context.Context, qtx *db.Queries, projectID uuid.U
 		)
 	}
 
-	return h.writeTuples(ctx, tuple(clusterObj, authz.ActionParent, projectObj))
+	return h.writeTuplesIfNotExist(ctx, tuple(clusterObj, authz.ActionParent, projectObj))
 }

--- a/authz-worker/pkg/worker/handler/project_member.go
+++ b/authz-worker/pkg/worker/handler/project_member.go
@@ -54,7 +54,7 @@ func (h *Handler) ProjectMember(ctx context.Context, qtx *db.Queries, memberID u
 		panic(fmt.Sprintf("unknown project member role: %s", member.Role))
 	}
 
-	return h.writeTuples(ctx,
+	return h.writeTuplesIfNotExist(ctx,
 		tuple(user, action, project),
 		tuple(project, authz.ActionParent, projectMember),
 	)

--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -19,7 +19,16 @@ import (
 	"github.com/fundament-oss/fundament/common/rollback"
 )
 
-const listenChannel = "authz_outbox"
+const (
+	listenChannel = "authz_outbox"
+
+	// finalizeTimeout bounds the post-dispatch DB work (mark processed/retry
+	// + commit) when running on a context that may already have been cancelled
+	// by SIGTERM. The OpenFGA write has already happened at that point; if we
+	// abandon the transaction the same tuple gets replayed on the next pod and
+	// OpenFGA rejects it as a duplicate.
+	finalizeTimeout = 10 * time.Second
+)
 
 // Config holds configuration for the outbox worker.
 type Config struct {
@@ -254,23 +263,32 @@ func (w *Worker) processOneItem(ctx context.Context) (found bool, err error) {
 		return false, fmt.Errorf("get next outbox row: %w", err)
 	}
 
-	if err := w.dispatchItem(ctx, qtx, &item); err != nil {
-		if err := w.handleProcessingError(ctx, qtx, &item, err); err != nil {
+	dispatchErr := w.dispatchItem(ctx, qtx, &item)
+
+	// Past this point the side effect on OpenFGA has already happened (success
+	// or partial), so the outbox row MUST be marked + committed even if the
+	// parent ctx was cancelled mid-flight. Run the remainder on a detached
+	// context with a bounded timeout.
+	finalizeCtx, cancel := context.WithTimeout(context.Background(), finalizeTimeout)
+	defer cancel()
+
+	if dispatchErr != nil {
+		if err := w.handleProcessingError(finalizeCtx, qtx, &item, dispatchErr); err != nil {
 			return true, fmt.Errorf("handle processing error: %w", err)
 		}
 
-		if err := tx.Commit(ctx); err != nil {
+		if err := tx.Commit(finalizeCtx); err != nil {
 			return true, fmt.Errorf("dispatch item commit: %w", err)
 		}
 
-		return true, err
+		return true, dispatchErr
 	}
 
-	if err := qtx.MarkOutboxRowProcessed(ctx, db.MarkOutboxRowProcessedParams{ID: item.ID}); err != nil {
+	if err := qtx.MarkOutboxRowProcessed(finalizeCtx, db.MarkOutboxRowProcessedParams{ID: item.ID}); err != nil {
 		return true, fmt.Errorf("mark as processed: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(finalizeCtx); err != nil {
 		return true, fmt.Errorf("commit: %w", err)
 	}
 


### PR DESCRIPTION
The outbox is at-least-once because writing to OpenFGA and committing the Postgres row are two stores: an ungraceful pod kill (SIGKILL/OOM/node loss) or a SIGTERM landing between the OpenFGA write and the Postgres commit leaves the tuple in OpenFGA with the outbox row still 'pending'. The next worker then replays the same tuple, OpenFGA rejects it as a duplicate, the row marks as failed after 3 retries, and e2e/terraform-acc tests stay broken until authz-worker is restarted (which only papers over it via ResetFailedOutboxItems).

Two changes to close the window:

  - All write handlers (project, project_member, node_pool, namespace) now use writeTuplesIfNotExist (OnDuplicateWrites: IGNORE), matching what cluster/api_key/organization_user already do and pairing with the existing deleteTuplesIfExist on the symmetric delete paths. A replayed outbox row no-ops on OpenFGA instead of erroring. The now-unused strict variants are removed.

  - processOneItem runs the post-dispatch work (handleProcessingError / MarkOutboxRowProcessed / tx.Commit) on a detached background context with a 10s timeout, so SIGTERM after the OpenFGA side-effect can't abort the row-status update.