### PR TITLE
feat(cluster-worker): make gardener provider config overridable for non-local providers

### DIFF
--- a/charts/fundament/templates/cluster-worker.yaml
+++ b/charts/fundament/templates/cluster-worker.yaml
@@ -39,8 +39,60 @@ spec:
               value: {{ $.Values.clusterWorker.gardenerProviderType | default "local" }}
             - name: GARDENER_CLOUD_PROFILE
               value: {{ $.Values.clusterWorker.gardenerCloudProfile | default "local" }}
+            {{- with $.Values.clusterWorker.gardenerRegion }}
+            - name: GARDENER_REGION
+              value: {{ . | quote }}
+            {{- end }}
             - name: GARDENER_CREDENTIALS_BINDING_NAME
               value: {{ $.Values.clusterWorker.gardenerCredentialsBindingName | default "" }}
+            {{- with $.Values.clusterWorker.gardenerCredentialsRef }}
+            - name: GARDENER_CREDENTIALS_REF
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerCredentialsRefKind }}
+            - name: GARDENER_CREDENTIALS_REF_KIND
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerCredentialsRefAPIVersion }}
+            - name: GARDENER_CREDENTIALS_REF_API_VERSION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerMachineImageName }}
+            - name: GARDENER_MACHINE_IMAGE_NAME
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerMachineImageVersion }}
+            - name: GARDENER_MACHINE_IMAGE_VERSION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerDefaultMachineType }}
+            - name: GARDENER_DEFAULT_MACHINE_TYPE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerNodesCIDR }}
+            - name: GARDENER_NODES_CIDR
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerPodsCIDR }}
+            - name: GARDENER_PODS_CIDR
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerServicesCIDR }}
+            - name: GARDENER_SERVICES_CIDR
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerInfrastructureConfig }}
+            - name: GARDENER_INFRASTRUCTURE_CONFIG
+              value: {{ . | toJson | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerControlPlaneConfig }}
+            - name: GARDENER_CONTROL_PLANE_CONFIG
+              value: {{ . | toJson | quote }}
+            {{- end }}
+            {{- with $.Values.clusterWorker.gardenerShootAnnotations }}
+            - name: GARDENER_SHOOT_ANNOTATIONS
+              value: {{ . | toJson | quote }}
+            {{- end }}
             {{- end }}
           {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}
           volumeMounts:

--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -110,6 +110,30 @@ clusterWorker:
   gardenerMode: mock # mock or real
   # Gardener kubeconfig secret for real mode. Also consumed by authn-api and organization-api.
   gardenerKubeconfigSecret: ""
+  # Provider wiring for real mode (defaults target the local provider in code).
+  gardenerProviderType: ""           # e.g. local, metal
+  gardenerCloudProfile: ""           # e.g. local, metal
+  gardenerRegion: ""                 # default shoot region when a cluster has none, e.g. local
+  gardenerCredentialsBindingName: "" # e.g. local, metal-credentials
+  # Shared credentials the per-project CredentialsBindings reference. The local
+  # provider uses a WorkloadIdentity (garden-local/local, the in-code default);
+  # non-local providers such as metal use a Secret and must set all three.
+  gardenerCredentialsRef: ""           # "namespace/name", e.g. garden/metal-credentials
+  gardenerCredentialsRefKind: ""       # Secret or WorkloadIdentity
+  gardenerCredentialsRefAPIVersion: "" # v1 (Secret) or security.gardener.cloud/v1alpha1 (WorkloadIdentity)
+  gardenerMachineImageName: ""    # e.g. ubuntu
+  gardenerMachineImageVersion: "" # e.g. 24.04
+  gardenerDefaultMachineType: ""  # e.g. c1-medium-x86
+  # Networking CIDRs. Node CIDR empty => the provider's IPAM allocates it (metal
+  # hands out a partition range); the local provider falls back to 10.0.0.0/16.
+  gardenerNodesCIDR: ""    # usually empty for metal
+  gardenerPodsCIDR: ""     # e.g. 10.240.0.0/16 (must be in the tenant super's additionalAnnouncableCIDRs)
+  gardenerServicesCIDR: "" # e.g. 10.248.0.0/16
+  # Provider extension configs stamped verbatim onto every Shoot (YAML here ->
+  # JSON in the env var). Required by metal; leave empty ({}) for the local provider.
+  gardenerInfrastructureConfig: {} # -> spec.provider.infrastructureConfig
+  gardenerControlPlaneConfig: {}   # -> spec.provider.controlPlaneConfig
+  gardenerShootAnnotations: {}     # extra shoot annotations, e.g. cluster.metal-stack.io/tenant: fundament
 
 # Console Frontend
 consoleFrontend:

