### PR TITLE
fix(deploy-remote): address codex review (secret leak, safe down, honest stack exit)

### DIFF
--- a/deploy-remote/box/run-stack.sh
+++ b/deploy-remote/box/run-stack.sh
@@ -45,14 +45,18 @@ mise exec -- kubectl --context k3d-fundament exec -n fundament db-1 -c postgres 
   || log "insert failed (check db pod name / schema)"
 
 log "=== STAGE E: watch shoot '$CLUSTER' -> Create Succeeded ==="
+shoot_ok=0
 for i in $(seq 1 80); do
   LINE=$(mise exec -- kubectl --kubeconfig "$VKC" get shoots -A --no-headers 2>/dev/null | grep -iF -- "$CLUSTER")
   log "shoot: $LINE"
-  echo "$LINE" | grep -qiE "Create Succeeded|100%" && { log "SHOOT SUCCEEDED"; break; }
+  echo "$LINE" | grep -qiE "Create Succeeded|100%" && { log "SHOOT SUCCEEDED"; shoot_ok=1; break; }
   sleep 15
 done
 
 log "=== SUMMARY ==="
 mise exec -- kubectl --kubeconfig "$VKC" get seed local 2>/dev/null
 mise exec -- kubectl --kubeconfig "$VKC" get shoots -A 2>/dev/null | grep -iF -e NAME -e "$CLUSTER"
+# Fail the run if the shoot never reached success, so the caller (hetzner.sh stack)
+# does not trust certs + print "access ready" after a failed smoke run.
+[ "$shoot_ok" = 1 ] || { log "FATAL: shoot '$CLUSTER' never reached Create Succeeded within the watch window"; exit 1; }
 log "=== DONE ==="

--- a/deploy-remote/hetzner.sh
+++ b/deploy-remote/hetzner.sh
@@ -128,10 +128,18 @@ trust_box_ca() { # ip
   CAROOT="$PWD/$BOX_CA" "${MKCERT[@]}" -install
 }
 
-# remove the box's ephemeral CA from local trust and delete the local copy (run on down)
+# remove the box's ephemeral CA from local trust and delete the local copy (run on down).
+# Best-effort: must NEVER abort `down`, or a failed cert cleanup would skip server
+# deletion and keep the paid box billing. If mkcert is missing we drop the local copy
+# and warn (the CA can be untrusted later with `mkcert -uninstall`).
 untrust_box_ca() {
   [ -f "$BOX_CA/rootCA.pem" ] || return 0
-  resolve_mkcert
+  if command -v mkcert >/dev/null 2>&1; then MKCERT=(mkcert)
+  elif mise exec -- mkcert --version >/dev/null 2>&1; then MKCERT=(mise exec -- mkcert)
+  else
+    log "WARN: mkcert not found — leaving the box CA in your trust store; remove later with 'mkcert -uninstall'"
+    rm -rf "$BOX_CA"; return 0
+  fi
   log "removing the box CA from local trust (mkcert -uninstall)"
   CAROOT="$PWD/$BOX_CA" "${MKCERT[@]}" -uninstall || true
   rm -rf "$BOX_CA"
@@ -146,6 +154,21 @@ print_access() {
   log "     (also docs./dcim./dex.fundament.localhost:8443 — the box CA is trusted locally, no cert warning)"
 }
 
+# Stage a SANITIZED copy of the flake source into a fresh temp dir and print its path.
+# Only nix-relevant files go in — NOT secrets/ (Hetzner token) or the rest of cache/
+# (private SSH keys, box CA key, machine-id). Critical because /work is mounted as a
+# plain (non-git) path, so nix copies the WHOLE tree into the store and --build-on-remote
+# ships it to the box; .gitignore does not filter a plain-path flake source. Only
+# cache/admin-keys.nix is needed (modules/baseline.nix imports ../cache/admin-keys.nix).
+stage_flake_src() {
+  local dir; dir=$(mktemp -d "${TMPDIR:-/tmp}/fundament-flake.XXXXXX")
+  cp flake.nix flake.lock "$dir/"
+  cp -R hosts modules "$dir/"
+  mkdir -p "$dir/cache"
+  cp "$ADMIN_KEYS_NIX" "$dir/cache/admin-keys.nix"
+  printf '%s\n' "$dir"
+}
+
 # --- install NixOS onto an already-created box -----------------------------
 # Returns 0 only when the installed NixOS answers SSH on :$SSH_PORT (nixos-anywhere's
 # exit code isn't reliable — it often drops SSH on the post-install reboot). Recovers
@@ -155,9 +178,11 @@ deploy_once() { # ip priv
   log "$HZ_NAME @ $ip — waiting for SSH on :22"
   wait_ssh "$ip" root 60 22 || { log "box never reachable on :22"; return 1; }
 
+  local src; src=$(stage_flake_src)
+  trap 'rm -rf "$src"' RETURN
   log "installing NixOS via nixos-anywhere (throwaway nixos/nix container; build-on-remote)"
   docker run --rm \
-    -v "$PWD:/work" -w /work \
+    -v "$src:/work" -w /work \
     -v "$priv:/root/.ssh/id_rsa:ro" \
     -e NIX_CONFIG="experimental-features = nix-command flakes" \
     "$NIX_IMAGE" \


### PR DESCRIPTION
Addresses codex review findings on the deploy-remote Hetzner box scripts. Fixes the three confirmed issues we chose to act on; P2a (per-operator SSH key) and P3 (whitespace, a false positive) are intentionally not included.

## Fixes

**P1a — secrets/cache leaked into the flake source (serious).**
`deploy-remote/` is not itself a git root (the `.git` lives in the parent `fundament` repo, which isn't mounted), so inside the nixos-anywhere container `/work` is a *plain path*. `nix --flake /work#hetzner --build-on-remote` copies the **whole** tree into the store and ships it to the box — `.gitignore` does not apply. That leaked `secrets/hetzner.env` (Hetzner API token), `cache/ssh/` + `cache/keys/` (private keys), the box CA private key, and `machine-id`. Fix: `stage_flake_src` copies only the nix-relevant files (`flake.nix`, `flake.lock`, `hosts/`, `modules/`, `cache/admin-keys.nix`) into a temp dir and mounts that instead; temp dir is cleaned via `trap ... RETURN`.

**P1b — `hetzner-down` could leave the paid box running.**
`untrust_box_ca` ran `resolve_mkcert`, which `die`s (i.e. `exit`s) if mkcert is missing — skipping `hc server delete` and leaving the box billing. `untrust_box_ca` is now best-effort: if mkcert is absent it drops the local CA copy, warns, and returns, so deletion always runs.

**P2b — a failed smoke run exited 0.**
`box/run-stack.sh` Stage E `break`s on success but fell through to `DONE` (exit 0) on timeout, so `hetzner stack` trusted certs + printed "access ready" after a failed shoot. Now records success and exits nonzero if the shoot never reached `Create Succeeded`.

## Not included
- **P2a** (multi-operator: reused hcloud key may not match local key) — real but only matters for shared/rotated keys; deferred by request.
- **P3** (trailing whitespace in `k3d-gardener-coexist.patch:6`) — false positive: that's a standard blank *context* line; no added line has trailing whitespace, and `git apply`/`git diff --check` only flag added lines.

## Verification
- `bash -n` passes on both scripts; `just --list` passes.
- Staging simulated: staged tree contains only the 6 nix files, confirmed no `secrets/`/private material.
- shellcheck unavailable in this environment; paid Hetzner flow not run.