### PR TITLE
feat(console-frontend): remove Members and Namespaces from the cluster detail page

### DIFF
--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -427,49 +427,8 @@
         </div>
       </div>
 
-      <!-- Members and Node Pools -->
+      <!-- Node Pools, Plugins and Monitoring -->
       <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <!-- Members -->
-        <div class="card card-body">
-          <h3 class="mb-4 text-xl font-medium">
-            Members
-            <!-- TODO: Update this link - clusters belong to organizations, not projects
-            <nldd-button routerLink="/project-members" text="Edit" start-icon="pencil" variant="secondary" size="xs" class="ml-1" ></nldd-button>
-            -->
-          </h3>
-          <div class="space-y-3">
-            @for (member of clusterData.members; track member.name) {
-              <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-3">
-                  <div class="flex-0">
-                    <div
-                      class="bg-accent-100 dark:bg-accent-900 flex h-8 w-8 items-center justify-center rounded-full"
-                    >
-                      <span class="text-accent-700 dark:text-accent-300 font-medium">{{
-                        member.name.charAt(0)
-                      }}</span>
-                    </div>
-                  </div>
-                  <p class="font-medium">{{ member.name }}</p>
-                </div>
-                <div class="text-right">
-                  <span
-                    class="badge-sm"
-                    [class.badge-purple]="member.role === 'admin'"
-                    [class.badge-blue]="member.role === 'edit'"
-                    [class.badge-emerald]="member.role === 'view'"
-                  >
-                    {{ member.role }}
-                  </span>
-                  <p class="mt-1 text-gray-500 dark:text-gray-400">
-                    Last active: {{ formatDate(member.lastActive) }}
-                  </p>
-                </div>
-              </div>
-            }
-          </div>
-        </div>
-
         <!-- Node Pools -->
         <div class="card card-body">
           <h3 class="mb-4 text-xl font-medium">
@@ -595,35 +554,6 @@
           }
         </div>
 
-        <!-- Namespaces Block -->
-        <div class="card card-body">
-          <h3 class="mb-4 text-xl font-medium">
-            Namespaces
-            <nldd-button
-              [routerLink]="['/clusters', clusterData.basics.id, 'namespaces']"
-              text="Edit"
-              start-icon="pencil"
-              variant="secondary"
-              size="xs"
-              class="ml-1"
-            ></nldd-button>
-          </h3>
-          @if (namespaces().length === 0) {
-            <p class="text-gray-500 dark:text-gray-400">No namespaces in this cluster yet.</p>
-          } @else {
-            <div class="space-y-3">
-              @for (namespace of namespaces(); track namespace.id) {
-                <div class="card card-body-sm">
-                  <p class="font-mono text-sm">{{ namespace.name }}</p>
-                  <p class="mt-1 text-gray-500 dark:text-gray-400">
-                    Project: {{ getProjectName(namespace.projectId) }} &bull; Created
-                    {{ formatDate(namespace.created) }}
-                  </p>
-                </div>
-              }
-            </div>
-          }
-        </div>
       </div>
 
       <!-- Danger Zone -->

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -237,12 +237,6 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
         details: 'High CPU usage alert cleared',
       },
     ],
-    members: [
-      { name: 'John Doe', role: 'admin', lastActive: '2024-12-06T14:20:00Z' },
-      { name: 'Jane Smith', role: 'edit', lastActive: '2024-12-06T11:45:00Z' },
-      { name: 'Mike Johnson', role: 'view', lastActive: '2024-12-05T16:30:00Z' },
-      { name: 'Sarah Wilson', role: 'edit', lastActive: '2024-12-04T09:15:00Z' },
-    ],
     nodePools: [] as NodePool[],
     resourceUsage: {
       cpu: { used: 2.4, limit: 8.0, unit: 'cores' },
@@ -438,10 +432,6 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
           : 'Failed to load namespaces',
       );
     }
-  }
-
-  getProjectName(projectId: string): string {
-    return this.organizationDataService.getProjectById(projectId)?.project.alias ?? projectId;
   }
 
   // Load installed plugins for the cluster


### PR DESCRIPTION
Removes two cards from the cluster detail page:

- **Members** - rendered hardcoded mock data (John Doe et al.); cluster membership is not a real concept yet, and the commented-out edit link already noted the link target was wrong (clusters belong to organizations, not projects).
- **Namespaces** - duplicated the dedicated namespaces page that its own edit button linked to.

Also removes the now-dead code behind them (the mock `members` array, `getProjectName`). Kept as-is: the **danger zone** still uses the namespaces data to block deleting non-empty clusters, and the namespaces page (`/clusters/:id/namespaces`) is untouched.

`ng build` + `ng lint` pass.

https://claude.ai/code/session_0194BFaQiZGDDmh3NyUSoRpz