--- a/cluster-worker/pkg/app/app.go
+++ b/cluster-worker/pkg/app/app.go
@@ -234,9 +234,15 @@ func createGardenerClient(cfg *Config, logger *slog.Logger) (gardener.Client, er
 			providerCfg.ServicesCIDR = g.ServicesCIDR
 		}
 		if g.InfrastructureConfig != "" {
+			if !json.Valid([]byte(g.InfrastructureConfig)) {
+				return nil, fmt.Errorf("GARDENER_INFRASTRUCTURE_CONFIG is not valid JSON")
+			}
 			providerCfg.InfrastructureConfig = g.InfrastructureConfig
 		}
 		if g.ControlPlaneConfig != "" {
+			if !json.Valid([]byte(g.ControlPlaneConfig)) {
+				return nil, fmt.Errorf("GARDENER_CONTROL_PLANE_CONFIG is not valid JSON")
+			}
 			providerCfg.ControlPlaneConfig = g.ControlPlaneConfig
 		}
 		if g.ShootAnnotations != "" {

--- a/cluster-worker/pkg/app/app.go
+++ b/cluster-worker/pkg/app/app.go
@@ -3,6 +3,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -29,21 +30,49 @@ type Config struct {
 	HealthPort      int           `env:"HEALTH_PORT" envDefault:"8097"`
 	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT" envDefault:"30s"`
 
-	GardenerMode       string `env:"GARDENER_MODE"`
-	GardenerKubeconfig string `env:"GARDENER_KUBECONFIG"`
-
-	// Provider configuration for real Gardener mode.
-	ProviderType                   string `env:"GARDENER_PROVIDER_TYPE"`
-	ProviderCloudProfile           string `env:"GARDENER_CLOUD_PROFILE"`
-	ProviderCredentialsBindingName string `env:"GARDENER_CREDENTIALS_BINDING_NAME"`
-	ProviderMachineImageName       string `env:"GARDENER_MACHINE_IMAGE_NAME"`
-	ProviderMachineImageVersion    string `env:"GARDENER_MACHINE_IMAGE_VERSION"`
-	ProviderDefaultMachineType     string `env:"GARDENER_DEFAULT_MACHINE_TYPE"`
+	Gardener GardenerConfig `envPrefix:"GARDENER_"`
 
 	Outbox    outbox.Config         `envPrefix:"OUTBOX_"`
 	Status    status.Config         `envPrefix:"STATUS_"`
 	Reconcile reconcile.Config      `envPrefix:"RECONCILE_"`
 	Cluster   clusterhandler.Config `envPrefix:"CLUSTER_"`
+}
+
+// GardenerConfig configures the Gardener client and the provider defaults the
+// cluster-worker stamps onto Shoots. Every field is read under the GARDENER_ env
+// prefix (factored out here rather than repeated per tag), so each env var is the
+// UPPER_SNAKE of the field name, e.g. ProviderType -> GARDENER_PROVIDER_TYPE.
+// The zero values target Gardener's local provider; non-local providers such as
+// metal override the provider fields (see the deployment's Helm values).
+type GardenerConfig struct {
+	Mode       string `env:"MODE"`       // mock or real
+	Kubeconfig string `env:"KUBECONFIG"` // required when Mode == real
+
+	ProviderType           string `env:"PROVIDER_TYPE"`            // e.g. local, metal
+	CloudProfile           string `env:"CLOUD_PROFILE"`            // e.g. local, metal
+	Region                 string `env:"REGION"`                   // default Shoot region when the cluster specifies none
+	CredentialsBindingName string `env:"CREDENTIALS_BINDING_NAME"` // e.g. local, metal-credentials
+
+	// Shared credentials that the per-project CredentialsBindings reference. The
+	// in-code defaults target the local provider's WorkloadIdentity
+	// (garden-local/local); metal uses a Secret and must set all three.
+	CredentialsRef           string `env:"CREDENTIALS_REF"`             // "namespace/name"
+	CredentialsRefKind       string `env:"CREDENTIALS_REF_KIND"`        // Secret or WorkloadIdentity
+	CredentialsRefAPIVersion string `env:"CREDENTIALS_REF_API_VERSION"` // v1 or security.gardener.cloud/v1alpha1
+
+	MachineImageName    string `env:"MACHINE_IMAGE_NAME"`
+	MachineImageVersion string `env:"MACHINE_IMAGE_VERSION"`
+	DefaultMachineType  string `env:"DEFAULT_MACHINE_TYPE"`
+
+	NodesCIDR    string `env:"NODES_CIDR"` // empty => provider IPAM allocates (metal); local falls back to 10.0.0.0/16
+	PodsCIDR     string `env:"PODS_CIDR"`
+	ServicesCIDR string `env:"SERVICES_CIDR"`
+
+	// Provider extension configs (raw JSON) stamped verbatim onto Shoots, plus
+	// extra Shoot annotations (a JSON object). Used by non-local providers (metal).
+	InfrastructureConfig string `env:"INFRASTRUCTURE_CONFIG"`
+	ControlPlaneConfig   string `env:"CONTROL_PLANE_CONFIG"`
+	ShootAnnotations     string `env:"SHOOT_ANNOTATIONS"`
 }
 
 // ReadyChecker reports whether a worker is ready to serve traffic.
@@ -80,7 +109,7 @@ func New(pool *pgxpool.Pool, logger *slog.Logger, cfg *Config) (*App, error) {
 	registry.RegisterReconcile(ch)
 
 	// User sync handler (SA/CRB lifecycle on shoots)
-	shootAccess, err := createShootAccess(cfg.GardenerMode, gardenerClient, logger)
+	shootAccess, err := createShootAccess(cfg.Gardener.Mode, gardenerClient, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +156,7 @@ func (a *App) Run(ctx context.Context) error {
 		"reconcile_interval", a.cfg.Reconcile.Interval,
 		"status_interval", a.cfg.Status.Interval,
 		"max_retries", a.cfg.Outbox.MaxRetries,
-		"gardener_mode", a.cfg.GardenerMode)
+		"gardener_mode", a.cfg.Gardener.Mode)
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -154,47 +183,82 @@ func (a *App) Run(ctx context.Context) error {
 }
 
 func createGardenerClient(cfg *Config, logger *slog.Logger) (gardener.Client, error) {
-	switch cfg.GardenerMode {
+	g := cfg.Gardener
+	switch g.Mode {
 	case "mock":
 		logger.Info("using mock Gardener client (in-memory)")
 		return gardener.NewMock(logger), nil
 
 	case "real":
-		if cfg.GardenerKubeconfig == "" {
+		if g.Kubeconfig == "" {
 			return nil, fmt.Errorf("GARDENER_KUBECONFIG required for real mode")
 		}
 		providerCfg := gardener.NewProviderConfig()
-		if cfg.ProviderType != "" {
-			providerCfg.Type = cfg.ProviderType
+		if g.ProviderType != "" {
+			providerCfg.Type = g.ProviderType
 		}
-		if cfg.ProviderCloudProfile != "" {
-			providerCfg.CloudProfile = cfg.ProviderCloudProfile
+		if g.CloudProfile != "" {
+			providerCfg.CloudProfile = g.CloudProfile
 		}
-		if cfg.ProviderCredentialsBindingName != "" {
-			providerCfg.CredentialsBindingName = cfg.ProviderCredentialsBindingName
+		if g.Region != "" {
+			providerCfg.Region = g.Region
 		}
-		if cfg.ProviderMachineImageName != "" {
-			providerCfg.MachineImageName = cfg.ProviderMachineImageName
+		if g.CredentialsBindingName != "" {
+			providerCfg.CredentialsBindingName = g.CredentialsBindingName
 		}
-		if cfg.ProviderMachineImageVersion != "" {
-			providerCfg.MachineImageVersion = cfg.ProviderMachineImageVersion
+		if g.CredentialsRef != "" {
+			providerCfg.CredentialsRef = g.CredentialsRef
 		}
-		if cfg.ProviderDefaultMachineType != "" {
-			providerCfg.DefaultMachineType = cfg.ProviderDefaultMachineType
+		if g.CredentialsRefKind != "" {
+			providerCfg.CredentialsRefKind = g.CredentialsRefKind
+		}
+		if g.CredentialsRefAPIVersion != "" {
+			providerCfg.CredentialsRefAPIVersion = g.CredentialsRefAPIVersion
+		}
+		if g.MachineImageName != "" {
+			providerCfg.MachineImageName = g.MachineImageName
+		}
+		if g.MachineImageVersion != "" {
+			providerCfg.MachineImageVersion = g.MachineImageVersion
+		}
+		if g.DefaultMachineType != "" {
+			providerCfg.DefaultMachineType = g.DefaultMachineType
+		}
+		if g.NodesCIDR != "" {
+			providerCfg.NodesCIDR = g.NodesCIDR
+		}
+		if g.PodsCIDR != "" {
+			providerCfg.PodsCIDR = g.PodsCIDR
+		}
+		if g.ServicesCIDR != "" {
+			providerCfg.ServicesCIDR = g.ServicesCIDR
+		}
+		if g.InfrastructureConfig != "" {
+			providerCfg.InfrastructureConfig = g.InfrastructureConfig
+		}
+		if g.ControlPlaneConfig != "" {
+			providerCfg.ControlPlaneConfig = g.ControlPlaneConfig
+		}
+		if g.ShootAnnotations != "" {
+			anns := map[string]string{}
+			if err := json.Unmarshal([]byte(g.ShootAnnotations), &anns); err != nil {
+				return nil, fmt.Errorf("parse GARDENER_SHOOT_ANNOTATIONS: %w", err)
+			}
+			providerCfg.ShootAnnotations = anns
 		}
 
 		logger.Info("using real Gardener client",
-			"kubeconfig", cfg.GardenerKubeconfig,
+			"kubeconfig", g.Kubeconfig,
 			"provider", providerCfg.Type,
 			"cloudProfile", providerCfg.CloudProfile)
-		client, err := gardener.NewReal(cfg.GardenerKubeconfig, providerCfg, logger)
+		client, err := gardener.NewReal(g.Kubeconfig, providerCfg, logger)
 		if err != nil {
 			return nil, fmt.Errorf("create gardener client: %w", err)
 		}
 		return client, nil
 
 	default:
-		return nil, fmt.Errorf("invalid GARDENER_MODE: %s (must be mock or real)", cfg.GardenerMode)
+		return nil, fmt.Errorf("invalid GARDENER_MODE: %s (must be mock or real)", g.Mode)
 	}
 }
 

--- a/cluster-worker/pkg/client/gardener/real.go
+++ b/cluster-worker/pkg/client/gardener/real.go
@@ -24,6 +24,7 @@ import (
 type ProviderConfig struct {
 	Type                   string // e.g., "local", "metal", "aws"
 	CloudProfile           string // e.g., "local", "metal", "aws"
+	Region                 string // default shoot region when the cluster specifies none (e.g., "local")
 	CredentialsBindingName string // e.g., "local", "metal-credentials" (required for all providers)
 
 	// CredentialsRef is the reference to the shared credentials resource.
@@ -41,6 +42,24 @@ type ProviderConfig struct {
 	MachineImageName    string // e.g., "local", "gardenlinux"
 	MachineImageVersion string // e.g., "1.0.0", "1592.2.0"
 	DefaultMachineType  string // e.g., "local", "n1-standard-4" (fallback when no node pools configured)
+
+	// Networking CIDRs. NodesCIDR empty leaves spec.networking.nodes unset so the
+	// provider's IPAM allocates the node range (metal hands out a partition /24);
+	// the local provider falls back to 10.0.0.0/16. Pods/Services are set only when
+	// configured (metal needs CIDRs inside the tenant super's additionalAnnouncableCIDRs).
+	NodesCIDR    string
+	PodsCIDR     string
+	ServicesCIDR string
+
+	// InfrastructureConfig and ControlPlaneConfig are raw JSON stamped verbatim
+	// onto spec.provider.* . Required by metal (partition/project/firewall +
+	// control plane); the local provider sets neither.
+	InfrastructureConfig string
+	ControlPlaneConfig   string
+
+	// ShootAnnotations are extra annotations merged onto every Shoot, e.g. metal's
+	// cluster.metal-stack.io/tenant (required by the provider-metal admission validator).
+	ShootAnnotations map[string]string
 }
 
 // NewProviderConfig creates a ProviderConfig with defaults for the local provider.
@@ -49,6 +68,7 @@ func NewProviderConfig() ProviderConfig {
 	return ProviderConfig{
 		Type:                     "local",
 		CloudProfile:             "local",
+		Region:                   "local",
 		CredentialsBindingName:   "local",                            // Name of CredentialsBinding to create/reference
 		CredentialsRef:           "garden-local/local",               // Shared WorkloadIdentity for local provider
 		CredentialsRefKind:       "WorkloadIdentity",                 // Local provider uses WorkloadIdentity
@@ -543,6 +563,11 @@ func (r *RealClient) shootAnnotations(clusterName string) map[string]string {
 	annotations := map[string]string{
 		AnnotationClusterName: clusterName,
 	}
+	// Operator-supplied annotations (e.g. metal's cluster.metal-stack.io/tenant,
+	// required by the provider-metal admission validator).
+	for k, v := range r.provider.ShootAnnotations {
+		annotations[k] = v
+	}
 	if r.provider.Type == "local" {
 		annotations["shoot.gardener.cloud/cleanup-webhooks-finalize-grace-period-seconds"] = "15"
 		annotations["shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds"] = "15"
@@ -556,6 +581,19 @@ func (r *RealClient) buildShootSpec(cluster *ClusterToSync) (*gardencorev1beta1.
 	workers, err := r.buildWorkers(cluster)
 	if err != nil {
 		return nil, err
+	}
+
+	provider := gardencorev1beta1.Provider{
+		Type:    r.provider.Type,
+		Workers: workers,
+	}
+	// Provider-specific extension configs, stamped verbatim. Required by metal
+	// (partition/project/firewall + control plane); the local provider sets neither.
+	if r.provider.InfrastructureConfig != "" {
+		provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte(r.provider.InfrastructureConfig)}
+	}
+	if r.provider.ControlPlaneConfig != "" {
+		provider.ControlPlaneConfig = &runtime.RawExtension{Raw: []byte(r.provider.ControlPlaneConfig)}
 	}
 
 	shoot := &gardencorev1beta1.Shoot{
@@ -573,18 +611,12 @@ func (r *RealClient) buildShootSpec(cluster *ClusterToSync) (*gardencorev1beta1.
 				Kind: "CloudProfile",
 				Name: r.provider.CloudProfile,
 			},
-			Region: cluster.Region,
+			Region: r.region(cluster),
 			Kubernetes: gardencorev1beta1.Kubernetes{
 				Version: cluster.KubernetesVersion,
 			},
-			Provider: gardencorev1beta1.Provider{
-				Type:    r.provider.Type,
-				Workers: workers,
-			},
-			Networking: &gardencorev1beta1.Networking{
-				Type:  new("calico"), // Default CNI
-				Nodes: new("10.0.0.0/16"),
-			},
+			Provider:   provider,
+			Networking: r.buildNetworking(),
 		},
 	}
 
@@ -594,6 +626,38 @@ func (r *RealClient) buildShootSpec(cluster *ClusterToSync) (*gardencorev1beta1.
 	}
 
 	return shoot, nil
+}
+
+// region returns the cluster's region, falling back to the provider default when
+// unset (single-region providers such as metal expose one region, e.g. "local").
+func (r *RealClient) region(cluster *ClusterToSync) string {
+	if cluster.Region != "" {
+		return cluster.Region
+	}
+	return r.provider.Region
+}
+
+// buildNetworking builds the Shoot networking from provider config. The node CIDR
+// is left unset when not configured so the provider's IPAM allocates it (metal
+// hands out a partition range); the local provider falls back to 10.0.0.0/16.
+// Pods/Services are set only when configured.
+func (r *RealClient) buildNetworking() *gardencorev1beta1.Networking {
+	n := &gardencorev1beta1.Networking{Type: new("calico")}
+
+	nodesCIDR := r.provider.NodesCIDR
+	if nodesCIDR == "" && r.provider.Type == "local" {
+		nodesCIDR = "10.0.0.0/16"
+	}
+	if nodesCIDR != "" {
+		n.Nodes = new(nodesCIDR)
+	}
+	if r.provider.PodsCIDR != "" {
+		n.Pods = new(r.provider.PodsCIDR)
+	}
+	if r.provider.ServicesCIDR != "" {
+		n.Services = new(r.provider.ServicesCIDR)
+	}
+	return n
 }
 
 // buildWorkers converts node pools to Gardener worker groups and enforces the
@@ -696,7 +760,7 @@ func (r *RealClient) updateShootSpec(shoot *gardencorev1beta1.Shoot, cluster *Cl
 	}
 	shoot.Annotations[AnnotationClusterName] = cluster.Name
 
-	shoot.Spec.Region = cluster.Region
+	shoot.Spec.Region = r.region(cluster)
 	shoot.Spec.Kubernetes.Version = cluster.KubernetesVersion
 	shoot.Spec.Provider.Workers = workers
 	return nil

--- a/cluster-worker/pkg/client/gardener/shootspec_test.go
+++ b/cluster-worker/pkg/client/gardener/shootspec_test.go
@@ -1,0 +1,85 @@
+package gardener
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(provider ProviderConfig) *RealClient {
+	return &RealClient{provider: provider, logger: slog.Default()}
+}
+
+func testCluster() *ClusterToSync {
+	return &ClusterToSync{
+		ID:                uuid.New(),
+		OrganizationID:    uuid.New(),
+		Name:              "demo",
+		ShootName:         "demo",
+		Namespace:         "garden-test",
+		Region:            "local",
+		KubernetesVersion: "1.35.6",
+	}
+}
+
+// The local provider gets the in-code node CIDR and no provider extension config.
+func TestBuildShootSpec_LocalDefaults(t *testing.T) {
+	r := testClient(NewProviderConfig())
+
+	shoot, err := r.buildShootSpec(testCluster())
+	require.NoError(t, err)
+
+	require.NotNil(t, shoot.Spec.Networking.Nodes)
+	require.Equal(t, "10.0.0.0/16", *shoot.Spec.Networking.Nodes)
+	require.Nil(t, shoot.Spec.Networking.Pods)
+	require.Nil(t, shoot.Spec.Provider.InfrastructureConfig)
+	require.Nil(t, shoot.Spec.Provider.ControlPlaneConfig)
+}
+
+// A metal-shaped provider omits the node CIDR (metal IPAM allocates it), sets
+// pods/services, stamps the raw extension configs verbatim, and merges the
+// operator-supplied annotations.
+func TestBuildShootSpec_MetalProvider(t *testing.T) {
+	infra := `{"apiVersion":"metal.provider.extensions.gardener.cloud/v1alpha1","kind":"InfrastructureConfig","partitionID":"fire"}`
+	cp := `{"apiVersion":"metal.provider.extensions.gardener.cloud/v1alpha1","kind":"ControlPlaneConfig"}`
+
+	r := testClient(ProviderConfig{
+		Type:                 "metal",
+		CloudProfile:         "metal",
+		Region:               "local",
+		PodsCIDR:             "10.240.0.0/16",
+		ServicesCIDR:         "10.248.0.0/16",
+		InfrastructureConfig: infra,
+		ControlPlaneConfig:   cp,
+		ShootAnnotations:     map[string]string{"cluster.metal-stack.io/tenant": "fundament"},
+	})
+
+	shoot, err := r.buildShootSpec(testCluster())
+	require.NoError(t, err)
+
+	// Node CIDR left unset so metal allocates a partition range.
+	require.Nil(t, shoot.Spec.Networking.Nodes)
+	require.Equal(t, "10.240.0.0/16", *shoot.Spec.Networking.Pods)
+	require.Equal(t, "10.248.0.0/16", *shoot.Spec.Networking.Services)
+
+	require.NotNil(t, shoot.Spec.Provider.InfrastructureConfig)
+	require.JSONEq(t, infra, string(shoot.Spec.Provider.InfrastructureConfig.Raw))
+	require.NotNil(t, shoot.Spec.Provider.ControlPlaneConfig)
+	require.JSONEq(t, cp, string(shoot.Spec.Provider.ControlPlaneConfig.Raw))
+
+	require.Equal(t, "fundament", shoot.Annotations["cluster.metal-stack.io/tenant"])
+}
+
+// An empty cluster region falls back to the provider default.
+func TestBuildShootSpec_RegionFallback(t *testing.T) {
+	r := testClient(ProviderConfig{Type: "metal", CloudProfile: "metal", Region: "local"})
+
+	cluster := testCluster()
+	cluster.Region = ""
+
+	shoot, err := r.buildShootSpec(cluster)
+	require.NoError(t, err)
+	require.Equal(t, "local", shoot.Spec.Region)
+}


### PR DESCRIPTION
## What

The real Gardener client (`cluster-worker`) builds a shoot that only fits the **local** provider: the shared credentials reference, node CIDR, and provider extension configs are hardcoded to local-provider values. This makes those defaults overridable so a non-local provider (we run **metal**) can drive real shoots, while leaving the local provider's behaviour byte-for-byte unchanged.

## Why

Running `cluster-worker` in `real` mode against a metal Gardener fails because:

- `NewProviderConfig()` pins `CredentialsRef=garden-local/local`, `Kind=WorkloadIdentity`. metal binds a **Secret**, and that WorkloadIdentity does not exist there.
- `buildShootSpec` hardcodes `spec.networking.nodes = 10.0.0.0/16`. metal's IPAM allocates the node range itself and rejects a fixed CIDR.
- There is no way to set `pods`/`services` CIDRs, a default region, the provider-specific `infrastructureConfig` / `controlPlaneConfig`, or extra Shoot annotations (metal requires `cluster.metal-stack.io/tenant`).

## Changes

- **`GardenerConfig` struct** with `envPrefix:"GARDENER_"`, mirroring the existing `Outbox`/`Status`/... pattern. The redundant per-tag `GARDENER_` prefix is factored out and each field maps 1:1 to its env suffix. **All existing env var names are unchanged** (verified via `helm template`).
- **`ProviderConfig`** gains `Region`, `NodesCIDR`/`PodsCIDR`/`ServicesCIDR`, `InfrastructureConfig`/`ControlPlaneConfig` (raw JSON, stamped verbatim into `spec.provider.*`) and `ShootAnnotations`, all overridable via new `GARDENER_*` env.
- **`buildShootSpec`**: region falls back to the provider default; the node CIDR is left unset unless configured (local still falls back to `10.0.0.0/16`) so a provider IPAM can allocate it; pods/services set only when configured; provider extension configs and operator annotations applied.
- **Chart**: renders the new env from `clusterWorker.gardener*` values (all optional, defaults empty).
- **Tests**: local defaults, the metal-shaped shoot spec (omitted node CIDR, stamped raw configs, merged annotations), and the region fallback.

## Compatibility

Every new field is optional and every existing env var name is preserved, so the local provider is unaffected. Non-local providers opt in via the new values.

## Testing

`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/client/gardener/...` (incl. the new tests) pass. The `pkg/handler/cluster` integration tests were not run here (they require the `trek` migration tool, unrelated to this change).

https://claude.ai/code/session_0194BFaQiZGDDmh3NyUSoRpz
