### PR TITLE
plugin-controller: hot-reload dev setup

### DIFF
--- a/plugin-controller/hotreload/.air.toml
+++ b/plugin-controller/hotreload/.air.toml
@@ -1,0 +1,16 @@
+root = "/src"
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o tmp/plugin-controller ./plugin-controller/cmd"
+entrypoint = "tmp/plugin-controller"
+include_ext = ["go", "mod", "sum"]
+include_dir = ["plugin-controller", "plugin-sdk", "common", "organization-api"]
+exclude_dir = ["tmp"]
+delay = 500
+
+[log]
+time = false
+
+[misc]
+clean_on_exit = true

--- a/plugin-controller/hotreload/Dockerfile
+++ b/plugin-controller/hotreload/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.26.5-alpine
+
+RUN go install github.com/air-verse/air@v1.65.0
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY plugin-controller/ ./plugin-controller/
+COPY plugin-sdk/pluginruntime/ ./plugin-sdk/pluginruntime/
+COPY common/ ./common/
+COPY organization-api/pkg/proto/ ./organization-api/pkg/proto/
+
+CMD ["air", "-c", "plugin-controller/hotreload/.air.toml"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -200,6 +200,12 @@ profiles:
         path: /build/artifacts/7/sync
         value: {}
       - op: replace
+        path: /build/artifacts/9/docker/dockerfile
+        value: plugin-controller/hotreload/Dockerfile
+      - op: add
+        path: /build/artifacts/9/sync
+        value: {}
+      - op: replace
         path: /build/artifacts/10/docker/dockerfile
         value: dcim-api/hotreload/Dockerfile
       - op: add


### PR DESCRIPTION
Adds an [air](https://github.com/air-verse/air)-based hot-reload dev setup for `plugin-controller`, split out of #320 so the dev-tooling change can be reviewed on its own.

## What's here
- `plugin-controller/hotreload/.air.toml` — air config (rebuild on changes under `plugin-controller`, `plugin-sdk`, `common`, `organization-api`).
- `plugin-controller/hotreload/Dockerfile` — `golang:1.26.5-alpine` image that installs air and runs it against the config.
- `skaffold.yaml` — wires artifact/9 (`plugin-controller`) to the hot-reload Dockerfile + sync in the hotreload profile.

## Notes
- Dev-only; production `plugin-controller/Dockerfile` is unchanged.
- Self-contained against `master` — the copied/watched dirs already exist, so it builds without the #320 feature work.
- The remaining hot-reload-adjacent edits in #320 (proto/plugin-sdk `COPY`s, `organizationApiUrl`, migration version bump) are genuinely required by the plugin-definition-storage feature and intentionally stay in #320.