### PR TITLE
functl: default to deployed endpoints, env override for local dev

### DIFF
--- a/functl/README.md
+++ b/functl/README.md
@@ -62,6 +62,7 @@ defaults and the config file.
 | `FUNCTL_CONFIG_DIR` | Override the configuration directory path (must be absolute) |
 | `FUNCTL_API_ENDPOINT` | Override the organization API endpoint (takes precedence over config file) |
 | `FUNCTL_AUTHN_URL` | Override the authn API endpoint (takes precedence over config file) |
+| `FUNCTL_DEBUG` | Enable debug logging (same as `--debug`); shows the resolved endpoints on startup |
 | `FUNDAMENT_API_KEY` | API key for authentication (takes precedence over credentials file) |
 
 ## Authentication

--- a/functl/README.md
+++ b/functl/README.md
@@ -45,16 +45,23 @@ Use `functl config dir` to see the resolved directory, or `functl config path` f
 Create `~/.config/fundament/config.yaml` to override defaults:
 
 ```yaml
-api_endpoint: https://organization.fundament.localhost:8443
-authn_url: https://authn.fundament.localhost:8443
+api_endpoint: https://organization-api.fundament-poc.nl
+authn_url: https://authn.fundament-poc.nl
 output: table
 ```
+
+The built-in defaults point at the deployed environment shown above. For
+local development the repo's `mise.toml` sets `FUNCTL_API_ENDPOINT` and
+`FUNCTL_AUTHN_URL` to the local skaffold endpoints, which override both the
+defaults and the config file.
 
 ### Environment variables
 
 | Variable | Description |
 |----------|-------------|
 | `FUNCTL_CONFIG_DIR` | Override the configuration directory path (must be absolute) |
+| `FUNCTL_API_ENDPOINT` | Override the organization API endpoint (takes precedence over config file) |
+| `FUNCTL_AUTHN_URL` | Override the authn API endpoint (takes precedence over config file) |
 | `FUNDAMENT_API_KEY` | API key for authentication (takes precedence over credentials file) |
 
 ## Authentication

--- a/functl/cmd/functl/main.go
+++ b/functl/cmd/functl/main.go
@@ -35,6 +35,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: failed to load config: %v\n", err)
 		os.Exit(1)
 	}
