### PR TITLE
kube-api-proxy: forward /version and match allowlist on whole path segments

### DIFF
--- a/kube-api-proxy/pkg/proxy/handler.go
+++ b/kube-api-proxy/pkg/proxy/handler.go
@@ -16,9 +16,9 @@ import (
 	"github.com/fundament-oss/fundament/kube-api-proxy/pkg/kube"
 )
 
-// allowedPathPrefixes are the Kubernetes API path prefixes the proxy forwards.
-// All other paths return 404.
-var allowedPathPrefixes = []string{"api", "apis", "openapi/"}
+// allowedPathRoots are the Kubernetes API path roots the proxy forwards,
+// matched on the whole first path segment. All other roots return 404.
+var allowedPathRoots = []string{"api", "apis", "openapi", "version"}
 
 // handleClusterProxy proxies Kubernetes API requests to a specific cluster.
 // The cluster ID and remaining path are extracted from the URL via Go 1.22+ wildcards:
@@ -37,7 +37,7 @@ func (s *Server) handleClusterProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// {path...} does not include leading slash.
+	// {path...} does not include a leading slash.
 	path := r.PathValue("path")
 	if !isAllowedPath(path) {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -149,13 +149,13 @@ func peekTokenType(r *http.Request) auth.TokenType {
 	return auth.TokenTypeUser
 }
 
-// isAllowedPath checks whether the path (without leading slash) starts with
-// one of the allowed Kubernetes API prefixes.
-func isAllowedPath(path string) bool {
-	for _, prefix := range allowedPathPrefixes {
-		if path == strings.TrimSuffix(prefix, "/") || strings.HasPrefix(path, prefix) {
-			return true
-		}
-	}
-	return false
+// isAllowedPath reports whether the first segment of the raw wildcard path (the
+// {path...} value, without a leading slash) is an allowed Kubernetes API root.
+// It matches whole segments, so "apix" or "versionz" do not match "api" /
+// "version". It does not concern itself with "." / ".." segments: the apiserver
+// owns path normalization and authorizes every request against the injected SA
+// token, so a traversal attempt cannot cross a privilege boundary here.
+func isAllowedPath(rawPath string) bool {
+	root, _, _ := strings.Cut(rawPath, "/")
+	return slices.Contains(allowedPathRoots, root)
 }

--- a/kube-api-proxy/pkg/proxy/handler_test.go
+++ b/kube-api-proxy/pkg/proxy/handler_test.go
@@ -66,3 +66,35 @@ func TestPeekTokenType(t *testing.T) {
 		})
 	}
 }
+
+// TestIsAllowedPath feeds raw {path...} wildcard values as r.PathValue returns
+// them in production (percent-decoded, no leading slash) and checks whole-segment
+// matching of the first path segment.
+func TestIsAllowedPath(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"api", true},
+		{"api/v1/pods", true},
+		{"apis", true},
+		{"apis/apps/v1/deployments", true},
+		{"openapi/v3", true},
+		{"version", true},
+		{"", false},
+		{"healthz", false},
+		{"livez", false},
+		{"metrics", false},
+		{"logs", false},
+		// Prefix collisions must not match: only whole path segments count.
+		{"apix", false},
+		{"apisx/apps", false},
+		{"versionz", false},
+		{"openapix/v3", false},
+	}
+	for _, tc := range cases {
+		t.Run("path "+tc.raw, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAllowedPath(tc.raw))
+		})
+	}
+}


### PR DESCRIPTION
## What

Add `version` to the kube-api-proxy path allowlist (`api`, `apis`, `openapi/`), and add a table test for `isAllowedPath`.

## Why

Clients probe `GET /version` to validate a connection before doing anything else: `kubectl version` does, and k9s does on startup via `ServerVersion()`. The proxy 404'd that path, so k9s refused to open the cluster ("no connection to dial") even though `kubectl get` worked fine through the same kubeconfig. `/version` is harmless to forward: it is unauthenticated metadata the shoot apiserver serves to any bearer of a valid token, and requests still pass the proxy's JWT + OpenFGA checks first.

## Testing

- `go test ./kube-api-proxy/pkg/proxy/` passes, including the new `TestIsAllowedPath`.
- Reproduced against the deployed proxy: `/clusters/<id>/version` returned the proxy's own 404 while `/clusters/<id>/api` passed through, matching the k9s failure.