### PR TITLE
feat(plugins): choose a version to pin when installing a plugin

### DIFF
--- a/console-frontend/src/app/install-plugin-modal/install-plugin-modal.html
+++ b/console-frontend/src/app/install-plugin-modal/install-plugin-modal.html
@@ -13,6 +13,30 @@
     <strong class="font-semibold">{{ pluginDisplayName() }}</strong> on:
   </p>
 
+  @if (versions().length > 0) {
+    <nldd-form-field label="Version" class="mb-4 block">
+      <nldd-dropdown>
+        <select
+          [value]="selectedVersion()"
+          (change)="onVersionChange($any($event).target.value)"
+        >
+          @for (v of versions(); track v.version) {
+            <option [value]="v.version">{{ v.version }}</option>
+          }
+        </select>
+      </nldd-dropdown>
+    </nldd-form-field>
+  } @else {
+    <nldd-box class="mb-4 block">
+      <nldd-inline-dialog
+        icon="ship-wheel"
+        icon-color="secondary"
+        text="No published version"
+        supporting-text="This plugin has no published definition to install yet."
+      ></nldd-inline-dialog>
+    </nldd-box>
+  }
+
   @if (clusters().length === 0) {
     <nldd-box>
       <nldd-inline-dialog
@@ -101,7 +125,9 @@
     (click)="onInstallSelected()"
     text="Install on selected ({{ selectedCount() }})"
     variant="primary"
-    [attr.disabled]="eligibleClusters().length === 0 || selectedCount() === 0 ? '' : null"
+    [attr.disabled]="
+      eligibleClusters().length === 0 || selectedCount() === 0 || versions().length === 0 ? '' : null
+    "
   ></nldd-button>
   <nldd-button
     slot="actions"

--- a/console-frontend/src/app/install-plugin-modal/install-plugin-modal.html
+++ b/console-frontend/src/app/install-plugin-modal/install-plugin-modal.html
@@ -16,21 +16,26 @@
   @if (versions().length > 0) {
     <nldd-form-field label="Version" class="mb-4 block">
       <nldd-dropdown>
-        <select
-          [value]="selectedVersion()"
-          (change)="onVersionChange($any($event).target.value)"
-        >
+        <select [value]="selectedVersion()" (change)="onVersionChange($any($event).target.value)">
           @for (v of versions(); track v.version) {
             <option [value]="v.version">{{ v.version }}</option>
           }
         </select>
       </nldd-dropdown>
     </nldd-form-field>
+  } @else if (versionsError()) {
+    <nldd-box class="mb-4 block">
+      <nldd-inline-dialog
+        icon="exclamation-triangle"
+        icon-color="critical"
+        text="Couldn't load versions"
+        supporting-text="Something went wrong loading this plugin's versions. Close this dialog and try again."
+      ></nldd-inline-dialog>
+    </nldd-box>
   } @else {
     <nldd-box class="mb-4 block">
       <nldd-inline-dialog
-        icon="ship-wheel"
-        icon-color="secondary"
+        variant="alert"
         text="No published version"
         supporting-text="This plugin has no published definition to install yet."
       ></nldd-inline-dialog>
@@ -126,7 +131,9 @@
     text="Install on selected ({{ selectedCount() }})"
     variant="primary"
     [attr.disabled]="
-      eligibleClusters().length === 0 || selectedCount() === 0 || versions().length === 0 ? '' : null
+      eligibleClusters().length === 0 || selectedCount() === 0 || versions().length === 0
+        ? ''
+        : null
     "
   ></nldd-button>
   <nldd-button

--- a/console-frontend/src/app/install-plugin-modal/install-plugin-modal.ts
+++ b/console-frontend/src/app/install-plugin-modal/install-plugin-modal.ts
@@ -27,6 +27,27 @@ interface Cluster {
   running: boolean;
 }
 
+// A published definition the user can pin on install: the version they see and
+// the content hash that version resolves to.
+export interface PluginVersionOption {
+  version: string;
+  hash: string;
+}
+
+// Emitted on install: the chosen clusters plus the pinned version/hash pair.
+export interface InstallSelection {
+  clusterIds: string[];
+  version: string;
+  hash: string;
+}
+
+// Emitted on retry: a single cluster plus the currently pinned version/hash.
+export interface RetrySelection {
+  clusterId: string;
+  version: string;
+  hash: string;
+}
+
 @Component({
   selector: 'app-install-plugin-modal',
   imports: [DialogSyncDirective, LoadingIndicatorComponent],
@@ -41,23 +62,40 @@ export default class InstallPluginModalComponent {
 
   clusters = input<Cluster[]>([]);
 
+  // Published versions to choose from, latest first. Empty means nothing is
+  // published yet — the plugin cannot be installed.
+  versions = input<PluginVersionOption[]>([]);
+
   show = input(false);
 
   closeModal = output<void>();
 
-  // Emits the cluster IDs to install the plugin on (batch).
-  install = output<string[]>();
+  // Emits the chosen clusters plus the pinned version/hash to install.
+  install = output<InstallSelection>();
 
   // Emits the cluster ID to uninstall the plugin from.
   uninstall = output<string>();
 
-  // Emits the cluster ID to retry a failed installation on.
-  retry = output<string>();
+  // Emits a cluster to retry a failed installation on, with the current pin.
+  retry = output<RetrySelection>();
 
   dialogRef = viewChild<ElementRef<HTMLElement>>('dialog');
 
   // Cluster IDs currently selected for batch install.
   selected = signal<Set<string>>(new Set());
+
+  // The version the user picked, or null to fall back to the latest. Reset on
+  // every open so re-opening defaults to the newest published version.
+  private pickedVersion = signal<string | null>(null);
+
+  // Effective selection: the user's pick when still valid, else the latest
+  // (first) published version. Empty when nothing is published.
+  selectedVersion = computed(() => {
+    const versions = this.versions();
+    const picked = this.pickedVersion();
+    if (picked && versions.some((v) => v.version === picked)) return picked;
+    return versions[0]?.version ?? '';
+  });
 
   // Clusters eligible for selection: running and not yet installed.
   eligibleClusters = computed(() =>
@@ -100,8 +138,13 @@ export default class InstallPluginModalComponent {
 
   onOpen(): void {
     this.selected.set(new Set());
+    this.pickedVersion.set(null);
     const el = this.dialogRef()?.nativeElement;
     if (el) focusFirstModalInput(el);
+  }
+
+  onVersionChange(version: string): void {
+    this.pickedVersion.set(version);
   }
 
   onClose(): void {
@@ -110,8 +153,9 @@ export default class InstallPluginModalComponent {
 
   onInstallSelected(): void {
     const ids = [...this.selected()];
-    if (ids.length === 0) return;
-    this.install.emit(ids);
+    const option = this.versions().find((v) => v.version === this.selectedVersion());
+    if (ids.length === 0 || !option) return;
+    this.install.emit({ clusterIds: ids, version: option.version, hash: option.hash });
     this.selected.set(new Set());
   }
 
@@ -120,6 +164,8 @@ export default class InstallPluginModalComponent {
   }
 
   onRetry(clusterId: string): void {
-    this.retry.emit(clusterId);
+    const option = this.versions().find((v) => v.version === this.selectedVersion());
+    if (!option) return;
+    this.retry.emit({ clusterId, version: option.version, hash: option.hash });
   }
 }

--- a/console-frontend/src/app/install-plugin-modal/install-plugin-modal.ts
+++ b/console-frontend/src/app/install-plugin-modal/install-plugin-modal.ts
@@ -10,6 +10,7 @@ import {
   ElementRef,
 } from '@angular/core';
 import DialogSyncDirective from '../dialog-sync.directive';
+import DropdownSyncDirective from '../dropdown-sync.directive';
 import focusFirstModalInput from '../modal-focus';
 import { LoadingIndicatorComponent } from '../icons';
 import {
@@ -50,7 +51,7 @@ export interface RetrySelection {
 
 @Component({
   selector: 'app-install-plugin-modal',
-  imports: [DialogSyncDirective, LoadingIndicatorComponent],
+  imports: [DialogSyncDirective, DropdownSyncDirective, LoadingIndicatorComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './install-plugin-modal.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -65,6 +66,11 @@ export default class InstallPluginModalComponent {
   // Published versions to choose from, latest first. Empty means nothing is
   // published yet — the plugin cannot be installed.
   versions = input<PluginVersionOption[]>([]);
+
+  // True when fetching the versions failed (as opposed to succeeding with an
+  // empty list). Lets the modal distinguish a transient error from "nothing
+  // published yet" so it doesn't send the user chasing a publishing problem.
+  versionsError = input(false);
 
   show = input(false);
 

--- a/console-frontend/src/app/plugin-details/plugin-details.component.html
+++ b/console-frontend/src/app/plugin-details/plugin-details.component.html
@@ -215,6 +215,7 @@
 <app-install-plugin-modal
   [pluginDisplayName]="plugin()?.displayName || plugin()?.name || ''"
   [clusters]="clusters()"
+  [versions]="installVersions()"
   [show]="showInstallModal()"
   (closeModal)="closeInstallModal()"
   (install)="onInstallOnClusters($event)"

--- a/console-frontend/src/app/plugin-details/plugin-details.component.html
+++ b/console-frontend/src/app/plugin-details/plugin-details.component.html
@@ -216,6 +216,7 @@
   [pluginDisplayName]="plugin()?.displayName || plugin()?.name || ''"
   [clusters]="clusters()"
   [versions]="installVersions()"
+  [versionsError]="installVersionsError()"
   [show]="showInstallModal()"
   (closeModal)="closeInstallModal()"
   (install)="onInstallOnClusters($event)"

--- a/console-frontend/src/app/plugin-details/plugin-details.component.ts
+++ b/console-frontend/src/app/plugin-details/plugin-details.component.ts
@@ -13,10 +13,18 @@ import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
 import { createIdempotencyRef } from '../../connect/idempotency';
 import { TitleService } from '../title.service';
-import InstallPluginModalComponent from '../install-plugin-modal/install-plugin-modal';
+import InstallPluginModalComponent, {
+  type PluginVersionOption,
+  type InstallSelection,
+  type RetrySelection,
+} from '../install-plugin-modal/install-plugin-modal';
 import { LoadingIndicatorComponent } from '../icons';
 import { PLUGIN, CLUSTER } from '../../connect/tokens';
-import { GetPluginDetailRequestSchema, type PluginDetail } from '../../generated/v1/plugin_pb';
+import {
+  GetPluginDetailRequestSchema,
+  ListPluginDefinitionsRequestSchema,
+  type PluginDetail,
+} from '../../generated/v1/plugin_pb';
 import {
   ListClustersRequestSchema,
   type ListClustersResponse_ClusterSummary as ClusterSummary,
@@ -71,6 +79,9 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
   plugin = signal<PluginDetail | null>(null);
 
   clusters = signal<ClusterWithState[]>([]);
+
+  // Published versions of this plugin, offered in the install modal.
+  installVersions = signal<PluginVersionOption[]>([]);
 
   isLoading = signal<boolean>(true);
 
@@ -153,8 +164,26 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
     return this.sanitizer.sanitize(1, html) || '';
   }
 
-  openInstallModal(): void {
+  async openInstallModal(): Promise<void> {
+    const plugin = this.plugin();
+    this.installVersions.set(plugin ? await this.fetchPluginVersions(plugin.id) : []);
     this.showInstallModal.set(true);
+  }
+
+  // Fetches the plugin's published versions (latest first) for the install
+  // modal's version picker; returns [] on failure so the modal shows its
+  // "no published version" state rather than breaking.
+  private async fetchPluginVersions(pluginId: string): Promise<PluginVersionOption[]> {
+    try {
+      const resp = await firstValueFrom(
+        this.pluginClient.listPluginDefinitions(
+          create(ListPluginDefinitionsRequestSchema, { pluginId }),
+        ),
+      );
+      return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
+    } catch {
+      return [];
+    }
   }
 
   closeInstallModal(): void {
@@ -241,11 +270,11 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async onInstallOnClusters(clusterIds: string[]): Promise<void> {
+  async onInstallOnClusters(selection: InstallSelection): Promise<void> {
     const plugin = this.plugin();
     if (!plugin) return;
 
-    const targets = clusterIds.filter(
+    const targets = selection.clusterIds.filter(
       (id) => this.clusters().find((c) => c.id === id)?.phase === null,
     );
     if (targets.length === 0) return;
@@ -257,8 +286,8 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
         this.pluginInstallationService.installPlugin(
           id,
           plugin.name,
-          plugin.pluginVersion,
-          plugin.definitionHash,
+          selection.version,
+          selection.hash,
         ),
       ),
     );
@@ -289,10 +318,11 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async onRetryInstall(clusterId: string): Promise<void> {
+  async onRetryInstall(retry: RetrySelection): Promise<void> {
     const plugin = this.plugin();
     if (!plugin) return;
 
+    const clusterId = retry.clusterId;
     this.setPhase(clusterId, 'Pending');
     try {
       await this.pluginInstallationService.uninstallPlugin(clusterId, plugin.name).catch(() => {});
@@ -300,8 +330,8 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
       await this.pluginInstallationService.installPlugin(
         clusterId,
         plugin.name,
-        plugin.pluginVersion,
-        plugin.definitionHash,
+        retry.version,
+        retry.hash,
       );
       this.startInstallPollingIfNeeded();
     } catch {

--- a/console-frontend/src/app/plugin-details/plugin-details.component.ts
+++ b/console-frontend/src/app/plugin-details/plugin-details.component.ts
@@ -83,6 +83,10 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
   // Published versions of this plugin, offered in the install modal.
   installVersions = signal<PluginVersionOption[]>([]);
 
+  // True when fetching the versions failed, so the modal can show an error
+  // state instead of the "no published version" notice.
+  installVersionsError = signal(false);
+
   isLoading = signal<boolean>(true);
 
   errorMessage = signal<string | null>(null);
@@ -166,28 +170,37 @@ export default class PluginDetailsComponent implements OnInit, OnDestroy {
 
   async openInstallModal(): Promise<void> {
     const plugin = this.plugin();
-    this.installVersions.set(plugin ? await this.fetchPluginVersions(plugin.id) : []);
+    this.installVersionsError.set(false);
+    if (!plugin) {
+      this.installVersions.set([]);
+      this.showInstallModal.set(true);
+      return;
+    }
+    try {
+      this.installVersions.set(await this.fetchPluginVersions(plugin.id));
+    } catch {
+      this.installVersions.set([]);
+      this.installVersionsError.set(true);
+    }
     this.showInstallModal.set(true);
   }
 
   // Fetches the plugin's published versions (latest first) for the install
-  // modal's version picker; returns [] on failure so the modal shows its
-  // "no published version" state rather than breaking.
+  // modal's version picker. Throws on failure so the caller can tell a fetch
+  // error apart from a plugin that simply has nothing published yet.
   private async fetchPluginVersions(pluginId: string): Promise<PluginVersionOption[]> {
-    try {
-      const resp = await firstValueFrom(
-        this.pluginClient.listPluginDefinitions(
-          create(ListPluginDefinitionsRequestSchema, { pluginId }),
-        ),
-      );
-      return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
-    } catch {
-      return [];
-    }
+    const resp = await firstValueFrom(
+      this.pluginClient.listPluginDefinitions(
+        create(ListPluginDefinitionsRequestSchema, { pluginId }),
+      ),
+    );
+    return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
   }
 
   closeInstallModal(): void {
     this.showInstallModal.set(false);
+    this.installVersions.set([]);
+    this.installVersionsError.set(false);
   }
 
   ngOnDestroy() {

--- a/console-frontend/src/app/plugins/plugins.component.html
+++ b/console-frontend/src/app/plugins/plugins.component.html
@@ -173,6 +173,7 @@
 <app-install-plugin-modal
   [pluginDisplayName]="selectedPlugin?.displayName || selectedPlugin?.name || ''"
   [clusters]="clustersForModal"
+  [versions]="installVersions()"
   [show]="showInstallModal()"
   (closeModal)="closeInstallModal()"
   (install)="onInstallOnClusters($event)"

--- a/console-frontend/src/app/plugins/plugins.component.html
+++ b/console-frontend/src/app/plugins/plugins.component.html
@@ -174,6 +174,7 @@
   [pluginDisplayName]="selectedPlugin?.displayName || selectedPlugin?.name || ''"
   [clusters]="clustersForModal"
   [versions]="installVersions()"
+  [versionsError]="installVersionsError()"
   [show]="showInstallModal()"
   (closeModal)="closeInstallModal()"
   (install)="onInstallOnClusters($event)"

--- a/console-frontend/src/app/plugins/plugins.component.ts
+++ b/console-frontend/src/app/plugins/plugins.component.ts
@@ -11,13 +11,18 @@ import { RouterLink } from '@angular/router';
 import { create } from '@bufbuild/protobuf';
 import { firstValueFrom } from 'rxjs';
 import { TitleService } from '../title.service';
-import InstallPluginModalComponent from '../install-plugin-modal/install-plugin-modal';
+import InstallPluginModalComponent, {
+  type PluginVersionOption,
+  type InstallSelection,
+  type RetrySelection,
+} from '../install-plugin-modal/install-plugin-modal';
 import { LoadingIndicatorComponent } from '../icons';
 import { OrganizationDataService } from '../organization-data.service';
 import { PLUGIN, CLUSTER } from '../../connect/tokens';
 import {
   ListPluginsRequestSchema,
   ListPresetsRequestSchema,
+  ListPluginDefinitionsRequestSchema,
   type Category,
   type Preset,
   type PluginSummary,
@@ -116,6 +121,9 @@ export default class PluginsComponent implements OnInit, OnDestroy {
   showInstallModal = signal(false);
 
   selectedPlugin: PluginWithPresets | null = null;
+
+  // Published versions of the selected plugin, offered in the install modal.
+  installVersions = signal<PluginVersionOption[]>([]);
 
   isLoading = signal(true);
 
@@ -486,9 +494,26 @@ export default class PluginsComponent implements OnInit, OnDestroy {
     return this.clusters().length;
   }
 
-  onInstallPlugin(plugin: PluginWithPresets) {
+  async onInstallPlugin(plugin: PluginWithPresets) {
     this.selectedPlugin = plugin;
+    this.installVersions.set(await this.fetchPluginVersions(plugin.id));
     this.showInstallModal.set(true);
+  }
+
+  // Fetches the plugin's published versions (latest first) for the install
+  // modal's version picker; returns [] on failure so the modal shows the
+  // "no published version" state rather than breaking.
+  private async fetchPluginVersions(pluginId: string): Promise<PluginVersionOption[]> {
+    try {
+      const resp = await firstValueFrom(
+        this.pluginClient.listPluginDefinitions(
+          create(ListPluginDefinitionsRequestSchema, { pluginId }),
+        ),
+      );
+      return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
+    } catch {
+      return [];
+    }
   }
 
   closeInstallModal(): void {
@@ -525,11 +550,11 @@ export default class PluginsComponent implements OnInit, OnDestroy {
     );
   }
 
-  async onInstallOnClusters(clusterIds: string[]): Promise<void> {
+  async onInstallOnClusters(selection: InstallSelection): Promise<void> {
     const plugin = this.selectedPlugin;
     if (!plugin) return;
 
-    const targets = clusterIds.filter(
+    const targets = selection.clusterIds.filter(
       (id) => !this.installs().some((i) => i.clusterId === id && i.pluginName === plugin.name),
     );
     if (targets.length === 0) return;
@@ -550,8 +575,8 @@ export default class PluginsComponent implements OnInit, OnDestroy {
         this.pluginInstallationService.installPlugin(
           clusterId,
           plugin.name,
-          plugin.pluginVersion,
-          plugin.definitionHash,
+          selection.version,
+          selection.hash,
         ),
       ),
     );
@@ -587,10 +612,11 @@ export default class PluginsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async onRetryInstall(clusterId: string): Promise<void> {
+  async onRetryInstall(retry: RetrySelection): Promise<void> {
     const plugin = this.selectedPlugin;
     if (!plugin) return;
 
+    const clusterId = retry.clusterId;
     this.setInstallPhase(clusterId, plugin.name, 'Pending');
     try {
       // The CRD from the failed install still exists, so remove it and wait for
@@ -600,8 +626,8 @@ export default class PluginsComponent implements OnInit, OnDestroy {
       await this.pluginInstallationService.installPlugin(
         clusterId,
         plugin.name,
-        plugin.pluginVersion,
-        plugin.definitionHash,
+        retry.version,
+        retry.hash,
       );
       this.startInstallPollingIfNeeded();
     } catch {

--- a/console-frontend/src/app/plugins/plugins.component.ts
+++ b/console-frontend/src/app/plugins/plugins.component.ts
@@ -125,6 +125,10 @@ export default class PluginsComponent implements OnInit, OnDestroy {
   // Published versions of the selected plugin, offered in the install modal.
   installVersions = signal<PluginVersionOption[]>([]);
 
+  // True when fetching the selected plugin's versions failed, so the modal can
+  // show an error state instead of the "no published version" notice.
+  installVersionsError = signal(false);
+
   isLoading = signal(true);
 
   errorMessage = signal<string | null>(null);
@@ -496,29 +500,38 @@ export default class PluginsComponent implements OnInit, OnDestroy {
 
   async onInstallPlugin(plugin: PluginWithPresets) {
     this.selectedPlugin = plugin;
-    this.installVersions.set(await this.fetchPluginVersions(plugin.id));
+    let versions: PluginVersionOption[] = [];
+    let errored = false;
+    try {
+      versions = await this.fetchPluginVersions(plugin.id);
+    } catch {
+      errored = true;
+    }
+    // Quick clicks (plugin A then B) can resolve out of order; ignore a result
+    // for a plugin the user has since navigated away from.
+    if (this.selectedPlugin !== plugin) return;
+    this.installVersions.set(versions);
+    this.installVersionsError.set(errored);
     this.showInstallModal.set(true);
   }
 
   // Fetches the plugin's published versions (latest first) for the install
-  // modal's version picker; returns [] on failure so the modal shows the
-  // "no published version" state rather than breaking.
+  // modal's version picker. Throws on failure so the caller can tell a fetch
+  // error apart from a plugin that simply has nothing published yet.
   private async fetchPluginVersions(pluginId: string): Promise<PluginVersionOption[]> {
-    try {
-      const resp = await firstValueFrom(
-        this.pluginClient.listPluginDefinitions(
-          create(ListPluginDefinitionsRequestSchema, { pluginId }),
-        ),
-      );
-      return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
-    } catch {
-      return [];
-    }
+    const resp = await firstValueFrom(
+      this.pluginClient.listPluginDefinitions(
+        create(ListPluginDefinitionsRequestSchema, { pluginId }),
+      ),
+    );
+    return resp.definitions.map((d) => ({ version: d.version, hash: d.hash }));
   }
 
   closeInstallModal(): void {
     this.showInstallModal.set(false);
     this.selectedPlugin = null;
+    this.installVersions.set([]);
+    this.installVersionsError.set(false);
   }
 
   private clusterName(clusterId: string): string {

--- a/console-frontend/src/generated/v1/plugin_pb.ts
+++ b/console-frontend/src/generated/v1/plugin_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file v1/plugin.proto.
  */
 export const file_v1_plugin: GenFile = /*@__PURE__*/
-  fileDesc("Cg92MS9wbHVnaW4ucHJvdG8SD29yZ2FuaXphdGlvbi52MSIfCgNUYWcSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCSIkCghDYXRlZ29yeRIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJIoICCg1QbHVnaW5TdW1tYXJ5EgoKAmlkGAogASgJEgwKBG5hbWUYFCABKAkSFAoMZGlzcGxheV9uYW1lGBkgASgJEhMKC2Rlc2NyaXB0aW9uGB4gASgJEhkKEWRlc2NyaXB0aW9uX3Nob3J0GCMgASgJEiIKBHRhZ3MYKCADKAsyFC5vcmdhbml6YXRpb24udjEuVGFnEi0KCmNhdGVnb3JpZXMYMiADKAsyGS5vcmdhbml6YXRpb24udjEuQ2F0ZWdvcnkSDQoFaW1hZ2UYPCABKAkSFgoOcGx1Z2luX3ZlcnNpb24YRiABKAkSFwoPZGVmaW5pdGlvbl9oYXNoGFAgASgJIhQKEkxpc3RQbHVnaW5zUmVxdWVzdCJGChNMaXN0UGx1Z2luc1Jlc3BvbnNlEi8KB3BsdWdpbnMYCiADKAsyHi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3VtbWFyeSJLCgZQcmVzZXQSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRISCgpwbHVnaW5faWRzGCggAygJIhQKEkxpc3RQcmVzZXRzUmVxdWVzdCI/ChNMaXN0UHJlc2V0c1Jlc3BvbnNlEigKB3ByZXNldHMYCiADKAsyFy5vcmdhbml6YXRpb24udjEuUHJlc2V0Ik0KEURvY3VtZW50YXRpb25MaW5rEgoKAmlkGAogASgJEg0KBXRpdGxlGBQgASgJEhAKCHVybF9uYW1lGB4gASgJEgsKA3VybBgoIAEoCSIjCgZBdXRob3ISDAoEbmFtZRgKIAEoCRILCgN1cmwYFCABKAki9AIKDFBsdWdpbkRldGFpbBIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJEhQKDGRpc3BsYXlfbmFtZRgZIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRIZChFkZXNjcmlwdGlvbl9zaG9ydBgjIAEoCRIiCgR0YWdzGCggAygLMhQub3JnYW5pemF0aW9uLnYxLlRhZxItCgpjYXRlZ29yaWVzGDIgAygLMhkub3JnYW5pemF0aW9uLnYxLkNhdGVnb3J5EicKBmF1dGhvchg8IAEoCzIXLm9yZ2FuaXphdGlvbi52MS5BdXRob3ISFgoOcmVwb3NpdG9yeV91cmwYRiABKAkSPwoTZG9jdW1lbnRhdGlvbl9saW5rcxhQIAMoCzIiLm9yZ2FuaXphdGlvbi52MS5Eb2N1bWVudGF0aW9uTGluaxIWCg5wbHVnaW5fdmVyc2lvbhhaIAEoCRIXCg9kZWZpbml0aW9uX2hhc2gYZCABKAkiKwoWR2V0UGx1Z2luRGV0YWlsUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkiSAoXR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USLQoGcGx1Z2luGAogASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRldGFpbCJqChpQdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkSEAoIbWFuaWZlc3QYHiABKAwSDwoHcmVwbGFjZRgoIAEoCCJiChtQdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2USCgoCaWQYCiABKAkSEQoJcGx1Z2luX2lkGBQgASgJEhYKDnBsdWdpbl92ZXJzaW9uGB4gASgJEgwKBGhhc2gYKCABKAkiSQoaR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkidAobR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEhAKCG1hbmlmZXN0GAogASgMEgwKBGhhc2gYFCABKAkSNQoKZGVmaW5pdGlvbhgeIAEoCzIhLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uIvUEChBQbHVnaW5EZWZpbml0aW9uEjsKCG1ldGFkYXRhGAogASgLMikub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb25NZXRhZGF0YRINCgVpbWFnZRgUIAEoCRIZChFpbWFnZV9wdWxsX3BvbGljeRgeIAEoCRI3CgtwZXJtaXNzaW9ucxgoIAEoCzIiLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5QZXJtaXNzaW9ucxIpCgRtZW51GDIgASgLMhsub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnUSDAoEY3Jkcxg8IAMoCRJSChFjdXN0b21fY29tcG9uZW50cxhGIAMoCzI3Lm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uLkN1c3RvbUNvbXBvbmVudHNFbnRyeRJBChFhbGxvd2VkX3Jlc291cmNlcxhQIAMoCzImLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5BbGxvd2VkUmVzb3VyY2USQAoIdWlfaGludHMYWiADKAsyLi5vcmdhbml6YXRpb24udjEuUGx1Z2luRGVmaW5pdGlvbi5VaUhpbnRzRW50cnkaYAoVQ3VzdG9tQ29tcG9uZW50c0VudHJ5EgsKA2tleRgBIAEoCRI2CgV2YWx1ZRgCIAEoCzInLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5Db21wb25lbnRNYXBwaW5nOgI4ARpNCgxVaUhpbnRzRW50cnkSCwoDa2V5GAEgASgJEiwKBXZhbHVlGAIgASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpblVJSGludDoCOAEizAEKGFBsdWdpbkRlZmluaXRpb25NZXRhZGF0YRIMCgRuYW1lGAogASgJEhQKDGRpc3BsYXlfbmFtZRgUIAEoCRIPCgd2ZXJzaW9uGB4gASgJEhMKC2Rlc2NyaXB0aW9uGCggASgJEg4KBmF1dGhvchgyIAEoCRIPCgdsaWNlbnNlGDwgASgJEgwKBGljb24YRiABKAkSKQoEdXJscxhQIAEoCzIbLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5VUkxzEgwKBHRhZ3MYWiADKAkiSQoKUGx1Z2luVVJMcxIQCghob21lcGFnZRgKIAEoCRISCgpyZXBvc2l0b3J5GBQgASgJEhUKDWRvY3VtZW50YXRpb24YHiABKAkiWgoRUGx1Z2luUGVybWlzc2lvbnMSFAoMY2FwYWJpbGl0aWVzGAogAygJEi8KBHJiYWMYFCADKAsyIS5vcmdhbml6YXRpb24udjEuUGx1Z2luUG9saWN5UnVsZSJIChBQbHVnaW5Qb2xpY3lSdWxlEhIKCmFwaV9ncm91cHMYCiADKAkSEQoJcmVzb3VyY2VzGBQgAygJEg0KBXZlcmJzGB4gAygJIncKClBsdWdpbk1lbnUSNgoMb3JnYW5pemF0aW9uGAogAygLMiAub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnVFbnRyeRIxCgdwcm9qZWN0GBQgAygLMiAub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnVFbnRyeSJKCg9QbHVnaW5NZW51RW50cnkSCwoDY3JkGAogASgJEgwKBGxpc3QYFCABKAgSDgoGZGV0YWlsGB4gASgIEgwKBGljb24YKCABKAkiRgoWUGx1Z2luQ29tcG9uZW50TWFwcGluZxIMCgRsaXN0GAogASgJEg4KBmRldGFpbBgUIAEoCRIOCgZjcmVhdGUYHiABKAkiWAoVUGx1Z2luQWxsb3dlZFJlc291cmNlEg0KBWdyb3VwGAogASgJEg8KB3ZlcnNpb24YFCABKAkSEAoIcmVzb3VyY2UYHiABKAkSDQoFdmVyYnMYKCADKAkigwEKDFBsdWdpblVJSGludBI1Cgtmb3JtX2dyb3VwcxgKIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5Gb3JtR3JvdXASPAoOc3RhdHVzX21hcHBpbmcYFCABKAsyJC5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzTWFwcGluZyIvCg9QbHVnaW5Gb3JtR3JvdXASDAoEbmFtZRgKIAEoCRIOCgZmaWVsZHMYFCADKAkivQEKE1BsdWdpblN0YXR1c01hcHBpbmcSEQoJanNvbl9wYXRoGAogASgJEkAKBnZhbHVlcxgUIAMoCzIwLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5TdGF0dXNNYXBwaW5nLlZhbHVlc0VudHJ5GlEKC1ZhbHVlc0VudHJ5EgsKA2tleRgBIAEoCRIxCgV2YWx1ZRgCIAEoCzIiLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5TdGF0dXNWYWx1ZToCOAEiMQoRUGx1Z2luU3RhdHVzVmFsdWUSDQoFYmFkZ2UYCiABKAkSDQoFbGFiZWwYFCABKAkyjQQKDVBsdWdpblNlcnZpY2USWAoLTGlzdFBsdWdpbnMSIy5vcmdhbml6YXRpb24udjEuTGlzdFBsdWdpbnNSZXF1ZXN0GiQub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5zUmVzcG9uc2USZAoPR2V0UGx1Z2luRGV0YWlsEicub3JnYW5pemF0aW9uLnYxLkdldFBsdWdpbkRldGFpbFJlcXVlc3QaKC5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USWAoLTGlzdFByZXNldHMSIy5vcmdhbml6YXRpb24udjEuTGlzdFByZXNldHNSZXF1ZXN0GiQub3JnYW5pemF0aW9uLnYxLkxpc3RQcmVzZXRzUmVzcG9uc2UScAoTUHV0UGx1Z2luRGVmaW5pdGlvbhIrLm9yZ2FuaXphdGlvbi52MS5QdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBosLm9yZ2FuaXphdGlvbi52MS5QdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2UScAoTR2V0UGx1Z2luRGVmaW5pdGlvbhIrLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBosLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2VCX1pTZ2l0aHViLmNvbS9mdW5kYW1lbnQtb3NzL2Z1bmRhbWVudC9vcmdhbml6YXRpb24tYXBpL3BrZy9wcm90by9nZW4vdjE7b3JnYW5pemF0aW9udjGSAwcIAtI+AhADYghlZGl0aW9uc3DoBw", [file_google_protobuf_go_features]);
+  fileDesc("Cg92MS9wbHVnaW4ucHJvdG8SD29yZ2FuaXphdGlvbi52MSIfCgNUYWcSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCSIkCghDYXRlZ29yeRIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJIoICCg1QbHVnaW5TdW1tYXJ5EgoKAmlkGAogASgJEgwKBG5hbWUYFCABKAkSFAoMZGlzcGxheV9uYW1lGBkgASgJEhMKC2Rlc2NyaXB0aW9uGB4gASgJEhkKEWRlc2NyaXB0aW9uX3Nob3J0GCMgASgJEiIKBHRhZ3MYKCADKAsyFC5vcmdhbml6YXRpb24udjEuVGFnEi0KCmNhdGVnb3JpZXMYMiADKAsyGS5vcmdhbml6YXRpb24udjEuQ2F0ZWdvcnkSDQoFaW1hZ2UYPCABKAkSFgoOcGx1Z2luX3ZlcnNpb24YRiABKAkSFwoPZGVmaW5pdGlvbl9oYXNoGFAgASgJIhQKEkxpc3RQbHVnaW5zUmVxdWVzdCJGChNMaXN0UGx1Z2luc1Jlc3BvbnNlEi8KB3BsdWdpbnMYCiADKAsyHi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3VtbWFyeSJLCgZQcmVzZXQSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRISCgpwbHVnaW5faWRzGCggAygJIhQKEkxpc3RQcmVzZXRzUmVxdWVzdCI/ChNMaXN0UHJlc2V0c1Jlc3BvbnNlEigKB3ByZXNldHMYCiADKAsyFy5vcmdhbml6YXRpb24udjEuUHJlc2V0Ik0KEURvY3VtZW50YXRpb25MaW5rEgoKAmlkGAogASgJEg0KBXRpdGxlGBQgASgJEhAKCHVybF9uYW1lGB4gASgJEgsKA3VybBgoIAEoCSIjCgZBdXRob3ISDAoEbmFtZRgKIAEoCRILCgN1cmwYFCABKAki9AIKDFBsdWdpbkRldGFpbBIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJEhQKDGRpc3BsYXlfbmFtZRgZIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRIZChFkZXNjcmlwdGlvbl9zaG9ydBgjIAEoCRIiCgR0YWdzGCggAygLMhQub3JnYW5pemF0aW9uLnYxLlRhZxItCgpjYXRlZ29yaWVzGDIgAygLMhkub3JnYW5pemF0aW9uLnYxLkNhdGVnb3J5EicKBmF1dGhvchg8IAEoCzIXLm9yZ2FuaXphdGlvbi52MS5BdXRob3ISFgoOcmVwb3NpdG9yeV91cmwYRiABKAkSPwoTZG9jdW1lbnRhdGlvbl9saW5rcxhQIAMoCzIiLm9yZ2FuaXphdGlvbi52MS5Eb2N1bWVudGF0aW9uTGluaxIWCg5wbHVnaW5fdmVyc2lvbhhaIAEoCRIXCg9kZWZpbml0aW9uX2hhc2gYZCABKAkiKwoWR2V0UGx1Z2luRGV0YWlsUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkiSAoXR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USLQoGcGx1Z2luGAogASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRldGFpbCJqChpQdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkSEAoIbWFuaWZlc3QYHiABKAwSDwoHcmVwbGFjZRgoIAEoCCJiChtQdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2USCgoCaWQYCiABKAkSEQoJcGx1Z2luX2lkGBQgASgJEhYKDnBsdWdpbl92ZXJzaW9uGB4gASgJEgwKBGhhc2gYKCABKAkiSQoaR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkidAobR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEhAKCG1hbmlmZXN0GAogASgMEgwKBGhhc2gYFCABKAkSNQoKZGVmaW5pdGlvbhgeIAEoCzIhLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uIjEKHExpc3RQbHVnaW5EZWZpbml0aW9uc1JlcXVlc3QSEQoJcGx1Z2luX2lkGAogASgJIl4KHUxpc3RQbHVnaW5EZWZpbml0aW9uc1Jlc3BvbnNlEj0KC2RlZmluaXRpb25zGAogAygLMigub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb25WZXJzaW9uIjgKF1BsdWdpbkRlZmluaXRpb25WZXJzaW9uEg8KB3ZlcnNpb24YCiABKAkSDAoEaGFzaBgUIAEoCSL1BAoQUGx1Z2luRGVmaW5pdGlvbhI7CghtZXRhZGF0YRgKIAEoCzIpLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uTWV0YWRhdGESDQoFaW1hZ2UYFCABKAkSGQoRaW1hZ2VfcHVsbF9wb2xpY3kYHiABKAkSNwoLcGVybWlzc2lvbnMYKCABKAsyIi5vcmdhbml6YXRpb24udjEuUGx1Z2luUGVybWlzc2lvbnMSKQoEbWVudRgyIAEoCzIbLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51EgwKBGNyZHMYPCADKAkSUgoRY3VzdG9tX2NvbXBvbmVudHMYRiADKAsyNy5vcmdhbml6YXRpb24udjEuUGx1Z2luRGVmaW5pdGlvbi5DdXN0b21Db21wb25lbnRzRW50cnkSQQoRYWxsb3dlZF9yZXNvdXJjZXMYUCADKAsyJi5vcmdhbml6YXRpb24udjEuUGx1Z2luQWxsb3dlZFJlc291cmNlEkAKCHVpX2hpbnRzGFogAygLMi4ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb24uVWlIaW50c0VudHJ5GmAKFUN1c3RvbUNvbXBvbmVudHNFbnRyeRILCgNrZXkYASABKAkSNgoFdmFsdWUYAiABKAsyJy5vcmdhbml6YXRpb24udjEuUGx1Z2luQ29tcG9uZW50TWFwcGluZzoCOAEaTQoMVWlIaW50c0VudHJ5EgsKA2tleRgBIAEoCRIsCgV2YWx1ZRgCIAEoCzIdLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5VSUhpbnQ6AjgBIswBChhQbHVnaW5EZWZpbml0aW9uTWV0YWRhdGESDAoEbmFtZRgKIAEoCRIUCgxkaXNwbGF5X25hbWUYFCABKAkSDwoHdmVyc2lvbhgeIAEoCRITCgtkZXNjcmlwdGlvbhgoIAEoCRIOCgZhdXRob3IYMiABKAkSDwoHbGljZW5zZRg8IAEoCRIMCgRpY29uGEYgASgJEikKBHVybHMYUCABKAsyGy5vcmdhbml6YXRpb24udjEuUGx1Z2luVVJMcxIMCgR0YWdzGFogAygJIkkKClBsdWdpblVSTHMSEAoIaG9tZXBhZ2UYCiABKAkSEgoKcmVwb3NpdG9yeRgUIAEoCRIVCg1kb2N1bWVudGF0aW9uGB4gASgJIloKEVBsdWdpblBlcm1pc3Npb25zEhQKDGNhcGFiaWxpdGllcxgKIAMoCRIvCgRyYmFjGBQgAygLMiEub3JnYW5pemF0aW9uLnYxLlBsdWdpblBvbGljeVJ1bGUiSAoQUGx1Z2luUG9saWN5UnVsZRISCgphcGlfZ3JvdXBzGAogAygJEhEKCXJlc291cmNlcxgUIAMoCRINCgV2ZXJicxgeIAMoCSJ3CgpQbHVnaW5NZW51EjYKDG9yZ2FuaXphdGlvbhgKIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51RW50cnkSMQoHcHJvamVjdBgUIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51RW50cnkiSgoPUGx1Z2luTWVudUVudHJ5EgsKA2NyZBgKIAEoCRIMCgRsaXN0GBQgASgIEg4KBmRldGFpbBgeIAEoCBIMCgRpY29uGCggASgJIkYKFlBsdWdpbkNvbXBvbmVudE1hcHBpbmcSDAoEbGlzdBgKIAEoCRIOCgZkZXRhaWwYFCABKAkSDgoGY3JlYXRlGB4gASgJIlgKFVBsdWdpbkFsbG93ZWRSZXNvdXJjZRINCgVncm91cBgKIAEoCRIPCgd2ZXJzaW9uGBQgASgJEhAKCHJlc291cmNlGB4gASgJEg0KBXZlcmJzGCggAygJIoMBCgxQbHVnaW5VSUhpbnQSNQoLZm9ybV9ncm91cHMYCiADKAsyIC5vcmdhbml6YXRpb24udjEuUGx1Z2luRm9ybUdyb3VwEjwKDnN0YXR1c19tYXBwaW5nGBQgASgLMiQub3JnYW5pemF0aW9uLnYxLlBsdWdpblN0YXR1c01hcHBpbmciLwoPUGx1Z2luRm9ybUdyb3VwEgwKBG5hbWUYCiABKAkSDgoGZmllbGRzGBQgAygJIr0BChNQbHVnaW5TdGF0dXNNYXBwaW5nEhEKCWpzb25fcGF0aBgKIAEoCRJACgZ2YWx1ZXMYFCADKAsyMC5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzTWFwcGluZy5WYWx1ZXNFbnRyeRpRCgtWYWx1ZXNFbnRyeRILCgNrZXkYASABKAkSMQoFdmFsdWUYAiABKAsyIi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzVmFsdWU6AjgBIjEKEVBsdWdpblN0YXR1c1ZhbHVlEg0KBWJhZGdlGAogASgJEg0KBWxhYmVsGBQgASgJMoUFCg1QbHVnaW5TZXJ2aWNlElgKC0xpc3RQbHVnaW5zEiMub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5zUmVxdWVzdBokLm9yZ2FuaXphdGlvbi52MS5MaXN0UGx1Z2luc1Jlc3BvbnNlEmQKD0dldFBsdWdpbkRldGFpbBInLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZXRhaWxSZXF1ZXN0Gigub3JnYW5pemF0aW9uLnYxLkdldFBsdWdpbkRldGFpbFJlc3BvbnNlElgKC0xpc3RQcmVzZXRzEiMub3JnYW5pemF0aW9uLnYxLkxpc3RQcmVzZXRzUmVxdWVzdBokLm9yZ2FuaXphdGlvbi52MS5MaXN0UHJlc2V0c1Jlc3BvbnNlEnYKFUxpc3RQbHVnaW5EZWZpbml0aW9ucxItLm9yZ2FuaXphdGlvbi52MS5MaXN0UGx1Z2luRGVmaW5pdGlvbnNSZXF1ZXN0Gi4ub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5EZWZpbml0aW9uc1Jlc3BvbnNlEnAKE1B1dFBsdWdpbkRlZmluaXRpb24SKy5vcmdhbml6YXRpb24udjEuUHV0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QaLC5vcmdhbml6YXRpb24udjEuUHV0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEnAKE0dldFBsdWdpbkRlZmluaXRpb24SKy5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QaLC5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlQl9aU2dpdGh1Yi5jb20vZnVuZGFtZW50LW9zcy9mdW5kYW1lbnQvb3JnYW5pemF0aW9uLWFwaS9wa2cvcHJvdG8vZ2VuL3YxO29yZ2FuaXphdGlvbnYxkgMHCALSPgIQA2IIZWRpdGlvbnNw6Ac", [file_google_protobuf_go_features]);
 
 /**
  * Tag information
@@ -533,6 +533,65 @@ export const GetPluginDefinitionResponseSchema: GenMessage<GetPluginDefinitionRe
   messageDesc(file_v1_plugin, 16);
 
 /**
+ * @generated from message organization.v1.ListPluginDefinitionsRequest
+ */
+export type ListPluginDefinitionsRequest = Message<"organization.v1.ListPluginDefinitionsRequest"> & {
+  /**
+   * @generated from field: string plugin_id = 10;
+   */
+  pluginId: string;
+};
+
+/**
+ * Describes the message organization.v1.ListPluginDefinitionsRequest.
+ * Use `create(ListPluginDefinitionsRequestSchema)` to create a new message.
+ */
+export const ListPluginDefinitionsRequestSchema: GenMessage<ListPluginDefinitionsRequest> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 17);
+
+/**
+ * @generated from message organization.v1.ListPluginDefinitionsResponse
+ */
+export type ListPluginDefinitionsResponse = Message<"organization.v1.ListPluginDefinitionsResponse"> & {
+  /**
+   * @generated from field: repeated organization.v1.PluginDefinitionVersion definitions = 10;
+   */
+  definitions: PluginDefinitionVersion[];
+};
+
+/**
+ * Describes the message organization.v1.ListPluginDefinitionsResponse.
+ * Use `create(ListPluginDefinitionsResponseSchema)` to create a new message.
+ */
+export const ListPluginDefinitionsResponseSchema: GenMessage<ListPluginDefinitionsResponse> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 18);
+
+/**
+ * A published definition's pin: the version an install references and the
+ * sha256 hash of that manifest.
+ *
+ * @generated from message organization.v1.PluginDefinitionVersion
+ */
+export type PluginDefinitionVersion = Message<"organization.v1.PluginDefinitionVersion"> & {
+  /**
+   * @generated from field: string version = 10;
+   */
+  version: string;
+
+  /**
+   * @generated from field: string hash = 20;
+   */
+  hash: string;
+};
+
+/**
+ * Describes the message organization.v1.PluginDefinitionVersion.
+ * Use `create(PluginDefinitionVersionSchema)` to create a new message.
+ */
+export const PluginDefinitionVersionSchema: GenMessage<PluginDefinitionVersion> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 19);
+
+/**
  * @generated from message organization.v1.PluginDefinition
  */
 export type PluginDefinition = Message<"organization.v1.PluginDefinition"> & {
@@ -587,7 +646,7 @@ export type PluginDefinition = Message<"organization.v1.PluginDefinition"> & {
  * Use `create(PluginDefinitionSchema)` to create a new message.
  */
 export const PluginDefinitionSchema: GenMessage<PluginDefinition> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 17);
+  messageDesc(file_v1_plugin, 20);
 
 /**
  * @generated from message organization.v1.PluginDefinitionMetadata
@@ -644,7 +703,7 @@ export type PluginDefinitionMetadata = Message<"organization.v1.PluginDefinition
  * Use `create(PluginDefinitionMetadataSchema)` to create a new message.
  */
 export const PluginDefinitionMetadataSchema: GenMessage<PluginDefinitionMetadata> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 18);
+  messageDesc(file_v1_plugin, 21);
 
 /**
  * @generated from message organization.v1.PluginURLs
@@ -671,7 +730,7 @@ export type PluginURLs = Message<"organization.v1.PluginURLs"> & {
  * Use `create(PluginURLsSchema)` to create a new message.
  */
 export const PluginURLsSchema: GenMessage<PluginURLs> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 19);
+  messageDesc(file_v1_plugin, 22);
 
 /**
  * @generated from message organization.v1.PluginPermissions
@@ -693,7 +752,7 @@ export type PluginPermissions = Message<"organization.v1.PluginPermissions"> & {
  * Use `create(PluginPermissionsSchema)` to create a new message.
  */
 export const PluginPermissionsSchema: GenMessage<PluginPermissions> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 20);
+  messageDesc(file_v1_plugin, 23);
 
 /**
  * @generated from message organization.v1.PluginPolicyRule
@@ -720,7 +779,7 @@ export type PluginPolicyRule = Message<"organization.v1.PluginPolicyRule"> & {
  * Use `create(PluginPolicyRuleSchema)` to create a new message.
  */
 export const PluginPolicyRuleSchema: GenMessage<PluginPolicyRule> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 21);
+  messageDesc(file_v1_plugin, 24);
 
 /**
  * @generated from message organization.v1.PluginMenu
@@ -742,7 +801,7 @@ export type PluginMenu = Message<"organization.v1.PluginMenu"> & {
  * Use `create(PluginMenuSchema)` to create a new message.
  */
 export const PluginMenuSchema: GenMessage<PluginMenu> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 22);
+  messageDesc(file_v1_plugin, 25);
 
 /**
  * @generated from message organization.v1.PluginMenuEntry
@@ -774,7 +833,7 @@ export type PluginMenuEntry = Message<"organization.v1.PluginMenuEntry"> & {
  * Use `create(PluginMenuEntrySchema)` to create a new message.
  */
 export const PluginMenuEntrySchema: GenMessage<PluginMenuEntry> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 23);
+  messageDesc(file_v1_plugin, 26);
 
 /**
  * @generated from message organization.v1.PluginComponentMapping
@@ -801,7 +860,7 @@ export type PluginComponentMapping = Message<"organization.v1.PluginComponentMap
  * Use `create(PluginComponentMappingSchema)` to create a new message.
  */
 export const PluginComponentMappingSchema: GenMessage<PluginComponentMapping> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 24);
+  messageDesc(file_v1_plugin, 27);
 
 /**
  * @generated from message organization.v1.PluginAllowedResource
@@ -833,7 +892,7 @@ export type PluginAllowedResource = Message<"organization.v1.PluginAllowedResour
  * Use `create(PluginAllowedResourceSchema)` to create a new message.
  */
 export const PluginAllowedResourceSchema: GenMessage<PluginAllowedResource> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 25);
+  messageDesc(file_v1_plugin, 28);
 
 /**
  * @generated from message organization.v1.PluginUIHint
@@ -855,7 +914,7 @@ export type PluginUIHint = Message<"organization.v1.PluginUIHint"> & {
  * Use `create(PluginUIHintSchema)` to create a new message.
  */
 export const PluginUIHintSchema: GenMessage<PluginUIHint> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 26);
+  messageDesc(file_v1_plugin, 29);
 
 /**
  * @generated from message organization.v1.PluginFormGroup
@@ -877,7 +936,7 @@ export type PluginFormGroup = Message<"organization.v1.PluginFormGroup"> & {
  * Use `create(PluginFormGroupSchema)` to create a new message.
  */
 export const PluginFormGroupSchema: GenMessage<PluginFormGroup> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 27);
+  messageDesc(file_v1_plugin, 30);
 
 /**
  * @generated from message organization.v1.PluginStatusMapping
@@ -899,7 +958,7 @@ export type PluginStatusMapping = Message<"organization.v1.PluginStatusMapping">
  * Use `create(PluginStatusMappingSchema)` to create a new message.
  */
 export const PluginStatusMappingSchema: GenMessage<PluginStatusMapping> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 28);
+  messageDesc(file_v1_plugin, 31);
 
 /**
  * @generated from message organization.v1.PluginStatusValue
@@ -921,7 +980,7 @@ export type PluginStatusValue = Message<"organization.v1.PluginStatusValue"> & {
  * Use `create(PluginStatusValueSchema)` to create a new message.
  */
 export const PluginStatusValueSchema: GenMessage<PluginStatusValue> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 29);
+  messageDesc(file_v1_plugin, 32);
 
 /**
  * PluginService provides information about available plugins and presets
@@ -958,6 +1017,17 @@ export const PluginService: GenService<{
     methodKind: "unary";
     input: typeof ListPresetsRequestSchema;
     output: typeof ListPresetsResponseSchema;
+  },
+  /**
+   * List the published definitions (version + hash) for a plugin, latest first.
+   * Used by the console to offer a version to pin on install.
+   *
+   * @generated from rpc organization.v1.PluginService.ListPluginDefinitions
+   */
+  listPluginDefinitions: {
+    methodKind: "unary";
+    input: typeof ListPluginDefinitionsRequestSchema;
+    output: typeof ListPluginDefinitionsResponseSchema;
   },
   /**
    * Idempotent upsert of a plugin definition. Server computes the hash from the

--- a/e2e/support/generated/v1/plugin_pb.ts
+++ b/e2e/support/generated/v1/plugin_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file v1/plugin.proto.
  */
 export const file_v1_plugin: GenFile = /*@__PURE__*/
-  fileDesc("Cg92MS9wbHVnaW4ucHJvdG8SD29yZ2FuaXphdGlvbi52MSIfCgNUYWcSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCSIkCghDYXRlZ29yeRIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJIoICCg1QbHVnaW5TdW1tYXJ5EgoKAmlkGAogASgJEgwKBG5hbWUYFCABKAkSFAoMZGlzcGxheV9uYW1lGBkgASgJEhMKC2Rlc2NyaXB0aW9uGB4gASgJEhkKEWRlc2NyaXB0aW9uX3Nob3J0GCMgASgJEiIKBHRhZ3MYKCADKAsyFC5vcmdhbml6YXRpb24udjEuVGFnEi0KCmNhdGVnb3JpZXMYMiADKAsyGS5vcmdhbml6YXRpb24udjEuQ2F0ZWdvcnkSDQoFaW1hZ2UYPCABKAkSFgoOcGx1Z2luX3ZlcnNpb24YRiABKAkSFwoPZGVmaW5pdGlvbl9oYXNoGFAgASgJIhQKEkxpc3RQbHVnaW5zUmVxdWVzdCJGChNMaXN0UGx1Z2luc1Jlc3BvbnNlEi8KB3BsdWdpbnMYCiADKAsyHi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3VtbWFyeSJLCgZQcmVzZXQSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRISCgpwbHVnaW5faWRzGCggAygJIhQKEkxpc3RQcmVzZXRzUmVxdWVzdCI/ChNMaXN0UHJlc2V0c1Jlc3BvbnNlEigKB3ByZXNldHMYCiADKAsyFy5vcmdhbml6YXRpb24udjEuUHJlc2V0Ik0KEURvY3VtZW50YXRpb25MaW5rEgoKAmlkGAogASgJEg0KBXRpdGxlGBQgASgJEhAKCHVybF9uYW1lGB4gASgJEgsKA3VybBgoIAEoCSIjCgZBdXRob3ISDAoEbmFtZRgKIAEoCRILCgN1cmwYFCABKAki9AIKDFBsdWdpbkRldGFpbBIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJEhQKDGRpc3BsYXlfbmFtZRgZIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRIZChFkZXNjcmlwdGlvbl9zaG9ydBgjIAEoCRIiCgR0YWdzGCggAygLMhQub3JnYW5pemF0aW9uLnYxLlRhZxItCgpjYXRlZ29yaWVzGDIgAygLMhkub3JnYW5pemF0aW9uLnYxLkNhdGVnb3J5EicKBmF1dGhvchg8IAEoCzIXLm9yZ2FuaXphdGlvbi52MS5BdXRob3ISFgoOcmVwb3NpdG9yeV91cmwYRiABKAkSPwoTZG9jdW1lbnRhdGlvbl9saW5rcxhQIAMoCzIiLm9yZ2FuaXphdGlvbi52MS5Eb2N1bWVudGF0aW9uTGluaxIWCg5wbHVnaW5fdmVyc2lvbhhaIAEoCRIXCg9kZWZpbml0aW9uX2hhc2gYZCABKAkiKwoWR2V0UGx1Z2luRGV0YWlsUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkiSAoXR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USLQoGcGx1Z2luGAogASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRldGFpbCJqChpQdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkSEAoIbWFuaWZlc3QYHiABKAwSDwoHcmVwbGFjZRgoIAEoCCJiChtQdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2USCgoCaWQYCiABKAkSEQoJcGx1Z2luX2lkGBQgASgJEhYKDnBsdWdpbl92ZXJzaW9uGB4gASgJEgwKBGhhc2gYKCABKAkiSQoaR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkidAobR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEhAKCG1hbmlmZXN0GAogASgMEgwKBGhhc2gYFCABKAkSNQoKZGVmaW5pdGlvbhgeIAEoCzIhLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uIvUEChBQbHVnaW5EZWZpbml0aW9uEjsKCG1ldGFkYXRhGAogASgLMikub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb25NZXRhZGF0YRINCgVpbWFnZRgUIAEoCRIZChFpbWFnZV9wdWxsX3BvbGljeRgeIAEoCRI3CgtwZXJtaXNzaW9ucxgoIAEoCzIiLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5QZXJtaXNzaW9ucxIpCgRtZW51GDIgASgLMhsub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnUSDAoEY3Jkcxg8IAMoCRJSChFjdXN0b21fY29tcG9uZW50cxhGIAMoCzI3Lm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uLkN1c3RvbUNvbXBvbmVudHNFbnRyeRJBChFhbGxvd2VkX3Jlc291cmNlcxhQIAMoCzImLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5BbGxvd2VkUmVzb3VyY2USQAoIdWlfaGludHMYWiADKAsyLi5vcmdhbml6YXRpb24udjEuUGx1Z2luRGVmaW5pdGlvbi5VaUhpbnRzRW50cnkaYAoVQ3VzdG9tQ29tcG9uZW50c0VudHJ5EgsKA2tleRgBIAEoCRI2CgV2YWx1ZRgCIAEoCzInLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5Db21wb25lbnRNYXBwaW5nOgI4ARpNCgxVaUhpbnRzRW50cnkSCwoDa2V5GAEgASgJEiwKBXZhbHVlGAIgASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpblVJSGludDoCOAEizAEKGFBsdWdpbkRlZmluaXRpb25NZXRhZGF0YRIMCgRuYW1lGAogASgJEhQKDGRpc3BsYXlfbmFtZRgUIAEoCRIPCgd2ZXJzaW9uGB4gASgJEhMKC2Rlc2NyaXB0aW9uGCggASgJEg4KBmF1dGhvchgyIAEoCRIPCgdsaWNlbnNlGDwgASgJEgwKBGljb24YRiABKAkSKQoEdXJscxhQIAEoCzIbLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5VUkxzEgwKBHRhZ3MYWiADKAkiSQoKUGx1Z2luVVJMcxIQCghob21lcGFnZRgKIAEoCRISCgpyZXBvc2l0b3J5GBQgASgJEhUKDWRvY3VtZW50YXRpb24YHiABKAkiWgoRUGx1Z2luUGVybWlzc2lvbnMSFAoMY2FwYWJpbGl0aWVzGAogAygJEi8KBHJiYWMYFCADKAsyIS5vcmdhbml6YXRpb24udjEuUGx1Z2luUG9saWN5UnVsZSJIChBQbHVnaW5Qb2xpY3lSdWxlEhIKCmFwaV9ncm91cHMYCiADKAkSEQoJcmVzb3VyY2VzGBQgAygJEg0KBXZlcmJzGB4gAygJIncKClBsdWdpbk1lbnUSNgoMb3JnYW5pemF0aW9uGAogAygLMiAub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnVFbnRyeRIxCgdwcm9qZWN0GBQgAygLMiAub3JnYW5pemF0aW9uLnYxLlBsdWdpbk1lbnVFbnRyeSJKCg9QbHVnaW5NZW51RW50cnkSCwoDY3JkGAogASgJEgwKBGxpc3QYFCABKAgSDgoGZGV0YWlsGB4gASgIEgwKBGljb24YKCABKAkiRgoWUGx1Z2luQ29tcG9uZW50TWFwcGluZxIMCgRsaXN0GAogASgJEg4KBmRldGFpbBgUIAEoCRIOCgZjcmVhdGUYHiABKAkiWAoVUGx1Z2luQWxsb3dlZFJlc291cmNlEg0KBWdyb3VwGAogASgJEg8KB3ZlcnNpb24YFCABKAkSEAoIcmVzb3VyY2UYHiABKAkSDQoFdmVyYnMYKCADKAkigwEKDFBsdWdpblVJSGludBI1Cgtmb3JtX2dyb3VwcxgKIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5Gb3JtR3JvdXASPAoOc3RhdHVzX21hcHBpbmcYFCABKAsyJC5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzTWFwcGluZyIvCg9QbHVnaW5Gb3JtR3JvdXASDAoEbmFtZRgKIAEoCRIOCgZmaWVsZHMYFCADKAkivQEKE1BsdWdpblN0YXR1c01hcHBpbmcSEQoJanNvbl9wYXRoGAogASgJEkAKBnZhbHVlcxgUIAMoCzIwLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5TdGF0dXNNYXBwaW5nLlZhbHVlc0VudHJ5GlEKC1ZhbHVlc0VudHJ5EgsKA2tleRgBIAEoCRIxCgV2YWx1ZRgCIAEoCzIiLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5TdGF0dXNWYWx1ZToCOAEiMQoRUGx1Z2luU3RhdHVzVmFsdWUSDQoFYmFkZ2UYCiABKAkSDQoFbGFiZWwYFCABKAkyjQQKDVBsdWdpblNlcnZpY2USWAoLTGlzdFBsdWdpbnMSIy5vcmdhbml6YXRpb24udjEuTGlzdFBsdWdpbnNSZXF1ZXN0GiQub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5zUmVzcG9uc2USZAoPR2V0UGx1Z2luRGV0YWlsEicub3JnYW5pemF0aW9uLnYxLkdldFBsdWdpbkRldGFpbFJlcXVlc3QaKC5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USWAoLTGlzdFByZXNldHMSIy5vcmdhbml6YXRpb24udjEuTGlzdFByZXNldHNSZXF1ZXN0GiQub3JnYW5pemF0aW9uLnYxLkxpc3RQcmVzZXRzUmVzcG9uc2UScAoTUHV0UGx1Z2luRGVmaW5pdGlvbhIrLm9yZ2FuaXphdGlvbi52MS5QdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBosLm9yZ2FuaXphdGlvbi52MS5QdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2UScAoTR2V0UGx1Z2luRGVmaW5pdGlvbhIrLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBosLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2VCX1pTZ2l0aHViLmNvbS9mdW5kYW1lbnQtb3NzL2Z1bmRhbWVudC9vcmdhbml6YXRpb24tYXBpL3BrZy9wcm90by9nZW4vdjE7b3JnYW5pemF0aW9udjGSAwcIAtI+AhADYghlZGl0aW9uc3DoBw", [file_google_protobuf_go_features]);
+  fileDesc("Cg92MS9wbHVnaW4ucHJvdG8SD29yZ2FuaXphdGlvbi52MSIfCgNUYWcSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCSIkCghDYXRlZ29yeRIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJIoICCg1QbHVnaW5TdW1tYXJ5EgoKAmlkGAogASgJEgwKBG5hbWUYFCABKAkSFAoMZGlzcGxheV9uYW1lGBkgASgJEhMKC2Rlc2NyaXB0aW9uGB4gASgJEhkKEWRlc2NyaXB0aW9uX3Nob3J0GCMgASgJEiIKBHRhZ3MYKCADKAsyFC5vcmdhbml6YXRpb24udjEuVGFnEi0KCmNhdGVnb3JpZXMYMiADKAsyGS5vcmdhbml6YXRpb24udjEuQ2F0ZWdvcnkSDQoFaW1hZ2UYPCABKAkSFgoOcGx1Z2luX3ZlcnNpb24YRiABKAkSFwoPZGVmaW5pdGlvbl9oYXNoGFAgASgJIhQKEkxpc3RQbHVnaW5zUmVxdWVzdCJGChNMaXN0UGx1Z2luc1Jlc3BvbnNlEi8KB3BsdWdpbnMYCiADKAsyHi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3VtbWFyeSJLCgZQcmVzZXQSCgoCaWQYCiABKAkSDAoEbmFtZRgUIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRISCgpwbHVnaW5faWRzGCggAygJIhQKEkxpc3RQcmVzZXRzUmVxdWVzdCI/ChNMaXN0UHJlc2V0c1Jlc3BvbnNlEigKB3ByZXNldHMYCiADKAsyFy5vcmdhbml6YXRpb24udjEuUHJlc2V0Ik0KEURvY3VtZW50YXRpb25MaW5rEgoKAmlkGAogASgJEg0KBXRpdGxlGBQgASgJEhAKCHVybF9uYW1lGB4gASgJEgsKA3VybBgoIAEoCSIjCgZBdXRob3ISDAoEbmFtZRgKIAEoCRILCgN1cmwYFCABKAki9AIKDFBsdWdpbkRldGFpbBIKCgJpZBgKIAEoCRIMCgRuYW1lGBQgASgJEhQKDGRpc3BsYXlfbmFtZRgZIAEoCRITCgtkZXNjcmlwdGlvbhgeIAEoCRIZChFkZXNjcmlwdGlvbl9zaG9ydBgjIAEoCRIiCgR0YWdzGCggAygLMhQub3JnYW5pemF0aW9uLnYxLlRhZxItCgpjYXRlZ29yaWVzGDIgAygLMhkub3JnYW5pemF0aW9uLnYxLkNhdGVnb3J5EicKBmF1dGhvchg8IAEoCzIXLm9yZ2FuaXphdGlvbi52MS5BdXRob3ISFgoOcmVwb3NpdG9yeV91cmwYRiABKAkSPwoTZG9jdW1lbnRhdGlvbl9saW5rcxhQIAMoCzIiLm9yZ2FuaXphdGlvbi52MS5Eb2N1bWVudGF0aW9uTGluaxIWCg5wbHVnaW5fdmVyc2lvbhhaIAEoCRIXCg9kZWZpbml0aW9uX2hhc2gYZCABKAkiKwoWR2V0UGx1Z2luRGV0YWlsUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkiSAoXR2V0UGx1Z2luRGV0YWlsUmVzcG9uc2USLQoGcGx1Z2luGAogASgLMh0ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRldGFpbCJqChpQdXRQbHVnaW5EZWZpbml0aW9uUmVxdWVzdBIRCglwbHVnaW5faWQYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkSEAoIbWFuaWZlc3QYHiABKAwSDwoHcmVwbGFjZRgoIAEoCCJiChtQdXRQbHVnaW5EZWZpbml0aW9uUmVzcG9uc2USCgoCaWQYCiABKAkSEQoJcGx1Z2luX2lkGBQgASgJEhYKDnBsdWdpbl92ZXJzaW9uGB4gASgJEgwKBGhhc2gYKCABKAkiSQoaR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYCiABKAkSFgoOcGx1Z2luX3ZlcnNpb24YFCABKAkidAobR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEhAKCG1hbmlmZXN0GAogASgMEgwKBGhhc2gYFCABKAkSNQoKZGVmaW5pdGlvbhgeIAEoCzIhLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uIjEKHExpc3RQbHVnaW5EZWZpbml0aW9uc1JlcXVlc3QSEQoJcGx1Z2luX2lkGAogASgJIl4KHUxpc3RQbHVnaW5EZWZpbml0aW9uc1Jlc3BvbnNlEj0KC2RlZmluaXRpb25zGAogAygLMigub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb25WZXJzaW9uIjgKF1BsdWdpbkRlZmluaXRpb25WZXJzaW9uEg8KB3ZlcnNpb24YCiABKAkSDAoEaGFzaBgUIAEoCSL1BAoQUGx1Z2luRGVmaW5pdGlvbhI7CghtZXRhZGF0YRgKIAEoCzIpLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5EZWZpbml0aW9uTWV0YWRhdGESDQoFaW1hZ2UYFCABKAkSGQoRaW1hZ2VfcHVsbF9wb2xpY3kYHiABKAkSNwoLcGVybWlzc2lvbnMYKCABKAsyIi5vcmdhbml6YXRpb24udjEuUGx1Z2luUGVybWlzc2lvbnMSKQoEbWVudRgyIAEoCzIbLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51EgwKBGNyZHMYPCADKAkSUgoRY3VzdG9tX2NvbXBvbmVudHMYRiADKAsyNy5vcmdhbml6YXRpb24udjEuUGx1Z2luRGVmaW5pdGlvbi5DdXN0b21Db21wb25lbnRzRW50cnkSQQoRYWxsb3dlZF9yZXNvdXJjZXMYUCADKAsyJi5vcmdhbml6YXRpb24udjEuUGx1Z2luQWxsb3dlZFJlc291cmNlEkAKCHVpX2hpbnRzGFogAygLMi4ub3JnYW5pemF0aW9uLnYxLlBsdWdpbkRlZmluaXRpb24uVWlIaW50c0VudHJ5GmAKFUN1c3RvbUNvbXBvbmVudHNFbnRyeRILCgNrZXkYASABKAkSNgoFdmFsdWUYAiABKAsyJy5vcmdhbml6YXRpb24udjEuUGx1Z2luQ29tcG9uZW50TWFwcGluZzoCOAEaTQoMVWlIaW50c0VudHJ5EgsKA2tleRgBIAEoCRIsCgV2YWx1ZRgCIAEoCzIdLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5VSUhpbnQ6AjgBIswBChhQbHVnaW5EZWZpbml0aW9uTWV0YWRhdGESDAoEbmFtZRgKIAEoCRIUCgxkaXNwbGF5X25hbWUYFCABKAkSDwoHdmVyc2lvbhgeIAEoCRITCgtkZXNjcmlwdGlvbhgoIAEoCRIOCgZhdXRob3IYMiABKAkSDwoHbGljZW5zZRg8IAEoCRIMCgRpY29uGEYgASgJEikKBHVybHMYUCABKAsyGy5vcmdhbml6YXRpb24udjEuUGx1Z2luVVJMcxIMCgR0YWdzGFogAygJIkkKClBsdWdpblVSTHMSEAoIaG9tZXBhZ2UYCiABKAkSEgoKcmVwb3NpdG9yeRgUIAEoCRIVCg1kb2N1bWVudGF0aW9uGB4gASgJIloKEVBsdWdpblBlcm1pc3Npb25zEhQKDGNhcGFiaWxpdGllcxgKIAMoCRIvCgRyYmFjGBQgAygLMiEub3JnYW5pemF0aW9uLnYxLlBsdWdpblBvbGljeVJ1bGUiSAoQUGx1Z2luUG9saWN5UnVsZRISCgphcGlfZ3JvdXBzGAogAygJEhEKCXJlc291cmNlcxgUIAMoCRINCgV2ZXJicxgeIAMoCSJ3CgpQbHVnaW5NZW51EjYKDG9yZ2FuaXphdGlvbhgKIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51RW50cnkSMQoHcHJvamVjdBgUIAMoCzIgLm9yZ2FuaXphdGlvbi52MS5QbHVnaW5NZW51RW50cnkiSgoPUGx1Z2luTWVudUVudHJ5EgsKA2NyZBgKIAEoCRIMCgRsaXN0GBQgASgIEg4KBmRldGFpbBgeIAEoCBIMCgRpY29uGCggASgJIkYKFlBsdWdpbkNvbXBvbmVudE1hcHBpbmcSDAoEbGlzdBgKIAEoCRIOCgZkZXRhaWwYFCABKAkSDgoGY3JlYXRlGB4gASgJIlgKFVBsdWdpbkFsbG93ZWRSZXNvdXJjZRINCgVncm91cBgKIAEoCRIPCgd2ZXJzaW9uGBQgASgJEhAKCHJlc291cmNlGB4gASgJEg0KBXZlcmJzGCggAygJIoMBCgxQbHVnaW5VSUhpbnQSNQoLZm9ybV9ncm91cHMYCiADKAsyIC5vcmdhbml6YXRpb24udjEuUGx1Z2luRm9ybUdyb3VwEjwKDnN0YXR1c19tYXBwaW5nGBQgASgLMiQub3JnYW5pemF0aW9uLnYxLlBsdWdpblN0YXR1c01hcHBpbmciLwoPUGx1Z2luRm9ybUdyb3VwEgwKBG5hbWUYCiABKAkSDgoGZmllbGRzGBQgAygJIr0BChNQbHVnaW5TdGF0dXNNYXBwaW5nEhEKCWpzb25fcGF0aBgKIAEoCRJACgZ2YWx1ZXMYFCADKAsyMC5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzTWFwcGluZy5WYWx1ZXNFbnRyeRpRCgtWYWx1ZXNFbnRyeRILCgNrZXkYASABKAkSMQoFdmFsdWUYAiABKAsyIi5vcmdhbml6YXRpb24udjEuUGx1Z2luU3RhdHVzVmFsdWU6AjgBIjEKEVBsdWdpblN0YXR1c1ZhbHVlEg0KBWJhZGdlGAogASgJEg0KBWxhYmVsGBQgASgJMoUFCg1QbHVnaW5TZXJ2aWNlElgKC0xpc3RQbHVnaW5zEiMub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5zUmVxdWVzdBokLm9yZ2FuaXphdGlvbi52MS5MaXN0UGx1Z2luc1Jlc3BvbnNlEmQKD0dldFBsdWdpbkRldGFpbBInLm9yZ2FuaXphdGlvbi52MS5HZXRQbHVnaW5EZXRhaWxSZXF1ZXN0Gigub3JnYW5pemF0aW9uLnYxLkdldFBsdWdpbkRldGFpbFJlc3BvbnNlElgKC0xpc3RQcmVzZXRzEiMub3JnYW5pemF0aW9uLnYxLkxpc3RQcmVzZXRzUmVxdWVzdBokLm9yZ2FuaXphdGlvbi52MS5MaXN0UHJlc2V0c1Jlc3BvbnNlEnYKFUxpc3RQbHVnaW5EZWZpbml0aW9ucxItLm9yZ2FuaXphdGlvbi52MS5MaXN0UGx1Z2luRGVmaW5pdGlvbnNSZXF1ZXN0Gi4ub3JnYW5pemF0aW9uLnYxLkxpc3RQbHVnaW5EZWZpbml0aW9uc1Jlc3BvbnNlEnAKE1B1dFBsdWdpbkRlZmluaXRpb24SKy5vcmdhbml6YXRpb24udjEuUHV0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QaLC5vcmdhbml6YXRpb24udjEuUHV0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlEnAKE0dldFBsdWdpbkRlZmluaXRpb24SKy5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGVmaW5pdGlvblJlcXVlc3QaLC5vcmdhbml6YXRpb24udjEuR2V0UGx1Z2luRGVmaW5pdGlvblJlc3BvbnNlQl9aU2dpdGh1Yi5jb20vZnVuZGFtZW50LW9zcy9mdW5kYW1lbnQvb3JnYW5pemF0aW9uLWFwaS9wa2cvcHJvdG8vZ2VuL3YxO29yZ2FuaXphdGlvbnYxkgMHCALSPgIQA2IIZWRpdGlvbnNw6Ac", [file_google_protobuf_go_features]);
 
 /**
  * Tag information
@@ -533,6 +533,65 @@ export const GetPluginDefinitionResponseSchema: GenMessage<GetPluginDefinitionRe
   messageDesc(file_v1_plugin, 16);
 
 /**
+ * @generated from message organization.v1.ListPluginDefinitionsRequest
+ */
+export type ListPluginDefinitionsRequest = Message<"organization.v1.ListPluginDefinitionsRequest"> & {
+  /**
+   * @generated from field: string plugin_id = 10;
+   */
+  pluginId: string;
+};
+
+/**
+ * Describes the message organization.v1.ListPluginDefinitionsRequest.
+ * Use `create(ListPluginDefinitionsRequestSchema)` to create a new message.
+ */
+export const ListPluginDefinitionsRequestSchema: GenMessage<ListPluginDefinitionsRequest> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 17);
+
+/**
+ * @generated from message organization.v1.ListPluginDefinitionsResponse
+ */
+export type ListPluginDefinitionsResponse = Message<"organization.v1.ListPluginDefinitionsResponse"> & {
+  /**
+   * @generated from field: repeated organization.v1.PluginDefinitionVersion definitions = 10;
+   */
+  definitions: PluginDefinitionVersion[];
+};
+
+/**
+ * Describes the message organization.v1.ListPluginDefinitionsResponse.
+ * Use `create(ListPluginDefinitionsResponseSchema)` to create a new message.
+ */
+export const ListPluginDefinitionsResponseSchema: GenMessage<ListPluginDefinitionsResponse> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 18);
+
+/**
+ * A published definition's pin: the version an install references and the
+ * sha256 hash of that manifest.
+ *
+ * @generated from message organization.v1.PluginDefinitionVersion
+ */
+export type PluginDefinitionVersion = Message<"organization.v1.PluginDefinitionVersion"> & {
+  /**
+   * @generated from field: string version = 10;
+   */
+  version: string;
+
+  /**
+   * @generated from field: string hash = 20;
+   */
+  hash: string;
+};
+
+/**
+ * Describes the message organization.v1.PluginDefinitionVersion.
+ * Use `create(PluginDefinitionVersionSchema)` to create a new message.
+ */
+export const PluginDefinitionVersionSchema: GenMessage<PluginDefinitionVersion> = /*@__PURE__*/
+  messageDesc(file_v1_plugin, 19);
+
+/**
  * @generated from message organization.v1.PluginDefinition
  */
 export type PluginDefinition = Message<"organization.v1.PluginDefinition"> & {
@@ -587,7 +646,7 @@ export type PluginDefinition = Message<"organization.v1.PluginDefinition"> & {
  * Use `create(PluginDefinitionSchema)` to create a new message.
  */
 export const PluginDefinitionSchema: GenMessage<PluginDefinition> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 17);
+  messageDesc(file_v1_plugin, 20);
 
 /**
  * @generated from message organization.v1.PluginDefinitionMetadata
@@ -644,7 +703,7 @@ export type PluginDefinitionMetadata = Message<"organization.v1.PluginDefinition
  * Use `create(PluginDefinitionMetadataSchema)` to create a new message.
  */
 export const PluginDefinitionMetadataSchema: GenMessage<PluginDefinitionMetadata> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 18);
+  messageDesc(file_v1_plugin, 21);
 
 /**
  * @generated from message organization.v1.PluginURLs
@@ -671,7 +730,7 @@ export type PluginURLs = Message<"organization.v1.PluginURLs"> & {
  * Use `create(PluginURLsSchema)` to create a new message.
  */
 export const PluginURLsSchema: GenMessage<PluginURLs> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 19);
+  messageDesc(file_v1_plugin, 22);
 
 /**
  * @generated from message organization.v1.PluginPermissions
@@ -693,7 +752,7 @@ export type PluginPermissions = Message<"organization.v1.PluginPermissions"> & {
  * Use `create(PluginPermissionsSchema)` to create a new message.
  */
 export const PluginPermissionsSchema: GenMessage<PluginPermissions> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 20);
+  messageDesc(file_v1_plugin, 23);
 
 /**
  * @generated from message organization.v1.PluginPolicyRule
@@ -720,7 +779,7 @@ export type PluginPolicyRule = Message<"organization.v1.PluginPolicyRule"> & {
  * Use `create(PluginPolicyRuleSchema)` to create a new message.
  */
 export const PluginPolicyRuleSchema: GenMessage<PluginPolicyRule> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 21);
+  messageDesc(file_v1_plugin, 24);
 
 /**
  * @generated from message organization.v1.PluginMenu
@@ -742,7 +801,7 @@ export type PluginMenu = Message<"organization.v1.PluginMenu"> & {
  * Use `create(PluginMenuSchema)` to create a new message.
  */
 export const PluginMenuSchema: GenMessage<PluginMenu> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 22);
+  messageDesc(file_v1_plugin, 25);
 
 /**
  * @generated from message organization.v1.PluginMenuEntry
@@ -774,7 +833,7 @@ export type PluginMenuEntry = Message<"organization.v1.PluginMenuEntry"> & {
  * Use `create(PluginMenuEntrySchema)` to create a new message.
  */
 export const PluginMenuEntrySchema: GenMessage<PluginMenuEntry> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 23);
+  messageDesc(file_v1_plugin, 26);
 
 /**
  * @generated from message organization.v1.PluginComponentMapping
@@ -801,7 +860,7 @@ export type PluginComponentMapping = Message<"organization.v1.PluginComponentMap
  * Use `create(PluginComponentMappingSchema)` to create a new message.
  */
 export const PluginComponentMappingSchema: GenMessage<PluginComponentMapping> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 24);
+  messageDesc(file_v1_plugin, 27);
 
 /**
  * @generated from message organization.v1.PluginAllowedResource
@@ -833,7 +892,7 @@ export type PluginAllowedResource = Message<"organization.v1.PluginAllowedResour
  * Use `create(PluginAllowedResourceSchema)` to create a new message.
  */
 export const PluginAllowedResourceSchema: GenMessage<PluginAllowedResource> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 25);
+  messageDesc(file_v1_plugin, 28);
 
 /**
  * @generated from message organization.v1.PluginUIHint
@@ -855,7 +914,7 @@ export type PluginUIHint = Message<"organization.v1.PluginUIHint"> & {
  * Use `create(PluginUIHintSchema)` to create a new message.
  */
 export const PluginUIHintSchema: GenMessage<PluginUIHint> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 26);
+  messageDesc(file_v1_plugin, 29);
 
 /**
  * @generated from message organization.v1.PluginFormGroup
@@ -877,7 +936,7 @@ export type PluginFormGroup = Message<"organization.v1.PluginFormGroup"> & {
  * Use `create(PluginFormGroupSchema)` to create a new message.
  */
 export const PluginFormGroupSchema: GenMessage<PluginFormGroup> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 27);
+  messageDesc(file_v1_plugin, 30);
 
 /**
  * @generated from message organization.v1.PluginStatusMapping
@@ -899,7 +958,7 @@ export type PluginStatusMapping = Message<"organization.v1.PluginStatusMapping">
  * Use `create(PluginStatusMappingSchema)` to create a new message.
  */
 export const PluginStatusMappingSchema: GenMessage<PluginStatusMapping> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 28);
+  messageDesc(file_v1_plugin, 31);
 
 /**
  * @generated from message organization.v1.PluginStatusValue
@@ -921,7 +980,7 @@ export type PluginStatusValue = Message<"organization.v1.PluginStatusValue"> & {
  * Use `create(PluginStatusValueSchema)` to create a new message.
  */
 export const PluginStatusValueSchema: GenMessage<PluginStatusValue> = /*@__PURE__*/
-  messageDesc(file_v1_plugin, 29);
+  messageDesc(file_v1_plugin, 32);
 
 /**
  * PluginService provides information about available plugins and presets
@@ -958,6 +1017,17 @@ export const PluginService: GenService<{
     methodKind: "unary";
     input: typeof ListPresetsRequestSchema;
     output: typeof ListPresetsResponseSchema;
+  },
+  /**
+   * List the published definitions (version + hash) for a plugin, latest first.
+   * Used by the console to offer a version to pin on install.
+   *
+   * @generated from rpc organization.v1.PluginService.ListPluginDefinitions
+   */
+  listPluginDefinitions: {
+    methodKind: "unary";
+    input: typeof ListPluginDefinitionsRequestSchema;
+    output: typeof ListPluginDefinitionsResponseSchema;
   },
   /**
    * Idempotent upsert of a plugin definition. Server computes the hash from the

--- a/organization-api/pkg/db/gen/plugin_definition.sql.go
+++ b/organization-api/pkg/db/gen/plugin_definition.sql.go
@@ -121,6 +121,42 @@ func (q *Queries) PluginDefinitionInsert(ctx context.Context, arg PluginDefiniti
 	return i, err
 }
 
+const pluginDefinitionListByPlugin = `-- name: PluginDefinitionListByPlugin :many
+SELECT appstore.plugin_definitions.plugin_version, appstore.plugin_definitions.hash
+FROM appstore.plugin_definitions
+WHERE appstore.plugin_definitions.plugin_id = $1 AND appstore.plugin_definitions.deleted IS NULL
+ORDER BY appstore.plugin_definitions.created DESC
+`
+
+type PluginDefinitionListByPluginParams struct {
+	PluginID uuid.UUID
+}
+
+type PluginDefinitionListByPluginRow struct {
+	PluginVersion string
+	Hash          string
+}
+
+func (q *Queries) PluginDefinitionListByPlugin(ctx context.Context, arg PluginDefinitionListByPluginParams) ([]PluginDefinitionListByPluginRow, error) {
+	rows, err := q.db.Query(ctx, pluginDefinitionListByPlugin, arg.PluginID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PluginDefinitionListByPluginRow
+	for rows.Next() {
+		var i PluginDefinitionListByPluginRow
+		if err := rows.Scan(&i.PluginVersion, &i.Hash); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const pluginDefinitionSoftDelete = `-- name: PluginDefinitionSoftDelete :execrows
 UPDATE appstore.plugin_definitions
 SET deleted = now()

--- a/organization-api/pkg/db/plugin_definition.sql
+++ b/organization-api/pkg/db/plugin_definition.sql
@@ -9,6 +9,12 @@ SELECT id, plugin_id, plugin_version, manifest, hash, created
 FROM appstore.plugin_definitions
 WHERE plugin_id = $1 AND plugin_version = $2 AND hash = $3 AND deleted IS NULL;
 
+-- name: PluginDefinitionListByPlugin :many
+SELECT appstore.plugin_definitions.plugin_version, appstore.plugin_definitions.hash
+FROM appstore.plugin_definitions
+WHERE appstore.plugin_definitions.plugin_id = $1 AND appstore.plugin_definitions.deleted IS NULL
+ORDER BY appstore.plugin_definitions.created DESC;
+
 -- name: PluginDefinitionInsert :one
 INSERT INTO appstore.plugin_definitions (plugin_id, plugin_version, manifest, hash)
 VALUES ($1, $2, $3, $4)

--- a/organization-api/pkg/organization/plugin_definition_list.go
+++ b/organization-api/pkg/organization/plugin_definition_list.go
@@ -1,0 +1,42 @@
+package organization
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	db "github.com/fundament-oss/fundament/organization-api/pkg/db/gen"
+	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
+)
+
+// ListPluginDefinitions returns the published definitions (version + hash) for a
+// plugin, latest first — the set the console offers as install-time version
+// choices. An unknown plugin simply yields an empty list.
+func (s *Server) ListPluginDefinitions(
+	ctx context.Context,
+	req *connect.Request[organizationv1.ListPluginDefinitionsRequest],
+) (*connect.Response[organizationv1.ListPluginDefinitionsResponse], error) {
+	pluginID, err := uuid.Parse(req.Msg.GetPluginId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("plugin_id must be a valid uuid: %w", err))
+	}
+
+	rows, err := s.queries.PluginDefinitionListByPlugin(ctx, db.PluginDefinitionListByPluginParams{PluginID: pluginID})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list plugin definitions: %w", err))
+	}
+
+	defs := make([]*organizationv1.PluginDefinitionVersion, 0, len(rows))
+	for _, row := range rows {
+		defs = append(defs, organizationv1.PluginDefinitionVersion_builder{
+			Version: row.PluginVersion,
+			Hash:    row.Hash,
+		}.Build())
+	}
+
+	return connect.NewResponse(organizationv1.ListPluginDefinitionsResponse_builder{
+		Definitions: defs,
+	}.Build()), nil
+}

--- a/organization-api/pkg/organization/plugin_definition_test.go
+++ b/organization-api/pkg/organization/plugin_definition_test.go
@@ -483,6 +483,68 @@ func TestListPlugins_SurfacesLatestDefinition(t *testing.T) {
 	assert.Equal(t, v2Hash, detailResp.Msg.GetPlugin().GetDefinitionHash())
 }
 
+// TestListPluginDefinitions_LatestFirst verifies the endpoint returns all
+// published (version, hash) pairs for a plugin, newest first — the set the
+// console offers as install-time version choices.
+func TestListPluginDefinitions_LatestFirst(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	env := newTestAPI(t,
+		WithOrganization(orgID, "test-org"),
+		WithUser(&UserArgs{
+			ID:     userID,
+			Name:   "test-user",
+			Email:  "test@example.com",
+			OrgIDs: []uuid.UUID{orgID},
+		}),
+	)
+
+	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	token := env.createAuthnToken(t, userID)
+	client := newPluginServiceClient(env)
+	ctx := context.Background()
+
+	list := func(t *testing.T) []*organizationv1.PluginDefinitionVersion {
+		t.Helper()
+		req := connect.NewRequest(organizationv1.ListPluginDefinitionsRequest_builder{
+			PluginId: pluginID.String(),
+		}.Build())
+		req.Header().Set("Authorization", "Bearer "+token)
+		req.Header().Set("Fun-Organization", orgID.String())
+		resp, err := client.ListPluginDefinitions(ctx, req)
+		require.NoError(t, err)
+		return resp.Msg.GetDefinitions()
+	}
+
+	// No definitions published yet → empty list.
+	assert.Empty(t, list(t))
+
+	put := func(version string, manifest []byte) string {
+		t.Helper()
+		req := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+			PluginId: pluginID.String(), PluginVersion: version, Manifest: manifest,
+		}.Build())
+		req.Header().Set("Authorization", "Bearer "+token)
+		req.Header().Set("Fun-Organization", orgID.String())
+		resp, err := client.PutPluginDefinition(ctx, req)
+		require.NoError(t, err)
+		return resp.Msg.GetHash()
+	}
+
+	put("v1", testManifest)
+	v2Manifest := bytes.ReplaceAll(testManifest, []byte("version: v1"), []byte("version: v2"))
+	v2Hash := put("v2", v2Manifest)
+
+	defs := list(t)
+	require.Len(t, defs, 2)
+	assert.Equal(t, "v2", defs[0].GetVersion(), "latest published version first")
+	assert.Equal(t, v2Hash, defs[0].GetHash())
+	assert.Equal(t, "v1", defs[1].GetVersion())
+}
+
 func TestGetPluginDefinition_ReturnsBytesHashAndProto(t *testing.T) {
 	t.Parallel()
 

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/plugin.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/plugin.connect.go
@@ -42,6 +42,9 @@ const (
 	// PluginServiceListPresetsProcedure is the fully-qualified name of the PluginService's ListPresets
 	// RPC.
 	PluginServiceListPresetsProcedure = "/organization.v1.PluginService/ListPresets"
+	// PluginServiceListPluginDefinitionsProcedure is the fully-qualified name of the PluginService's
+	// ListPluginDefinitions RPC.
+	PluginServiceListPluginDefinitionsProcedure = "/organization.v1.PluginService/ListPluginDefinitions"
 	// PluginServicePutPluginDefinitionProcedure is the fully-qualified name of the PluginService's
 	// PutPluginDefinition RPC.
 	PluginServicePutPluginDefinitionProcedure = "/organization.v1.PluginService/PutPluginDefinition"
@@ -58,6 +61,9 @@ type PluginServiceClient interface {
 	GetPluginDetail(context.Context, *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error)
 	// List all available presets
 	ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error)
+	// List the published definitions (version + hash) for a plugin, latest first.
+	// Used by the console to offer a version to pin on install.
+	ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error)
 	// Idempotent upsert of a plugin definition. Server computes the hash from the
 	// manifest bytes. Same (plugin_id, version, hash) → returns the existing row;
 	// same (plugin_id, version) with a different hash → FAILED_PRECONDITION unless
@@ -100,6 +106,12 @@ func NewPluginServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 			connect.WithSchema(pluginServiceMethods.ByName("ListPresets")),
 			connect.WithClientOptions(opts...),
 		),
+		listPluginDefinitions: connect.NewClient[v1.ListPluginDefinitionsRequest, v1.ListPluginDefinitionsResponse](
+			httpClient,
+			baseURL+PluginServiceListPluginDefinitionsProcedure,
+			connect.WithSchema(pluginServiceMethods.ByName("ListPluginDefinitions")),
+			connect.WithClientOptions(opts...),
+		),
 		putPluginDefinition: connect.NewClient[v1.PutPluginDefinitionRequest, v1.PutPluginDefinitionResponse](
 			httpClient,
 			baseURL+PluginServicePutPluginDefinitionProcedure,
@@ -117,11 +129,12 @@ func NewPluginServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 
 // pluginServiceClient implements PluginServiceClient.
 type pluginServiceClient struct {
-	listPlugins         *connect.Client[v1.ListPluginsRequest, v1.ListPluginsResponse]
-	getPluginDetail     *connect.Client[v1.GetPluginDetailRequest, v1.GetPluginDetailResponse]
-	listPresets         *connect.Client[v1.ListPresetsRequest, v1.ListPresetsResponse]
-	putPluginDefinition *connect.Client[v1.PutPluginDefinitionRequest, v1.PutPluginDefinitionResponse]
-	getPluginDefinition *connect.Client[v1.GetPluginDefinitionRequest, v1.GetPluginDefinitionResponse]
+	listPlugins           *connect.Client[v1.ListPluginsRequest, v1.ListPluginsResponse]
+	getPluginDetail       *connect.Client[v1.GetPluginDetailRequest, v1.GetPluginDetailResponse]
+	listPresets           *connect.Client[v1.ListPresetsRequest, v1.ListPresetsResponse]
+	listPluginDefinitions *connect.Client[v1.ListPluginDefinitionsRequest, v1.ListPluginDefinitionsResponse]
+	putPluginDefinition   *connect.Client[v1.PutPluginDefinitionRequest, v1.PutPluginDefinitionResponse]
+	getPluginDefinition   *connect.Client[v1.GetPluginDefinitionRequest, v1.GetPluginDefinitionResponse]
 }
 
 // ListPlugins calls organization.v1.PluginService.ListPlugins.
@@ -137,6 +150,11 @@ func (c *pluginServiceClient) GetPluginDetail(ctx context.Context, req *connect.
 // ListPresets calls organization.v1.PluginService.ListPresets.
 func (c *pluginServiceClient) ListPresets(ctx context.Context, req *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error) {
 	return c.listPresets.CallUnary(ctx, req)
+}
+
+// ListPluginDefinitions calls organization.v1.PluginService.ListPluginDefinitions.
+func (c *pluginServiceClient) ListPluginDefinitions(ctx context.Context, req *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error) {
+	return c.listPluginDefinitions.CallUnary(ctx, req)
 }
 
 // PutPluginDefinition calls organization.v1.PluginService.PutPluginDefinition.
@@ -157,6 +175,9 @@ type PluginServiceHandler interface {
 	GetPluginDetail(context.Context, *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error)
 	// List all available presets
 	ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error)
+	// List the published definitions (version + hash) for a plugin, latest first.
+	// Used by the console to offer a version to pin on install.
+	ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error)
 	// Idempotent upsert of a plugin definition. Server computes the hash from the
 	// manifest bytes. Same (plugin_id, version, hash) → returns the existing row;
 	// same (plugin_id, version) with a different hash → FAILED_PRECONDITION unless
@@ -195,6 +216,12 @@ func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOp
 		connect.WithSchema(pluginServiceMethods.ByName("ListPresets")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pluginServiceListPluginDefinitionsHandler := connect.NewUnaryHandler(
+		PluginServiceListPluginDefinitionsProcedure,
+		svc.ListPluginDefinitions,
+		connect.WithSchema(pluginServiceMethods.ByName("ListPluginDefinitions")),
+		connect.WithHandlerOptions(opts...),
+	)
 	pluginServicePutPluginDefinitionHandler := connect.NewUnaryHandler(
 		PluginServicePutPluginDefinitionProcedure,
 		svc.PutPluginDefinition,
@@ -215,6 +242,8 @@ func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOp
 			pluginServiceGetPluginDetailHandler.ServeHTTP(w, r)
 		case PluginServiceListPresetsProcedure:
 			pluginServiceListPresetsHandler.ServeHTTP(w, r)
+		case PluginServiceListPluginDefinitionsProcedure:
+			pluginServiceListPluginDefinitionsHandler.ServeHTTP(w, r)
 		case PluginServicePutPluginDefinitionProcedure:
 			pluginServicePutPluginDefinitionHandler.ServeHTTP(w, r)
 		case PluginServiceGetPluginDefinitionProcedure:
@@ -238,6 +267,10 @@ func (UnimplementedPluginServiceHandler) GetPluginDetail(context.Context, *conne
 
 func (UnimplementedPluginServiceHandler) ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.ListPresets is not implemented"))
+}
+
+func (UnimplementedPluginServiceHandler) ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.ListPluginDefinitions is not implemented"))
 }
 
 func (UnimplementedPluginServiceHandler) PutPluginDefinition(context.Context, *connect.Request[v1.PutPluginDefinitionRequest]) (*connect.Response[v1.PutPluginDefinitionResponse], error) {

--- a/organization-api/pkg/proto/gen/v1/plugin.pb.go
+++ b/organization-api/pkg/proto/gen/v1/plugin.pb.go
@@ -1574,6 +1574,195 @@ func (b0 GetPluginDefinitionResponse_builder) Build() *GetPluginDefinitionRespon
 	return m0
 }
 
+type ListPluginDefinitionsRequest struct {
+	state               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PluginId string                 `protobuf:"bytes,10,opt,name=plugin_id,json=pluginId"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *ListPluginDefinitionsRequest) Reset() {
+	*x = ListPluginDefinitionsRequest{}
+	mi := &file_v1_plugin_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginDefinitionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginDefinitionsRequest) ProtoMessage() {}
+
+func (x *ListPluginDefinitionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_plugin_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListPluginDefinitionsRequest) GetPluginId() string {
+	if x != nil {
+		return x.xxx_hidden_PluginId
+	}
+	return ""
+}
+
+func (x *ListPluginDefinitionsRequest) SetPluginId(v string) {
+	x.xxx_hidden_PluginId = v
+}
+
+type ListPluginDefinitionsRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	PluginId string
+}
+
+func (b0 ListPluginDefinitionsRequest_builder) Build() *ListPluginDefinitionsRequest {
+	m0 := &ListPluginDefinitionsRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PluginId = b.PluginId
+	return m0
+}
+
+type ListPluginDefinitionsResponse struct {
+	state                  protoimpl.MessageState      `protogen:"opaque.v1"`
+	xxx_hidden_Definitions *[]*PluginDefinitionVersion `protobuf:"bytes,10,rep,name=definitions"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ListPluginDefinitionsResponse) Reset() {
+	*x = ListPluginDefinitionsResponse{}
+	mi := &file_v1_plugin_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginDefinitionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginDefinitionsResponse) ProtoMessage() {}
+
+func (x *ListPluginDefinitionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_plugin_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListPluginDefinitionsResponse) GetDefinitions() []*PluginDefinitionVersion {
+	if x != nil {
+		if x.xxx_hidden_Definitions != nil {
+			return *x.xxx_hidden_Definitions
+		}
+	}
+	return nil
+}
+
+func (x *ListPluginDefinitionsResponse) SetDefinitions(v []*PluginDefinitionVersion) {
+	x.xxx_hidden_Definitions = &v
+}
+
+type ListPluginDefinitionsResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Definitions []*PluginDefinitionVersion
+}
+
+func (b0 ListPluginDefinitionsResponse_builder) Build() *ListPluginDefinitionsResponse {
+	m0 := &ListPluginDefinitionsResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Definitions = &b.Definitions
+	return m0
+}
+
+// A published definition's pin: the version an install references and the
+// sha256 hash of that manifest.
+type PluginDefinitionVersion struct {
+	state              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Version string                 `protobuf:"bytes,10,opt,name=version"`
+	xxx_hidden_Hash    string                 `protobuf:"bytes,20,opt,name=hash"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *PluginDefinitionVersion) Reset() {
+	*x = PluginDefinitionVersion{}
+	mi := &file_v1_plugin_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginDefinitionVersion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginDefinitionVersion) ProtoMessage() {}
+
+func (x *PluginDefinitionVersion) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_plugin_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PluginDefinitionVersion) GetVersion() string {
+	if x != nil {
+		return x.xxx_hidden_Version
+	}
+	return ""
+}
+
+func (x *PluginDefinitionVersion) GetHash() string {
+	if x != nil {
+		return x.xxx_hidden_Hash
+	}
+	return ""
+}
+
+func (x *PluginDefinitionVersion) SetVersion(v string) {
+	x.xxx_hidden_Version = v
+}
+
+func (x *PluginDefinitionVersion) SetHash(v string) {
+	x.xxx_hidden_Hash = v
+}
+
+type PluginDefinitionVersion_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Version string
+	Hash    string
+}
+
+func (b0 PluginDefinitionVersion_builder) Build() *PluginDefinitionVersion {
+	m0 := &PluginDefinitionVersion{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Version = b.Version
+	x.xxx_hidden_Hash = b.Hash
+	return m0
+}
+
 type PluginDefinition struct {
 	state                       protoimpl.MessageState             `protogen:"opaque.v1"`
 	xxx_hidden_Metadata         *PluginDefinitionMetadata          `protobuf:"bytes,10,opt,name=metadata"`
@@ -1591,7 +1780,7 @@ type PluginDefinition struct {
 
 func (x *PluginDefinition) Reset() {
 	*x = PluginDefinition{}
-	mi := &file_v1_plugin_proto_msgTypes[17]
+	mi := &file_v1_plugin_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1603,7 +1792,7 @@ func (x *PluginDefinition) String() string {
 func (*PluginDefinition) ProtoMessage() {}
 
 func (x *PluginDefinition) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[17]
+	mi := &file_v1_plugin_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1795,7 +1984,7 @@ type PluginDefinitionMetadata struct {
 
 func (x *PluginDefinitionMetadata) Reset() {
 	*x = PluginDefinitionMetadata{}
-	mi := &file_v1_plugin_proto_msgTypes[18]
+	mi := &file_v1_plugin_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1807,7 +1996,7 @@ func (x *PluginDefinitionMetadata) String() string {
 func (*PluginDefinitionMetadata) ProtoMessage() {}
 
 func (x *PluginDefinitionMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[18]
+	mi := &file_v1_plugin_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1969,7 +2158,7 @@ type PluginURLs struct {
 
 func (x *PluginURLs) Reset() {
 	*x = PluginURLs{}
-	mi := &file_v1_plugin_proto_msgTypes[19]
+	mi := &file_v1_plugin_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1981,7 +2170,7 @@ func (x *PluginURLs) String() string {
 func (*PluginURLs) ProtoMessage() {}
 
 func (x *PluginURLs) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[19]
+	mi := &file_v1_plugin_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2053,7 +2242,7 @@ type PluginPermissions struct {
 
 func (x *PluginPermissions) Reset() {
 	*x = PluginPermissions{}
-	mi := &file_v1_plugin_proto_msgTypes[20]
+	mi := &file_v1_plugin_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2065,7 +2254,7 @@ func (x *PluginPermissions) String() string {
 func (*PluginPermissions) ProtoMessage() {}
 
 func (x *PluginPermissions) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[20]
+	mi := &file_v1_plugin_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2316,7 @@ type PluginPolicyRule struct {
 
 func (x *PluginPolicyRule) Reset() {
 	*x = PluginPolicyRule{}
-	mi := &file_v1_plugin_proto_msgTypes[21]
+	mi := &file_v1_plugin_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2139,7 +2328,7 @@ func (x *PluginPolicyRule) String() string {
 func (*PluginPolicyRule) ProtoMessage() {}
 
 func (x *PluginPolicyRule) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[21]
+	mi := &file_v1_plugin_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2211,7 +2400,7 @@ type PluginMenu struct {
 
 func (x *PluginMenu) Reset() {
 	*x = PluginMenu{}
-	mi := &file_v1_plugin_proto_msgTypes[22]
+	mi := &file_v1_plugin_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2223,7 +2412,7 @@ func (x *PluginMenu) String() string {
 func (*PluginMenu) ProtoMessage() {}
 
 func (x *PluginMenu) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[22]
+	mi := &file_v1_plugin_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2288,7 +2477,7 @@ type PluginMenuEntry struct {
 
 func (x *PluginMenuEntry) Reset() {
 	*x = PluginMenuEntry{}
-	mi := &file_v1_plugin_proto_msgTypes[23]
+	mi := &file_v1_plugin_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2489,7 @@ func (x *PluginMenuEntry) String() string {
 func (*PluginMenuEntry) ProtoMessage() {}
 
 func (x *PluginMenuEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[23]
+	mi := &file_v1_plugin_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2386,7 +2575,7 @@ type PluginComponentMapping struct {
 
 func (x *PluginComponentMapping) Reset() {
 	*x = PluginComponentMapping{}
-	mi := &file_v1_plugin_proto_msgTypes[24]
+	mi := &file_v1_plugin_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2398,7 +2587,7 @@ func (x *PluginComponentMapping) String() string {
 func (*PluginComponentMapping) ProtoMessage() {}
 
 func (x *PluginComponentMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[24]
+	mi := &file_v1_plugin_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2472,7 +2661,7 @@ type PluginAllowedResource struct {
 
 func (x *PluginAllowedResource) Reset() {
 	*x = PluginAllowedResource{}
-	mi := &file_v1_plugin_proto_msgTypes[25]
+	mi := &file_v1_plugin_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2484,7 +2673,7 @@ func (x *PluginAllowedResource) String() string {
 func (*PluginAllowedResource) ProtoMessage() {}
 
 func (x *PluginAllowedResource) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[25]
+	mi := &file_v1_plugin_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2569,7 +2758,7 @@ type PluginUIHint struct {
 
 func (x *PluginUIHint) Reset() {
 	*x = PluginUIHint{}
-	mi := &file_v1_plugin_proto_msgTypes[26]
+	mi := &file_v1_plugin_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2581,7 +2770,7 @@ func (x *PluginUIHint) String() string {
 func (*PluginUIHint) ProtoMessage() {}
 
 func (x *PluginUIHint) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[26]
+	mi := &file_v1_plugin_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2653,7 +2842,7 @@ type PluginFormGroup struct {
 
 func (x *PluginFormGroup) Reset() {
 	*x = PluginFormGroup{}
-	mi := &file_v1_plugin_proto_msgTypes[27]
+	mi := &file_v1_plugin_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2665,7 +2854,7 @@ func (x *PluginFormGroup) String() string {
 func (*PluginFormGroup) ProtoMessage() {}
 
 func (x *PluginFormGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[27]
+	mi := &file_v1_plugin_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2724,7 +2913,7 @@ type PluginStatusMapping struct {
 
 func (x *PluginStatusMapping) Reset() {
 	*x = PluginStatusMapping{}
-	mi := &file_v1_plugin_proto_msgTypes[28]
+	mi := &file_v1_plugin_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2736,7 +2925,7 @@ func (x *PluginStatusMapping) String() string {
 func (*PluginStatusMapping) ProtoMessage() {}
 
 func (x *PluginStatusMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[28]
+	mi := &file_v1_plugin_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2795,7 +2984,7 @@ type PluginStatusValue struct {
 
 func (x *PluginStatusValue) Reset() {
 	*x = PluginStatusValue{}
-	mi := &file_v1_plugin_proto_msgTypes[29]
+	mi := &file_v1_plugin_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2807,7 +2996,7 @@ func (x *PluginStatusValue) String() string {
 func (*PluginStatusValue) ProtoMessage() {}
 
 func (x *PluginStatusValue) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_plugin_proto_msgTypes[29]
+	mi := &file_v1_plugin_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2953,7 +3142,17 @@ const file_v1_plugin_proto_rawDesc = "" +
 	"\x04hash\x18\x14 \x01(\tR\x04hash\x12A\n" +
 	"\n" +
 	"definition\x18\x1e \x01(\v2!.organization.v1.PluginDefinitionR\n" +
-	"definition\"\xf5\x05\n" +
+	"definition\";\n" +
+	"\x1cListPluginDefinitionsRequest\x12\x1b\n" +
+	"\tplugin_id\x18\n" +
+	" \x01(\tR\bpluginId\"k\n" +
+	"\x1dListPluginDefinitionsResponse\x12J\n" +
+	"\vdefinitions\x18\n" +
+	" \x03(\v2(.organization.v1.PluginDefinitionVersionR\vdefinitions\"G\n" +
+	"\x17PluginDefinitionVersion\x12\x18\n" +
+	"\aversion\x18\n" +
+	" \x01(\tR\aversion\x12\x12\n" +
+	"\x04hash\x18\x14 \x01(\tR\x04hash\"\xf5\x05\n" +
 	"\x10PluginDefinition\x12E\n" +
 	"\bmetadata\x18\n" +
 	" \x01(\v2).organization.v1.PluginDefinitionMetadataR\bmetadata\x12\x14\n" +
@@ -3041,49 +3240,53 @@ const file_v1_plugin_proto_rawDesc = "" +
 	"\x11PluginStatusValue\x12\x14\n" +
 	"\x05badge\x18\n" +
 	" \x01(\tR\x05badge\x12\x14\n" +
-	"\x05label\x18\x14 \x01(\tR\x05label2\x8d\x04\n" +
+	"\x05label\x18\x14 \x01(\tR\x05label2\x85\x05\n" +
 	"\rPluginService\x12X\n" +
 	"\vListPlugins\x12#.organization.v1.ListPluginsRequest\x1a$.organization.v1.ListPluginsResponse\x12d\n" +
 	"\x0fGetPluginDetail\x12'.organization.v1.GetPluginDetailRequest\x1a(.organization.v1.GetPluginDetailResponse\x12X\n" +
-	"\vListPresets\x12#.organization.v1.ListPresetsRequest\x1a$.organization.v1.ListPresetsResponse\x12p\n" +
+	"\vListPresets\x12#.organization.v1.ListPresetsRequest\x1a$.organization.v1.ListPresetsResponse\x12v\n" +
+	"\x15ListPluginDefinitions\x12-.organization.v1.ListPluginDefinitionsRequest\x1a..organization.v1.ListPluginDefinitionsResponse\x12p\n" +
 	"\x13PutPluginDefinition\x12+.organization.v1.PutPluginDefinitionRequest\x1a,.organization.v1.PutPluginDefinitionResponse\x12p\n" +
 	"\x13GetPluginDefinition\x12+.organization.v1.GetPluginDefinitionRequest\x1a,.organization.v1.GetPluginDefinitionResponseB_ZSgithub.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1;organizationv1\x92\x03\a\xd2>\x02\x10\x03\b\x02b\beditionsp\xe8\a"
 
-var file_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_v1_plugin_proto_goTypes = []any{
-	(*Tag)(nil),                         // 0: organization.v1.Tag
-	(*Category)(nil),                    // 1: organization.v1.Category
-	(*PluginSummary)(nil),               // 2: organization.v1.PluginSummary
-	(*ListPluginsRequest)(nil),          // 3: organization.v1.ListPluginsRequest
-	(*ListPluginsResponse)(nil),         // 4: organization.v1.ListPluginsResponse
-	(*Preset)(nil),                      // 5: organization.v1.Preset
-	(*ListPresetsRequest)(nil),          // 6: organization.v1.ListPresetsRequest
-	(*ListPresetsResponse)(nil),         // 7: organization.v1.ListPresetsResponse
-	(*DocumentationLink)(nil),           // 8: organization.v1.DocumentationLink
-	(*Author)(nil),                      // 9: organization.v1.Author
-	(*PluginDetail)(nil),                // 10: organization.v1.PluginDetail
-	(*GetPluginDetailRequest)(nil),      // 11: organization.v1.GetPluginDetailRequest
-	(*GetPluginDetailResponse)(nil),     // 12: organization.v1.GetPluginDetailResponse
-	(*PutPluginDefinitionRequest)(nil),  // 13: organization.v1.PutPluginDefinitionRequest
-	(*PutPluginDefinitionResponse)(nil), // 14: organization.v1.PutPluginDefinitionResponse
-	(*GetPluginDefinitionRequest)(nil),  // 15: organization.v1.GetPluginDefinitionRequest
-	(*GetPluginDefinitionResponse)(nil), // 16: organization.v1.GetPluginDefinitionResponse
-	(*PluginDefinition)(nil),            // 17: organization.v1.PluginDefinition
-	(*PluginDefinitionMetadata)(nil),    // 18: organization.v1.PluginDefinitionMetadata
-	(*PluginURLs)(nil),                  // 19: organization.v1.PluginURLs
-	(*PluginPermissions)(nil),           // 20: organization.v1.PluginPermissions
-	(*PluginPolicyRule)(nil),            // 21: organization.v1.PluginPolicyRule
-	(*PluginMenu)(nil),                  // 22: organization.v1.PluginMenu
-	(*PluginMenuEntry)(nil),             // 23: organization.v1.PluginMenuEntry
-	(*PluginComponentMapping)(nil),      // 24: organization.v1.PluginComponentMapping
-	(*PluginAllowedResource)(nil),       // 25: organization.v1.PluginAllowedResource
-	(*PluginUIHint)(nil),                // 26: organization.v1.PluginUIHint
-	(*PluginFormGroup)(nil),             // 27: organization.v1.PluginFormGroup
-	(*PluginStatusMapping)(nil),         // 28: organization.v1.PluginStatusMapping
-	(*PluginStatusValue)(nil),           // 29: organization.v1.PluginStatusValue
-	nil,                                 // 30: organization.v1.PluginDefinition.CustomComponentsEntry
-	nil,                                 // 31: organization.v1.PluginDefinition.UiHintsEntry
-	nil,                                 // 32: organization.v1.PluginStatusMapping.ValuesEntry
+	(*Tag)(nil),                           // 0: organization.v1.Tag
+	(*Category)(nil),                      // 1: organization.v1.Category
+	(*PluginSummary)(nil),                 // 2: organization.v1.PluginSummary
+	(*ListPluginsRequest)(nil),            // 3: organization.v1.ListPluginsRequest
+	(*ListPluginsResponse)(nil),           // 4: organization.v1.ListPluginsResponse
+	(*Preset)(nil),                        // 5: organization.v1.Preset
+	(*ListPresetsRequest)(nil),            // 6: organization.v1.ListPresetsRequest
+	(*ListPresetsResponse)(nil),           // 7: organization.v1.ListPresetsResponse
+	(*DocumentationLink)(nil),             // 8: organization.v1.DocumentationLink
+	(*Author)(nil),                        // 9: organization.v1.Author
+	(*PluginDetail)(nil),                  // 10: organization.v1.PluginDetail
+	(*GetPluginDetailRequest)(nil),        // 11: organization.v1.GetPluginDetailRequest
+	(*GetPluginDetailResponse)(nil),       // 12: organization.v1.GetPluginDetailResponse
+	(*PutPluginDefinitionRequest)(nil),    // 13: organization.v1.PutPluginDefinitionRequest
+	(*PutPluginDefinitionResponse)(nil),   // 14: organization.v1.PutPluginDefinitionResponse
+	(*GetPluginDefinitionRequest)(nil),    // 15: organization.v1.GetPluginDefinitionRequest
+	(*GetPluginDefinitionResponse)(nil),   // 16: organization.v1.GetPluginDefinitionResponse
+	(*ListPluginDefinitionsRequest)(nil),  // 17: organization.v1.ListPluginDefinitionsRequest
+	(*ListPluginDefinitionsResponse)(nil), // 18: organization.v1.ListPluginDefinitionsResponse
+	(*PluginDefinitionVersion)(nil),       // 19: organization.v1.PluginDefinitionVersion
+	(*PluginDefinition)(nil),              // 20: organization.v1.PluginDefinition
+	(*PluginDefinitionMetadata)(nil),      // 21: organization.v1.PluginDefinitionMetadata
+	(*PluginURLs)(nil),                    // 22: organization.v1.PluginURLs
+	(*PluginPermissions)(nil),             // 23: organization.v1.PluginPermissions
+	(*PluginPolicyRule)(nil),              // 24: organization.v1.PluginPolicyRule
+	(*PluginMenu)(nil),                    // 25: organization.v1.PluginMenu
+	(*PluginMenuEntry)(nil),               // 26: organization.v1.PluginMenuEntry
+	(*PluginComponentMapping)(nil),        // 27: organization.v1.PluginComponentMapping
+	(*PluginAllowedResource)(nil),         // 28: organization.v1.PluginAllowedResource
+	(*PluginUIHint)(nil),                  // 29: organization.v1.PluginUIHint
+	(*PluginFormGroup)(nil),               // 30: organization.v1.PluginFormGroup
+	(*PluginStatusMapping)(nil),           // 31: organization.v1.PluginStatusMapping
+	(*PluginStatusValue)(nil),             // 32: organization.v1.PluginStatusValue
+	nil,                                   // 33: organization.v1.PluginDefinition.CustomComponentsEntry
+	nil,                                   // 34: organization.v1.PluginDefinition.UiHintsEntry
+	nil,                                   // 35: organization.v1.PluginStatusMapping.ValuesEntry
 }
 var file_v1_plugin_proto_depIdxs = []int32{
 	0,  // 0: organization.v1.PluginSummary.tags:type_name -> organization.v1.Tag
@@ -3095,38 +3298,41 @@ var file_v1_plugin_proto_depIdxs = []int32{
 	9,  // 6: organization.v1.PluginDetail.author:type_name -> organization.v1.Author
 	8,  // 7: organization.v1.PluginDetail.documentation_links:type_name -> organization.v1.DocumentationLink
 	10, // 8: organization.v1.GetPluginDetailResponse.plugin:type_name -> organization.v1.PluginDetail
-	17, // 9: organization.v1.GetPluginDefinitionResponse.definition:type_name -> organization.v1.PluginDefinition
-	18, // 10: organization.v1.PluginDefinition.metadata:type_name -> organization.v1.PluginDefinitionMetadata
-	20, // 11: organization.v1.PluginDefinition.permissions:type_name -> organization.v1.PluginPermissions
-	22, // 12: organization.v1.PluginDefinition.menu:type_name -> organization.v1.PluginMenu
-	30, // 13: organization.v1.PluginDefinition.custom_components:type_name -> organization.v1.PluginDefinition.CustomComponentsEntry
-	25, // 14: organization.v1.PluginDefinition.allowed_resources:type_name -> organization.v1.PluginAllowedResource
-	31, // 15: organization.v1.PluginDefinition.ui_hints:type_name -> organization.v1.PluginDefinition.UiHintsEntry
-	19, // 16: organization.v1.PluginDefinitionMetadata.urls:type_name -> organization.v1.PluginURLs
-	21, // 17: organization.v1.PluginPermissions.rbac:type_name -> organization.v1.PluginPolicyRule
-	23, // 18: organization.v1.PluginMenu.organization:type_name -> organization.v1.PluginMenuEntry
-	23, // 19: organization.v1.PluginMenu.project:type_name -> organization.v1.PluginMenuEntry
-	27, // 20: organization.v1.PluginUIHint.form_groups:type_name -> organization.v1.PluginFormGroup
-	28, // 21: organization.v1.PluginUIHint.status_mapping:type_name -> organization.v1.PluginStatusMapping
-	32, // 22: organization.v1.PluginStatusMapping.values:type_name -> organization.v1.PluginStatusMapping.ValuesEntry
-	24, // 23: organization.v1.PluginDefinition.CustomComponentsEntry.value:type_name -> organization.v1.PluginComponentMapping
-	26, // 24: organization.v1.PluginDefinition.UiHintsEntry.value:type_name -> organization.v1.PluginUIHint
-	29, // 25: organization.v1.PluginStatusMapping.ValuesEntry.value:type_name -> organization.v1.PluginStatusValue
-	3,  // 26: organization.v1.PluginService.ListPlugins:input_type -> organization.v1.ListPluginsRequest
-	11, // 27: organization.v1.PluginService.GetPluginDetail:input_type -> organization.v1.GetPluginDetailRequest
-	6,  // 28: organization.v1.PluginService.ListPresets:input_type -> organization.v1.ListPresetsRequest
-	13, // 29: organization.v1.PluginService.PutPluginDefinition:input_type -> organization.v1.PutPluginDefinitionRequest
-	15, // 30: organization.v1.PluginService.GetPluginDefinition:input_type -> organization.v1.GetPluginDefinitionRequest
-	4,  // 31: organization.v1.PluginService.ListPlugins:output_type -> organization.v1.ListPluginsResponse
-	12, // 32: organization.v1.PluginService.GetPluginDetail:output_type -> organization.v1.GetPluginDetailResponse
-	7,  // 33: organization.v1.PluginService.ListPresets:output_type -> organization.v1.ListPresetsResponse
-	14, // 34: organization.v1.PluginService.PutPluginDefinition:output_type -> organization.v1.PutPluginDefinitionResponse
-	16, // 35: organization.v1.PluginService.GetPluginDefinition:output_type -> organization.v1.GetPluginDefinitionResponse
-	31, // [31:36] is the sub-list for method output_type
-	26, // [26:31] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	20, // 9: organization.v1.GetPluginDefinitionResponse.definition:type_name -> organization.v1.PluginDefinition
+	19, // 10: organization.v1.ListPluginDefinitionsResponse.definitions:type_name -> organization.v1.PluginDefinitionVersion
+	21, // 11: organization.v1.PluginDefinition.metadata:type_name -> organization.v1.PluginDefinitionMetadata
+	23, // 12: organization.v1.PluginDefinition.permissions:type_name -> organization.v1.PluginPermissions
+	25, // 13: organization.v1.PluginDefinition.menu:type_name -> organization.v1.PluginMenu
+	33, // 14: organization.v1.PluginDefinition.custom_components:type_name -> organization.v1.PluginDefinition.CustomComponentsEntry
+	28, // 15: organization.v1.PluginDefinition.allowed_resources:type_name -> organization.v1.PluginAllowedResource
+	34, // 16: organization.v1.PluginDefinition.ui_hints:type_name -> organization.v1.PluginDefinition.UiHintsEntry
+	22, // 17: organization.v1.PluginDefinitionMetadata.urls:type_name -> organization.v1.PluginURLs
+	24, // 18: organization.v1.PluginPermissions.rbac:type_name -> organization.v1.PluginPolicyRule
+	26, // 19: organization.v1.PluginMenu.organization:type_name -> organization.v1.PluginMenuEntry
+	26, // 20: organization.v1.PluginMenu.project:type_name -> organization.v1.PluginMenuEntry
+	30, // 21: organization.v1.PluginUIHint.form_groups:type_name -> organization.v1.PluginFormGroup
+	31, // 22: organization.v1.PluginUIHint.status_mapping:type_name -> organization.v1.PluginStatusMapping
+	35, // 23: organization.v1.PluginStatusMapping.values:type_name -> organization.v1.PluginStatusMapping.ValuesEntry
+	27, // 24: organization.v1.PluginDefinition.CustomComponentsEntry.value:type_name -> organization.v1.PluginComponentMapping
+	29, // 25: organization.v1.PluginDefinition.UiHintsEntry.value:type_name -> organization.v1.PluginUIHint
+	32, // 26: organization.v1.PluginStatusMapping.ValuesEntry.value:type_name -> organization.v1.PluginStatusValue
+	3,  // 27: organization.v1.PluginService.ListPlugins:input_type -> organization.v1.ListPluginsRequest
+	11, // 28: organization.v1.PluginService.GetPluginDetail:input_type -> organization.v1.GetPluginDetailRequest
+	6,  // 29: organization.v1.PluginService.ListPresets:input_type -> organization.v1.ListPresetsRequest
+	17, // 30: organization.v1.PluginService.ListPluginDefinitions:input_type -> organization.v1.ListPluginDefinitionsRequest
+	13, // 31: organization.v1.PluginService.PutPluginDefinition:input_type -> organization.v1.PutPluginDefinitionRequest
+	15, // 32: organization.v1.PluginService.GetPluginDefinition:input_type -> organization.v1.GetPluginDefinitionRequest
+	4,  // 33: organization.v1.PluginService.ListPlugins:output_type -> organization.v1.ListPluginsResponse
+	12, // 34: organization.v1.PluginService.GetPluginDetail:output_type -> organization.v1.GetPluginDetailResponse
+	7,  // 35: organization.v1.PluginService.ListPresets:output_type -> organization.v1.ListPresetsResponse
+	18, // 36: organization.v1.PluginService.ListPluginDefinitions:output_type -> organization.v1.ListPluginDefinitionsResponse
+	14, // 37: organization.v1.PluginService.PutPluginDefinition:output_type -> organization.v1.PutPluginDefinitionResponse
+	16, // 38: organization.v1.PluginService.GetPluginDefinition:output_type -> organization.v1.GetPluginDefinitionResponse
+	33, // [33:39] is the sub-list for method output_type
+	27, // [27:33] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_v1_plugin_proto_init() }
@@ -3140,7 +3346,7 @@ func file_v1_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_plugin_proto_rawDesc), len(file_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/organization-api/pkg/proto/v1/plugin.proto
+++ b/organization-api/pkg/proto/v1/plugin.proto
@@ -16,6 +16,9 @@ service PluginService {
   rpc GetPluginDetail(GetPluginDetailRequest) returns (GetPluginDetailResponse);
   // List all available presets
   rpc ListPresets(ListPresetsRequest) returns (ListPresetsResponse);
+  // List the published definitions (version + hash) for a plugin, latest first.
+  // Used by the console to offer a version to pin on install.
+  rpc ListPluginDefinitions(ListPluginDefinitionsRequest) returns (ListPluginDefinitionsResponse);
   // Idempotent upsert of a plugin definition. Server computes the hash from the
   // manifest bytes. Same (plugin_id, version, hash) → returns the existing row;
   // same (plugin_id, version) with a different hash → FAILED_PRECONDITION unless
@@ -153,6 +156,19 @@ message GetPluginDefinitionResponse {
   bytes manifest = 10;
   string hash = 20;
   PluginDefinition definition = 30;
+}
+
+message ListPluginDefinitionsRequest {
+  string plugin_id = 10;
+}
+message ListPluginDefinitionsResponse {
+  repeated PluginDefinitionVersion definitions = 10;
+}
+// A published definition's pin: the version an install references and the
+// sha256 hash of that manifest.
+message PluginDefinitionVersion {
+  string version = 10;
+  string hash = 20;
 }
 
 message PluginDefinition {


### PR DESCRIPTION
Add a version dropdown to the install-plugin modal so an install pins a
specific published definition instead of always the latest.

- organization-api: ListPluginDefinitions(plugin_id) RPC returning every
  published (version, hash) for a plugin, latest first (new sqlc query +
  handler + test).
- console: the shared install modal fetches the plugin's versions on open and
  renders a <select> that defaults to the latest (the sole option when only
  one is published). Install and retry emit the chosen version+hash; the
  plugins page and plugin detail page wire it through. When nothing is
  published the modal shows a "no published version" notice and disables
  install.

The bulk cluster-plugins toggle form is unchanged — it still pins the latest.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>