### PR TITLE
functl: release builds on every push to master

### DIFF
--- a/.github/workflows/release-functl.yml
+++ b/.github/workflows/release-functl.yml
@@ -1,0 +1,75 @@
+name: Release functl
+
+on:
+  push:
+    branches: [master]
+
+permissions: {}
+
+concurrency:
+  group: release-functl
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          VERSION="${GITHUB_SHA::7}-master-${{ github.run_number }}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+          mkdir -p dist
+          for target in linux/amd64 linux/arm64 darwin/arm64; do
+            GOOS="${target%/*}"
+            GOARCH="${target#*/}"
+            OUT_DIR="dist/functl_${GOOS}_${GOARCH}"
+            mkdir -p "$OUT_DIR"
+            CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+              go build -trimpath \
+                -ldflags "-s -w -X github.com/fundament-oss/fundament/functl/pkg/cli.version=${VERSION}" \
+                -o "$OUT_DIR/functl" ./functl/cmd/functl
+            tar -C "$OUT_DIR" -czf "dist/functl_${GOOS}_${GOARCH}.tar.gz" functl
+          done
+          (cd dist && sha256sum *.tar.gz > SHA256SUMS)
+
+      - name: Update rolling release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Move the rolling tag to the current commit.
+          git tag -f functl-latest
+          git push -f origin functl-latest
+
+          if ! gh release view functl-latest > /dev/null 2>&1; then
+            gh release create functl-latest \
+              --prerelease \
+              --title "functl (rolling)" \
+              --notes "placeholder"
+          fi
+
+          gh release edit functl-latest \
+            --prerelease \
+            --title "functl (rolling)" \
+            --notes "Rolling build of functl from the latest push to master.
+
+          - Version: \`${VERSION}\`
+          - Commit: ${GITHUB_SHA}
+
+          See functl/README.md for install instructions."
+
+          gh release upload functl-latest \
+            dist/functl_linux_amd64.tar.gz \
+            dist/functl_linux_arm64.tar.gz \
+            dist/functl_darwin_arm64.tar.gz \
+            dist/SHA256SUMS \
+            --clobber

--- a/functl/README.md
+++ b/functl/README.md
@@ -11,7 +11,7 @@ Every push to master publishes binaries for Linux (amd64, arm64) and macOS (Appl
 ```bash
 # Pick your platform: linux_amd64, linux_arm64, or darwin_arm64
 curl -fsSL https://github.com/fundament-oss/fundament/releases/download/functl-latest/functl_linux_amd64.tar.gz \
-  | tar -xz functl
+  | tar -xzf - functl
 sudo mv functl /usr/local/bin/
 ```
 

--- a/functl/README.md
+++ b/functl/README.md
@@ -4,6 +4,19 @@ CLI for managing Fundament platform resources using an API key.
 
 ## Installation
 
+### Download a prebuilt binary
+
+Every push to master publishes binaries for Linux (amd64, arm64) and macOS (Apple Silicon) to the rolling [`functl-latest`](https://github.com/fundament-oss/fundament/releases/tag/functl-latest) release:
+
+```bash
+# Pick your platform: linux_amd64, linux_arm64, or darwin_arm64
+curl -fsSL https://github.com/fundament-oss/fundament/releases/download/functl-latest/functl_linux_amd64.tar.gz \
+  | tar -xz functl
+sudo mv functl /usr/local/bin/
+```
+
+Checksums are published alongside the archives as `SHA256SUMS`. Check the installed build with `functl version`.
+
 ### Build from source
 
 ```bash

--- a/functl/pkg/cli/cli.go
+++ b/functl/pkg/cli/cli.go
@@ -26,6 +26,7 @@ type CLI struct {
 	Project   ProjectCmd   `cmd:"" help:"Manage projects."`
 	Namespace NamespaceCmd `cmd:"" help:"Manage namespaces."`
 	APIKey    APIKeyCmd    `cmd:"" name:"apikey" help:"Manage API keys."`
+	Version   VersionCmd   `cmd:"" help:"Print the functl version."`
 }
 
 // Context holds shared dependencies for command execution.

--- a/functl/pkg/cli/version.go
+++ b/functl/pkg/cli/version.go
@@ -1,0 +1,17 @@
+package cli
+
+import "fmt"
+
+// version is set at build time via:
+//
+//	-ldflags "-X github.com/fundament-oss/fundament/functl/pkg/cli.version=<version>"
+var version = "dev"
+
+// VersionCmd prints the functl build version.
+type VersionCmd struct{}
+
+// Run executes the version command.
+func (c *VersionCmd) Run(ctx *Context) error {
+	fmt.Println(version)
+	return nil
+}


### PR DESCRIPTION
## Summary

- New `release-functl` workflow: on every push to master, cross-compiles functl for **linux/amd64**, **linux/arm64**, and **darwin/arm64** (`CGO_ENABLED=0`, `-trimpath`, stripped) from a single Ubuntu job, packages each as a tar.gz with a `SHA256SUMS` file, and publishes them to a rolling `functl-latest` pre-release.
- The `functl-latest` tag is force-moved to the released commit each run, so the release always points at what was built and download URLs stay stable, e.g. `releases/download/functl-latest/functl_linux_amd64.tar.gz`.
- Adds a `functl version` subcommand; the workflow injects `<short-sha>-master-<run_number>` via ldflags (defaults to `dev` for local builds).
- README gains a "Download a prebuilt binary" install section.

## Notes

- A `release-functl` concurrency group (no cancellation) serializes back-to-back master pushes so uploads never race.
- The tag push uses the default `GITHUB_TOKEN` (job has `contents: write`); token-initiated pushes don't trigger workflows, so no recursion.
- First run creates the pre-release automatically — no manual setup.
- Deliberately deferred: semver-tagged releases, Homebrew tap, macOS notarization (not needed for curl installs), and darwin/amd64 (Intel Macs).

## Test plan

- [x] All three targets cross-compile locally with `CGO_ENABLED=0`
- [x] `gofmt`, `go vet`, `go test ./functl/...` pass
- [x] Built binary prints injected version via `functl version`
- [x] Workflow YAML parses; release script block renders with correct quoting
- [ ] After merge: verify first `Release functl` run publishes the `functl-latest` release with 3 archives + `SHA256SUMS`