+	logger.Debug("resolved endpoints",
+		"api_endpoint", cfg.APIEndpoint,
+		"api_endpoint_from_env", os.Getenv(config.EnvAPIEndpoint) != "",
+		"authn_url", cfg.AuthnURL,
+		"authn_url_from_env", os.Getenv(config.EnvAuthnURL) != "")
 
 	runCtx := &cli.Context{
 		Debug:  root.Debug,

--- a/functl/pkg/cli/cli.go
+++ b/functl/pkg/cli/cli.go
@@ -15,7 +15,7 @@ var ErrNoActiveOrganization = errors.New("no active organization: pass --org=<or
 
 // CLI defines the root command-line interface structure.
 type CLI struct {
-	Debug       bool         `help:"Enable debug logging."`
+	Debug       bool         `help:"Enable debug logging." env:"FUNCTL_DEBUG"`
 	Output      OutputFormat `help:"Output format: table or json." short:"o" default:"table" enum:"table,json"`
 	OrgOverride string       `name:"org" help:"Organization ID (overrides the active organization configured via 'functl org set')."`
 

--- a/functl/pkg/config/config.go
+++ b/functl/pkg/config/config.go
@@ -33,15 +33,21 @@ func DefaultConfig() *Config {
 	}
 }
 
+// Environment variables that override the endpoint configuration.
+const (
+	EnvAPIEndpoint = "FUNCTL_API_ENDPOINT"
+	EnvAuthnURL    = "FUNCTL_AUTHN_URL"
+)
+
 // applyEnvOverrides overrides endpoint settings from the environment.
-// FUNCTL_API_ENDPOINT and FUNCTL_AUTHN_URL take precedence over both the
-// config file and the built-in defaults; the fundament repo sets them via
-// mise so a checkout talks to the local dev endpoints.
+// EnvAPIEndpoint and EnvAuthnURL take precedence over both the config file
+// and the built-in defaults; the fundament repo sets them via mise so a
+// checkout talks to the local dev endpoints.
 func applyEnvOverrides(cfg *Config) {
-	if v := os.Getenv("FUNCTL_API_ENDPOINT"); v != "" {
+	if v := os.Getenv(EnvAPIEndpoint); v != "" {
 		cfg.APIEndpoint = v
 	}
-	if v := os.Getenv("FUNCTL_AUTHN_URL"); v != "" {
+	if v := os.Getenv(EnvAuthnURL); v != "" {
 		cfg.AuthnURL = v
 	}
 }

--- a/functl/pkg/config/config.go
+++ b/functl/pkg/config/config.go
@@ -27,9 +27,22 @@ type Credentials struct {
 // DefaultConfig returns the default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		APIEndpoint: "https://organization.fundament.localhost:8443",
-		AuthnURL:    "https://authn.fundament.localhost:8443",
+		APIEndpoint: "https://organization-api.fundament-poc.nl",
+		AuthnURL:    "https://authn.fundament-poc.nl",
 		Output:      "table",
+	}
+}
+
+// applyEnvOverrides overrides endpoint settings from the environment.
+// FUNCTL_API_ENDPOINT and FUNCTL_AUTHN_URL take precedence over both the
+// config file and the built-in defaults; the fundament repo sets them via
+// mise so a checkout talks to the local dev endpoints.
+func applyEnvOverrides(cfg *Config) {
+	if v := os.Getenv("FUNCTL_API_ENDPOINT"); v != "" {
+		cfg.APIEndpoint = v
+	}
+	if v := os.Getenv("FUNCTL_AUTHN_URL"); v != "" {
+		cfg.AuthnURL = v
 	}
 }
 
@@ -91,6 +104,8 @@ func EnsureConfigDir() error {
 
 // LoadConfig loads the configuration from the config file.
 // If the file doesn't exist, it returns the default configuration.
+// FUNCTL_API_ENDPOINT and FUNCTL_AUTHN_URL environment variables override
+// the endpoints from either source.
 func LoadConfig() (*Config, error) {
 	path, err := ConfigPath()
 	if err != nil {
@@ -100,7 +115,9 @@ func LoadConfig() (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return DefaultConfig(), nil
+			cfg := DefaultConfig()
+			applyEnvOverrides(cfg)
+			return cfg, nil
 		}
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -109,6 +126,7 @@ func LoadConfig() (*Config, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+	applyEnvOverrides(cfg)
 
 	return cfg, nil
 }

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,9 @@
 JUST_ONE = true
 # Local k3d registry for Skaffold image builds
 SKAFFOLD_DEFAULT_REPO = "k3d-registry.localhost:5111"
+# Point functl at the local dev endpoints
+FUNCTL_API_ENDPOINT = "https://organization.fundament.localhost:8443"
+FUNCTL_AUTHN_URL = "https://authn.fundament.localhost:8443"
 
 [tools]
 # Scripting & Meta

--- a/mise.toml
+++ b/mise.toml
@@ -2,9 +2,11 @@
 JUST_ONE = true
 # Local k3d registry for Skaffold image builds
 SKAFFOLD_DEFAULT_REPO = "k3d-registry.localhost:5111"
-# Point functl at the local dev endpoints
+# Point functl at the local dev endpoints, and log at debug level so the
+# endpoint override is visible on startup
 FUNCTL_API_ENDPOINT = "https://organization.fundament.localhost:8443"
 FUNCTL_AUTHN_URL = "https://authn.fundament.localhost:8443"
+FUNCTL_DEBUG = "true"
 
 [tools]
 # Scripting & Meta


### PR DESCRIPTION
## What

- Change functl's built-in default endpoints from the `fundament.localhost:8443` dev URLs to the deployed environment (`https://organization-api.fundament-poc.nl` / `https://authn.fundament-poc.nl`).
- Add `FUNCTL_API_ENDPOINT` and `FUNCTL_AUTHN_URL` environment variables that override both the defaults and `config.yaml` (naming follows the existing `FUNCTL_CONFIG_DIR` pattern).
- Set both vars in `mise.toml` to the local skaffold endpoints, so shells inside the repo checkout keep using local dev.
- Update the functl README accordingly.

## Why

A kubeconfig downloaded from the console authenticates through the `functl cluster token` exec plugin. With the old defaults, a plain functl install pointed at localhost and the kubeconfig did not work without first hand-writing a config file. Now the out-of-the-box experience targets the deployed environment, and developers get the local endpoints automatically via mise.

## Testing

- `go build ./functl/...` and `go test ./functl/pkg/config/` pass.
- `mise env` inside the repo exports both override vars.
- Running the built binary outside the repo reaches the deployed authn API (invalid dummy key is rejected by the server, proving connectivity).