### PR TITLE
fix(deps): bump bundled OpenFGA to v1.18.0 for CVEs

### DIFF
--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -139,7 +139,7 @@ authzWorker:
 # OpenFGA (Fine-Grained Authorization)
 openfga:
   enabled: true
-  image: openfga/openfga:v1.11.3
+  image: openfga/openfga:v1.18.0
   replicas: 1
   playground:
     enabled: false


### PR DESCRIPTION
Bumps the bundled OpenFGA image to close known CVEs.

## Dependency bump

- OpenFGA: `openfga/openfga:v1.11.3` → `openfga/openfga:v1.18.0` — closes CVE-2026-55689 (authorization-model `aud` validation bypass) and other issues fixed in the 1.12–1.18 line.

Pinned in `charts/fundament/values.yaml` (`openfga.image`). No other values files or overlays override this image.

### Notes
- This chart bundles only OpenFGA among the commonly-flagged data services; it does not ship Redis, NATS, RabbitMQ, or Typesense, so no bumps were needed for those.
- No `Chart.lock` / subchart dependencies exist, so nothing to regenerate.
- Verified: `helm lint charts/fundament` passes and `helm template` renders `openfga/openfga:v1.18.0`.
