### PR TITLE
feat(plugins): org-owned plugins

### DIFF
--- a/authz-worker/pkg/db/gen/queries.sql.go
+++ b/authz-worker/pkg/db/gen/queries.sql.go
@@ -23,6 +23,7 @@ SELECT
     namespace_id,
     api_key_id,
     organization_user_id,
+    plugin_id,
     created,
     retries
 FROM authz.outbox
@@ -42,6 +43,7 @@ type GetAndLockNextOutboxRowRow struct {
 	NamespaceID        pgtype.UUID
 	ApiKeyID           pgtype.UUID
 	OrganizationUserID pgtype.UUID
+	PluginID           pgtype.UUID
 	Created            pgtype.Timestamptz
 	Retries            int32
 }
@@ -60,6 +62,7 @@ func (q *Queries) GetAndLockNextOutboxRow(ctx context.Context) (GetAndLockNextOu
 		&i.NamespaceID,
 		&i.ApiKeyID,
 		&i.OrganizationUserID,
+		&i.PluginID,
 		&i.Created,
 		&i.Retries,
 	)
@@ -198,6 +201,29 @@ func (q *Queries) GetOrganizationUserByID(ctx context.Context, arg GetOrganizati
 		&i.Status,
 		&i.Deleted,
 	)
+	return i, err
+}
+
+const getPluginByID = `-- name: GetPluginByID :one
+SELECT id, organization_id, deleted
+FROM appstore.plugins
+WHERE id = $1
+`
+
+type GetPluginByIDParams struct {
+	ID uuid.UUID
+}
+
+type GetPluginByIDRow struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	Deleted        pgtype.Timestamptz
+}
+
+func (q *Queries) GetPluginByID(ctx context.Context, arg GetPluginByIDParams) (GetPluginByIDRow, error) {
+	row := q.db.QueryRow(ctx, getPluginByID, arg.ID)
+	var i GetPluginByIDRow
+	err := row.Scan(&i.ID, &i.OrganizationID, &i.Deleted)
 	return i, err
 }
 

--- a/authz-worker/pkg/db/queries.sql
+++ b/authz-worker/pkg/db/queries.sql
@@ -10,6 +10,7 @@ SELECT
     namespace_id,
     api_key_id,
     organization_user_id,
+    plugin_id,
     created,
     retries
 FROM authz.outbox
@@ -86,5 +87,10 @@ WHERE id = @id;
 -- name: GetApiKeyByID :one
 SELECT id, organization_id, user_id, expires, revoked, deleted
 FROM authn.api_keys
+WHERE id = @id;
+
+-- name: GetPluginByID :one
+SELECT id, organization_id, deleted
+FROM appstore.plugins
 WHERE id = @id;
 

--- a/authz-worker/pkg/worker/handler/plugin.go
+++ b/authz-worker/pkg/worker/handler/plugin.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	db "github.com/fundament-oss/fundament/authz-worker/pkg/db/gen"
+	"github.com/fundament-oss/fundament/common/authz"
+)
+
+// Plugin syncs a plugin's organization ownership to OpenFGA.
+func (h *Handler) Plugin(ctx context.Context, qtx *db.Queries, pluginID uuid.UUID) error {
+	plugin, err := qtx.GetPluginByID(ctx, db.GetPluginByIDParams{ID: pluginID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("plugin not found: %s", pluginID)
+		}
+
+		return fmt.Errorf("get plugin: %w", err)
+	}
+
+	h.logger.DebugContext(ctx, "handle plugin", "plugin", plugin)
+
+	orgObj := authz.Organization(plugin.OrganizationID)
+	pluginObj := authz.Plugin(plugin.ID)
+
+	if plugin.Deleted.Valid {
+		return h.deleteTuplesIfExist(ctx,
+			tupleDelete(orgObj, authz.ActionOwner, pluginObj),
+		)
+	}
+
+	return h.writeTuplesIfNotExist(ctx, tuple(orgObj, authz.ActionOwner, pluginObj))
+}

--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -366,6 +366,8 @@ func (w *Worker) dispatchItem(ctx context.Context, qtx *db.Queries, item *db.Get
 		return w.handler.Namespace(ctx, qtx, item.NamespaceID.Bytes)
 	case item.ApiKeyID.Valid:
 		return w.handler.ApiKey(ctx, qtx, item.ApiKeyID.Bytes)
+	case item.PluginID.Valid:
+		return w.handler.Plugin(ctx, qtx, item.PluginID.Bytes)
 	default:
 		return fmt.Errorf("unknown outbox subject FK")
 	}

--- a/charts/fundament/openfga/model.fga
+++ b/charts/fundament/openfga/model.fga
@@ -79,7 +79,6 @@ type api_key
 type plugin
   relations
     define owner: [organization]
-    define can_view: viewer from owner or admin from owner
     define can_edit: admin from owner
     define can_delete: admin from owner
 

--- a/charts/fundament/openfga/model.fga
+++ b/charts/fundament/openfga/model.fga
@@ -76,6 +76,13 @@ type api_key
     define can_delete: creator or admin from owner
     define can_use: usable_by
 
+type plugin
+  relations
+    define owner: [organization]
+    define can_view: viewer from owner or admin from owner
+    define can_edit: admin from owner
+    define can_delete: admin from owner
+
 condition is_not_expired(current_time: timestamp, expiration: timestamp) {
   current_time < expiration
 }

--- a/charts/fundament/templates/db-migrations.yaml
+++ b/charts/fundament/templates/db-migrations.yaml
@@ -47,6 +47,8 @@ spec:
             - |
               set -e
               trek apply
+              echo "Seeding system organization..."
+              psql --single-transaction -v ON_ERROR_STOP=1 -f /data/seed/0100-system-org.sql
               echo "Seeding appstore plugin catalog..."
               psql --single-transaction -v ON_ERROR_STOP=1 -f /data/seed/0101-appstore-catalog.sql
               {{- if and $.Values.db.reset $.Values.openfga.enabled }}

--- a/charts/fundament/values-local.yaml
+++ b/charts/fundament/values-local.yaml
@@ -121,6 +121,11 @@ dex:
       hash: "$2y$10$KdEtpACqX8Jh0AYF2n1sfeySkYkG8hRK6Tmn85/VpvaVVPgxL3Hsi"
       username: Grace
       userID: "019b4000-1000-7000-8000-000000000007"
+    # Platform maintainer: admin of the system org (see db/testdata/033_0101-content.sql).
+    - email: platform-admin@fundament.io
+      hash: "$2y$10$KdEtpACqX8Jh0AYF2n1sfeySkYkG8hRK6Tmn85/VpvaVVPgxL3Hsi"
+      username: Platform Admin
+      userID: "019b4000-1000-7000-8000-000000000008"
 
 pluginController:
   enabled: true

--- a/common/authz/types_gen.go
+++ b/common/authz/types_gen.go
@@ -15,6 +15,7 @@ const (
 	ObjectTypeNodePool      ObjectType = "node_pool"
 	ObjectTypeNamespace     ObjectType = "namespace"
 	ObjectTypeApiKey        ObjectType = "api_key"
+	ObjectTypePlugin        ObjectType = "plugin"
 )
 
 // ActionName identifies the operation being performed.
@@ -183,6 +184,14 @@ func Namespace(id uuid.UUID) Object {
 func ApiKey(id uuid.UUID) Object {
 	return Object{
 		Type: ObjectTypeApiKey,
+		ID:   id.String(),
+	}
+}
+
+// Plugin creates an Object of type plugin.
+func Plugin(id uuid.UUID) Object {
+	return Object{
+		Type: ObjectTypePlugin,
 		ID:   id.String(),
 	}
 }

--- a/common/dbconst/constraints.go
+++ b/common/dbconst/constraints.go
@@ -269,6 +269,8 @@ const (
 	ConstraintPluginsCategoriesCategoryId = "plugins_categories_category_id"
 	// ConstraintPluginsCategoriesPluginId is defined on appstore.categories_plugins.
 	ConstraintPluginsCategoriesPluginId = "plugins_categories_plugin_id"
+	// ConstraintPluginsFkOrganization is defined on appstore.plugins.
+	ConstraintPluginsFkOrganization = "plugins_fk_organization"
 	// ConstraintPluginsPresetsPluginId is defined on appstore.preset_plugins.
 	ConstraintPluginsPresetsPluginId = "plugins_presets_plugin_id"
 	// ConstraintPluginsPresetsPresetId is defined on appstore.preset_plugins.

--- a/common/dbversion/version.go
+++ b/common/dbversion/version.go
@@ -1,4 +1,4 @@
 package dbversion
 
 // LatestVersion is the latest version for the db migrations.
-const LatestVersion = 32
+const LatestVersion = 33

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -4624,6 +4624,11 @@ END;]]> </definition>
 	<privileges usage="true"/>
 </permission>
 <permission>
+	<object name="appstore.plugins" type="table"/>
+	<roles names="fun_authz_worker"/>
+	<privileges select="true"/>
+</permission>
+<permission>
 	<object name="tenant.organizations_users" type="table"/>
 	<roles names="fun_authz_worker"/>
 	<privileges select="true"/>

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -1377,10 +1377,6 @@ END;]]> </definition>
 	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 </policy>
 
-<policy name="plugins_delete_owner" table="appstore.plugins" command="DELETE" permissive="true">	<roles names="fun_fundament_api"/>
-	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
-</policy>
-
 <table name="plugin_definitions" layers="0" collapse-mode="2" rls-enabled="true" max-obj-count="7" z-value="0">
 	<schema name="appstore"/>
 	<role name="fun_owner"/>
@@ -1423,10 +1419,6 @@ END;]]> </definition>
 </policy>
 
 <policy name="plugin_definitions_update_owner" table="appstore.plugin_definitions" command="UPDATE" permissive="true">	<roles names="fun_fundament_api"/>
-	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
-</policy>
-
-<policy name="plugin_definitions_delete_owner" table="appstore.plugin_definitions" command="DELETE" permissive="true">	<roles names="fun_fundament_api"/>
 	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
 </policy>
 

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -1313,12 +1313,16 @@ END;]]> </definition>
 	<expression type="using-exp"> <![CDATA[true]]> </expression>
 </policy>
 
-<table name="plugins" layers="0" collapse-mode="1" max-obj-count="13" z-value="0">
+<table name="plugins" layers="0" collapse-mode="1" rls-enabled="true" max-obj-count="13" z-value="0">
 	<schema name="appstore"/>
 	<role name="fun_owner"/>
 	<position x="840" y="1900"/>
 	<column name="id" not-null="true" default-value="uuidv7()">
 		<type name="uuid" length="0"/>
+	</column>
+	<column name="organization_id" not-null="true">
+		<type name="uuid" length="0"/>
+		<comment> <![CDATA[Owning organization. Gates who may publish/edit this plugin (RLS). Catalog visibility is NOT org-scoped — reads stay global.]]> </comment>
 	</column>
 	<column name="name" not-null="true">
 		<type name="text" length="0"/>
@@ -1360,7 +1364,24 @@ END;]]> </definition>
 	</constraint>
 </table>
 
-<table name="plugin_definitions" layers="0" collapse-mode="2" max-obj-count="7" z-value="0">
+<policy name="plugins_select_all" table="appstore.plugins" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="plugins_insert_owner" table="appstore.plugins" command="INSERT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+</policy>
+
+<policy name="plugins_update_owner" table="appstore.plugins" command="UPDATE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+</policy>
+
+<policy name="plugins_delete_owner" table="appstore.plugins" command="DELETE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+</policy>
+
+<table name="plugin_definitions" layers="0" collapse-mode="2" rls-enabled="true" max-obj-count="7" z-value="0">
 	<schema name="appstore"/>
 	<role name="fun_owner"/>
 	<position x="840" y="1620"/>
@@ -1392,6 +1413,22 @@ END;]]> </definition>
 		<columns names="id" ref-type="src-columns"/>
 	</constraint>
 </table>
+
+<policy name="plugin_definitions_select_all" table="appstore.plugin_definitions" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="plugin_definitions_insert_owner" table="appstore.plugin_definitions" command="INSERT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_definitions_update_owner" table="appstore.plugin_definitions" command="UPDATE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_definitions_delete_owner" table="appstore.plugin_definitions" command="DELETE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
 
 <table name="presets" layers="0" collapse-mode="1" max-obj-count="3" z-value="0">
 	<schema name="appstore"/>
@@ -1870,6 +1907,9 @@ END;]]> </definition>
 	<column name="organization_user_id">
 		<type name="uuid" length="0"/>
 	</column>
+	<column name="plugin_id">
+		<type name="uuid" length="0"/>
+	</column>
 	<column name="created" not-null="true" default-value="now()">
 		<type name="timestamptz" length="0"/>
 	</column>
@@ -1902,7 +1942,8 @@ END;]]> </definition>
 	node_pool_id,
 	namespace_id,
 	api_key_id,
-	organization_user_id
+	organization_user_id,
+	plugin_id
 ) = 1]]> </expression>
 	</constraint>
 	<constraint name="outbox_ck_status" type="ck-constr" table="authz.outbox">
@@ -2069,6 +2110,31 @@ END;]]> </definition>
 END;]]> </definition>
 </function>
 
+<function name="plugins_sync_trigger"
+		window-func="false"
+		returns-setof="false"
+		behavior-type="CALLED ON NULL INPUT"
+		function-type="VOLATILE"
+		security-type="SECURITY INVOKER"
+		parallel-type="PARALLEL UNSAFE"
+		execution-cost="1"
+		row-amount="0">
+	<schema name="authz"/>
+	<role name="fun_owner"/>
+	<language name="plpgsql"/>
+	<return-type>
+	<type name="trigger" length="0"/>
+	</return-type>
+	<definition> <![CDATA[BEGIN
+    -- Only insert into outbox if this is an INSERT, DELETE, or if data actually changed
+    IF TG_OP = 'INSERT' OR NEW IS DISTINCT FROM OLD THEN
+        INSERT INTO authz.outbox (plugin_id)
+        VALUES (COALESCE(NEW.id, OLD.id));
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;]]> </definition>
+</function>
+
 <function name="organizations_users_sync_trigger"
 		window-func="false"
 		returns-setof="false"
@@ -2190,6 +2256,12 @@ END;]]> </definition>
 	 ins-event="true" del-event="false" upd-event="true" trunc-event="false"
 	 table="authn.api_keys">
 		<function signature="authz.api_keys_sync_trigger()"/>
+</trigger>
+
+<trigger name="plugins_outbox" firing-type="AFTER" per-line="true" constraint="false"
+	 ins-event="true" del-event="false" upd-event="true" trunc-event="false"
+	 table="appstore.plugins">
+		<function signature="authz.plugins_sync_trigger()"/>
 </trigger>
 
 <trigger name="outbox_notify" firing-type="AFTER" per-line="true" constraint="false"
@@ -3239,6 +3311,12 @@ END;]]> </definition>
 	<columns names="id" ref-type="dst-columns"/>
 </constraint>
 
+<constraint name="plugins_fk_organization" type="fk-constr" comparison-type="MATCH SIMPLE"
+	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="tenant.organizations" table="appstore.plugins">
+	<columns names="organization_id" ref-type="src-columns"/>
+	<columns names="id" ref-type="dst-columns"/>
+</constraint>
+
 <constraint name="api_keys_fk_user" type="fk-constr" comparison-type="MATCH SIMPLE"
 	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="tenant.users" table="authn.api_keys">
 	<columns names="user_id" ref-type="src-columns"/>
@@ -3798,6 +3876,11 @@ END;]]> </definition>
 	 custom-color="#f0f0f0"
 	 src-table="authn.api_keys"
 	 dst-table="tenant.organizations" reference-fk="api_keys_fk_organization"
+	 src-required="false" dst-required="true"/>
+
+<relationship name="rel_plugins_organizations" type="relfk" layers="0"
+	 src-table="appstore.plugins"
+	 dst-table="tenant.organizations" reference-fk="plugins_fk_organization"
 	 src-required="false" dst-required="true"/>
 
 <relationship name="rel_api_keys_users" type="relfk" layers="0"

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1111,15 +1111,6 @@ CREATE POLICY plugins_update_owner ON appstore.plugins
 	WITH CHECK (organization_id = authn.current_organization_id());
 -- ddl-end --
 
--- object: plugins_delete_owner | type: POLICY --
--- DROP POLICY IF EXISTS plugins_delete_owner ON appstore.plugins CASCADE;
-CREATE POLICY plugins_delete_owner ON appstore.plugins
-	AS PERMISSIVE
-	FOR DELETE
-	TO fun_fundament_api
-	USING (organization_id = authn.current_organization_id());
--- ddl-end --
-
 -- object: appstore.plugin_definitions | type: TABLE --
 -- DROP TABLE IF EXISTS appstore.plugin_definitions CASCADE;
 CREATE TABLE appstore.plugin_definitions (
@@ -1162,15 +1153,6 @@ CREATE POLICY plugin_definitions_insert_owner ON appstore.plugin_definitions
 CREATE POLICY plugin_definitions_update_owner ON appstore.plugin_definitions
 	AS PERMISSIVE
 	FOR UPDATE
-	TO fun_fundament_api
-	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
--- ddl-end --
-
--- object: plugin_definitions_delete_owner | type: POLICY --
--- DROP POLICY IF EXISTS plugin_definitions_delete_owner ON appstore.plugin_definitions CASCADE;
-CREATE POLICY plugin_definitions_delete_owner ON appstore.plugin_definitions
-	AS PERMISSIVE
-	FOR DELETE
 	TO fun_fundament_api
 	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
 -- ddl-end --
@@ -3796,6 +3778,14 @@ GRANT SELECT
 -- object: "grant_U_19fbeed564" | type: PERMISSION --
 GRANT USAGE
    ON SCHEMA appstore
+   TO fun_authz_worker;
+
+-- ddl-end --
+
+
+-- object: grant_r_1e94bded2d | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.plugins
    TO fun_authz_worker;
 
 -- ddl-end --

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1057,6 +1057,7 @@ CREATE POLICY node_pools_cluster_worker_read ON tenant.node_pools
 -- DROP TABLE IF EXISTS appstore.plugins CASCADE;
 CREATE TABLE appstore.plugins (
 	id uuid NOT NULL DEFAULT uuidv7(),
+	organization_id uuid NOT NULL,
 	name text NOT NULL,
 	display_name text NOT NULL DEFAULT '',
 	description_short text NOT NULL DEFAULT '',
@@ -1071,11 +1072,52 @@ CREATE TABLE appstore.plugins (
 	CONSTRAINT plugins_pk PRIMARY KEY (id)
 );
 -- ddl-end --
+COMMENT ON COLUMN appstore.plugins.organization_id IS E'Owning organization. Gates who may publish/edit this plugin (RLS). Catalog visibility is NOT org-scoped — reads stay global.';
+-- ddl-end --
 COMMENT ON COLUMN appstore.plugins.name IS E'Stable identifier, matching the plugin''s definition.yaml metadata.name (e.g. "openfsc"). Used as the PluginInstallation resource name in the cluster — not for display.';
 -- ddl-end --
 COMMENT ON COLUMN appstore.plugins.display_name IS E'Human-readable name shown in the Console, matching the plugin''s definition.yaml metadata.displayName (e.g. "OpenFSC").';
 -- ddl-end --
 ALTER TABLE appstore.plugins OWNER TO fun_owner;
+-- ddl-end --
+ALTER TABLE appstore.plugins ENABLE ROW LEVEL SECURITY;
+-- ddl-end --
+
+-- object: plugins_select_all | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_select_all ON appstore.plugins CASCADE;
+CREATE POLICY plugins_select_all ON appstore.plugins
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (true);
+-- ddl-end --
+
+-- object: plugins_insert_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_insert_owner ON appstore.plugins CASCADE;
+CREATE POLICY plugins_insert_owner ON appstore.plugins
+	AS PERMISSIVE
+	FOR INSERT
+	TO fun_fundament_api
+	WITH CHECK (organization_id = authn.current_organization_id());
+-- ddl-end --
+
+-- object: plugins_update_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_update_owner ON appstore.plugins CASCADE;
+CREATE POLICY plugins_update_owner ON appstore.plugins
+	AS PERMISSIVE
+	FOR UPDATE
+	TO fun_fundament_api
+	USING (organization_id = authn.current_organization_id())
+	WITH CHECK (organization_id = authn.current_organization_id());
+-- ddl-end --
+
+-- object: plugins_delete_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_delete_owner ON appstore.plugins CASCADE;
+CREATE POLICY plugins_delete_owner ON appstore.plugins
+	AS PERMISSIVE
+	FOR DELETE
+	TO fun_fundament_api
+	USING (organization_id = authn.current_organization_id());
 -- ddl-end --
 
 -- object: appstore.plugin_definitions | type: TABLE --
@@ -1093,6 +1135,44 @@ CREATE TABLE appstore.plugin_definitions (
 );
 -- ddl-end --
 ALTER TABLE appstore.plugin_definitions OWNER TO fun_owner;
+-- ddl-end --
+ALTER TABLE appstore.plugin_definitions ENABLE ROW LEVEL SECURITY;
+-- ddl-end --
+
+-- object: plugin_definitions_select_all | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_select_all ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_select_all ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (true);
+-- ddl-end --
+
+-- object: plugin_definitions_insert_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_insert_owner ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_insert_owner ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR INSERT
+	TO fun_fundament_api
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_definitions_update_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_update_owner ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_update_owner ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR UPDATE
+	TO fun_fundament_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_definitions_delete_owner | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_delete_owner ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_delete_owner ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR DELETE
+	TO fun_fundament_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
 -- ddl-end --
 
 -- object: appstore.presets | type: TABLE --
@@ -1527,6 +1607,7 @@ CREATE TABLE authz.outbox (
 	namespace_id uuid,
 	api_key_id uuid,
 	organization_user_id uuid,
+	plugin_id uuid,
 	created timestamptz NOT NULL DEFAULT now(),
 	processed timestamptz,
 	retries integer NOT NULL DEFAULT 0,
@@ -1542,7 +1623,8 @@ CREATE TABLE authz.outbox (
 	node_pool_id,
 	namespace_id,
 	api_key_id,
-	organization_user_id
+	organization_user_id,
+	plugin_id
 ) = 1),
 	CONSTRAINT outbox_ck_status CHECK (status IN ('pending', 'completed', 'retrying', 'failed'))
 );
@@ -1710,6 +1792,31 @@ $function$;
 ALTER FUNCTION authz.api_keys_sync_trigger() OWNER TO fun_owner;
 -- ddl-end --
 
+-- object: authz.plugins_sync_trigger | type: FUNCTION --
+-- DROP FUNCTION IF EXISTS authz.plugins_sync_trigger() CASCADE;
+CREATE OR REPLACE FUNCTION authz.plugins_sync_trigger ()
+	RETURNS trigger
+	LANGUAGE plpgsql
+	VOLATILE 
+	CALLED ON NULL INPUT
+	SECURITY INVOKER
+	PARALLEL UNSAFE
+	COST 1
+	AS 
+$function$
+BEGIN
+    -- Only insert into outbox if this is an INSERT, DELETE, or if data actually changed
+    IF TG_OP = 'INSERT' OR NEW IS DISTINCT FROM OLD THEN
+        INSERT INTO authz.outbox (plugin_id)
+        VALUES (COALESCE(NEW.id, OLD.id));
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+-- ddl-end --
+ALTER FUNCTION authz.plugins_sync_trigger() OWNER TO fun_owner;
+-- ddl-end --
+
 -- object: authz.organizations_users_sync_trigger | type: FUNCTION --
 -- DROP FUNCTION IF EXISTS authz.organizations_users_sync_trigger() CASCADE;
 CREATE OR REPLACE FUNCTION authz.organizations_users_sync_trigger ()
@@ -1864,6 +1971,15 @@ CREATE OR REPLACE TRIGGER api_keys_outbox
 	ON authn.api_keys
 	FOR EACH ROW
 	EXECUTE PROCEDURE authz.api_keys_sync_trigger();
+-- ddl-end --
+
+-- object: plugins_outbox | type: TRIGGER --
+-- DROP TRIGGER IF EXISTS plugins_outbox ON appstore.plugins CASCADE;
+CREATE OR REPLACE TRIGGER plugins_outbox
+	AFTER INSERT OR UPDATE
+	ON appstore.plugins
+	FOR EACH ROW
+	EXECUTE PROCEDURE authz.plugins_sync_trigger();
 -- ddl-end --
 
 -- object: outbox_notify | type: TRIGGER --
@@ -2613,6 +2729,13 @@ ON DELETE RESTRICT ON UPDATE CASCADE;
 -- ALTER TABLE tenant.node_pools DROP CONSTRAINT IF EXISTS node_pools_fk_cluster CASCADE;
 ALTER TABLE tenant.node_pools ADD CONSTRAINT node_pools_fk_cluster FOREIGN KEY (cluster_id)
 REFERENCES tenant.clusters (id) MATCH SIMPLE
+ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ddl-end --
+
+-- object: plugins_fk_organization | type: CONSTRAINT --
+-- ALTER TABLE appstore.plugins DROP CONSTRAINT IF EXISTS plugins_fk_organization CASCADE;
+ALTER TABLE appstore.plugins ADD CONSTRAINT plugins_fk_organization FOREIGN KEY (organization_id)
+REFERENCES tenant.organizations (id) MATCH SIMPLE
 ON DELETE NO ACTION ON UPDATE NO ACTION;
 -- ddl-end --
 

--- a/db/migrations/033_org-owned-plugins.up.sql
+++ b/db/migrations/033_org-owned-plugins.up.sql
@@ -1,0 +1,128 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+-- System organization owns first-party (seeded) plugins. Idempotent; the same
+-- fixed UUID is (re)asserted by db/seed/0100-system-org.sql for fresh installs.
+INSERT INTO "tenant"."organizations" ("id", "name", "alias")
+VALUES ('019b4000-1000-7000-8000-000000000001', 'system', 'System')
+ON CONFLICT ("id") DO NOTHING;
+
+-- Add the owner column nullable first so existing rows can be backfilled.
+ALTER TABLE "appstore"."plugins" ADD COLUMN "organization_id" uuid;
+
+COMMENT ON COLUMN "appstore"."plugins"."organization_id" IS E'Owning organization. Gates who may publish/edit this plugin (RLS). Catalog visibility is NOT org-scoped — reads stay global.';
+
+-- Backfill existing plugins to the system organization.
+UPDATE "appstore"."plugins"
+SET "organization_id" = '019b4000-1000-7000-8000-000000000001'
+WHERE "organization_id" IS NULL;
+
+-- Enforce NOT NULL and the FK now that every row has an owner.
+ALTER TABLE "appstore"."plugins" ALTER COLUMN "organization_id" SET NOT NULL;
+
+ALTER TABLE "appstore"."plugins" ADD CONSTRAINT "plugins_fk_organization" FOREIGN KEY ("organization_id") REFERENCES "tenant"."organizations"("id") MATCH SIMPLE ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- RLS on appstore.plugins: catalog reads stay GLOBAL (SELECT USING (true));
+-- writes are gated to the owning organization. The UPDATE WITH CHECK also
+-- prevents reassigning a plugin to another org (no ownership transfer).
+CREATE POLICY "plugins_select_all" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (true);
+
+CREATE POLICY "plugins_insert_owner" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR INSERT
+	TO fun_fundament_api
+	WITH CHECK ((organization_id = authn.current_organization_id()));
+
+CREATE POLICY "plugins_update_owner" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR UPDATE
+	TO fun_fundament_api
+	USING ((organization_id = authn.current_organization_id()))
+	WITH CHECK ((organization_id = authn.current_organization_id()));
+
+CREATE POLICY "plugins_delete_owner" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR DELETE
+	TO fun_fundament_api
+	USING ((organization_id = authn.current_organization_id()));
+
+ALTER TABLE "appstore"."plugins" ENABLE ROW LEVEL SECURITY;
+
+-- RLS on appstore.plugin_definitions: ownership lives on the parent plugins
+-- row, so writes are gated by the parent's organization_id (no aliases).
+CREATE POLICY "plugin_definitions_select_all" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (true);
+
+CREATE POLICY "plugin_definitions_insert_owner" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR INSERT
+	TO fun_fundament_api
+	WITH CHECK ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
+
+CREATE POLICY "plugin_definitions_update_owner" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR UPDATE
+	TO fun_fundament_api
+	USING ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
+
+CREATE POLICY "plugin_definitions_delete_owner" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR DELETE
+	TO fun_fundament_api
+	USING ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
+
+ALTER TABLE "appstore"."plugin_definitions" ENABLE ROW LEVEL SECURITY;
+
+-- OpenFGA authorization: sync plugin ownership (plugin owner organization) to
+-- OpenFGA via the authz.outbox pipeline. A trigger on appstore.plugins enqueues
+-- an outbox row on insert/update; the authz-worker writes the tuple. Because it
+-- is a trigger, the seeded catalog plugins enqueue automatically.
+ALTER TABLE "authz"."outbox" ADD COLUMN "plugin_id" uuid;
+
+ALTER TABLE "authz"."outbox" DROP CONSTRAINT "outbox_ck_single_fk";
+
+ALTER TABLE "authz"."outbox" ADD CONSTRAINT "outbox_ck_single_fk" CHECK (num_nonnulls(
+	project_id,
+	project_member_id,
+	cluster_id,
+	node_pool_id,
+	namespace_id,
+	api_key_id,
+	organization_user_id,
+	plugin_id
+) = 1);
+
+CREATE OR REPLACE FUNCTION authz.plugins_sync_trigger ()
+	RETURNS trigger
+	LANGUAGE plpgsql
+	VOLATILE
+	CALLED ON NULL INPUT
+	SECURITY INVOKER
+	PARALLEL UNSAFE
+	COST 1
+	AS
+$function$
+BEGIN
+    -- Only insert into outbox if this is an INSERT, DELETE, or if data actually changed
+    IF TG_OP = 'INSERT' OR NEW IS DISTINCT FROM OLD THEN
+        INSERT INTO authz.outbox (plugin_id)
+        VALUES (COALESCE(NEW.id, OLD.id));
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+
+ALTER FUNCTION authz.plugins_sync_trigger() OWNER TO fun_owner;
+
+CREATE OR REPLACE TRIGGER plugins_outbox
+	AFTER INSERT OR UPDATE
+	ON appstore.plugins
+	FOR EACH ROW
+	EXECUTE PROCEDURE authz.plugins_sync_trigger();

--- a/db/migrations/033_org-owned-plugins.up.sql
+++ b/db/migrations/033_org-owned-plugins.up.sql
@@ -4,7 +4,7 @@ SET SESSION lock_timeout = 3000;
 -- System organization owns first-party (seeded) plugins. Idempotent; the same
 -- fixed UUID is (re)asserted by db/seed/0100-system-org.sql for fresh installs.
 INSERT INTO "tenant"."organizations" ("id", "name", "alias")
-VALUES ('019b4000-1000-7000-8000-000000000001', 'system', 'System')
+VALUES ('019b4000-0000-7000-8000-000000000000', 'system', 'System')
 ON CONFLICT ("id") DO NOTHING;
 
 -- Add the owner column nullable first so existing rows can be backfilled.
@@ -68,7 +68,7 @@ CREATE OR REPLACE TRIGGER plugins_outbox
 -- empty here (seeded afterwards), so this is a no-op and the 0101 seed INSERTs
 -- enqueue via the trigger instead.
 UPDATE "appstore"."plugins"
-SET "organization_id" = '019b4000-1000-7000-8000-000000000001'
+SET "organization_id" = '019b4000-0000-7000-8000-000000000000'
 WHERE "organization_id" IS NULL;
 
 -- Enforce NOT NULL and the FK now that every row has an owner.
@@ -79,6 +79,8 @@ ALTER TABLE "appstore"."plugins" ADD CONSTRAINT "plugins_fk_organization" FOREIG
 -- RLS on appstore.plugins: catalog reads stay GLOBAL (SELECT USING (true));
 -- writes are gated to the owning organization. The UPDATE WITH CHECK also
 -- prevents reassigning a plugin to another org (no ownership transfer).
+-- No DELETE policy on either table: fun_fundament_api has no DELETE grant and
+-- the project soft-deletes throughout.
 CREATE POLICY "plugins_select_all" ON "appstore"."plugins"
 	AS PERMISSIVE
 	FOR SELECT
@@ -97,12 +99,6 @@ CREATE POLICY "plugins_update_owner" ON "appstore"."plugins"
 	TO fun_fundament_api
 	USING ((organization_id = authn.current_organization_id()))
 	WITH CHECK ((organization_id = authn.current_organization_id()));
-
-CREATE POLICY "plugins_delete_owner" ON "appstore"."plugins"
-	AS PERMISSIVE
-	FOR DELETE
-	TO fun_fundament_api
-	USING ((organization_id = authn.current_organization_id()));
 
 ALTER TABLE "appstore"."plugins" ENABLE ROW LEVEL SECURITY;
 
@@ -129,12 +125,6 @@ CREATE POLICY "plugin_definitions_insert_owner" ON "appstore"."plugin_definition
 CREATE POLICY "plugin_definitions_update_owner" ON "appstore"."plugin_definitions"
 	AS PERMISSIVE
 	FOR UPDATE
-	TO fun_fundament_api
-	USING ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
-
-CREATE POLICY "plugin_definitions_delete_owner" ON "appstore"."plugin_definitions"
-	AS PERMISSIVE
-	FOR DELETE
 	TO fun_fundament_api
 	USING ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
 

--- a/db/migrations/033_org-owned-plugins.up.sql
+++ b/db/migrations/033_org-owned-plugins.up.sql
@@ -52,6 +52,12 @@ CREATE POLICY "plugins_delete_owner" ON "appstore"."plugins"
 
 ALTER TABLE "appstore"."plugins" ENABLE ROW LEVEL SECURITY;
 
+-- authz-worker reads appstore.plugins (GetPluginByID) to sync ownership to
+-- OpenFGA. It already has USAGE on the appstore schema; grant table SELECT too.
+-- Row visibility relies on fun_authz_worker's BYPASSRLS attribute (same as every
+-- other RLS table it reads), so no per-worker policy is needed.
+GRANT SELECT ON TABLE "appstore"."plugins" TO fun_authz_worker;
+
 -- RLS on appstore.plugin_definitions: ownership lives on the parent plugins
 -- row, so writes are gated by the parent's organization_id (no aliases).
 CREATE POLICY "plugin_definitions_select_all" ON "appstore"."plugin_definitions"

--- a/db/migrations/033_org-owned-plugins.up.sql
+++ b/db/migrations/033_org-owned-plugins.up.sql
@@ -12,7 +12,61 @@ ALTER TABLE "appstore"."plugins" ADD COLUMN "organization_id" uuid;
 
 COMMENT ON COLUMN "appstore"."plugins"."organization_id" IS E'Owning organization. Gates who may publish/edit this plugin (RLS). Catalog visibility is NOT org-scoped — reads stay global.';
 
--- Backfill existing plugins to the system organization.
+-- OpenFGA authorization: sync plugin ownership to OpenFGA via the authz.outbox
+-- pipeline. A trigger on appstore.plugins enqueues an outbox row on insert/update;
+-- the authz-worker writes the organization -> owner -> plugin tuple. Created
+-- BEFORE the ownership backfill below on purpose: the backfill UPDATE then
+-- enqueues every pre-existing plugin through this single canonical path, and on
+-- fresh installs the 0101 catalog seed's INSERTs do the same — so no separate
+-- backfill INSERT into authz.outbox is needed.
+ALTER TABLE "authz"."outbox" ADD COLUMN "plugin_id" uuid;
+
+ALTER TABLE "authz"."outbox" DROP CONSTRAINT "outbox_ck_single_fk";
+
+ALTER TABLE "authz"."outbox" ADD CONSTRAINT "outbox_ck_single_fk" CHECK (num_nonnulls(
+	project_id,
+	project_member_id,
+	cluster_id,
+	node_pool_id,
+	namespace_id,
+	api_key_id,
+	organization_user_id,
+	plugin_id
+) = 1);
+
+CREATE OR REPLACE FUNCTION authz.plugins_sync_trigger ()
+	RETURNS trigger
+	LANGUAGE plpgsql
+	VOLATILE
+	CALLED ON NULL INPUT
+	SECURITY INVOKER
+	PARALLEL UNSAFE
+	COST 1
+	AS
+$function$
+BEGIN
+    -- Only insert into outbox if this is an INSERT, DELETE, or if data actually changed
+    IF TG_OP = 'INSERT' OR NEW IS DISTINCT FROM OLD THEN
+        INSERT INTO authz.outbox (plugin_id)
+        VALUES (COALESCE(NEW.id, OLD.id));
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+
+ALTER FUNCTION authz.plugins_sync_trigger() OWNER TO fun_owner;
+
+CREATE OR REPLACE TRIGGER plugins_outbox
+	AFTER INSERT OR UPDATE
+	ON appstore.plugins
+	FOR EACH ROW
+	EXECUTE PROCEDURE authz.plugins_sync_trigger();
+
+-- Backfill existing plugins to the system organization. With the trigger above
+-- already in place, this UPDATE enqueues an authz.outbox row for every plugin
+-- that predates org ownership. On a fresh database appstore.plugins is still
+-- empty here (seeded afterwards), so this is a no-op and the 0101 seed INSERTs
+-- enqueue via the trigger instead.
 UPDATE "appstore"."plugins"
 SET "organization_id" = '019b4000-1000-7000-8000-000000000001'
 WHERE "organization_id" IS NULL;
@@ -85,61 +139,3 @@ CREATE POLICY "plugin_definitions_delete_owner" ON "appstore"."plugin_definition
 	USING ((EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())));
 
 ALTER TABLE "appstore"."plugin_definitions" ENABLE ROW LEVEL SECURITY;
-
--- OpenFGA authorization: sync plugin ownership (plugin owner organization) to
--- OpenFGA via the authz.outbox pipeline. A trigger on appstore.plugins enqueues
--- an outbox row on insert/update; the authz-worker writes the tuple. Because it
--- is a trigger, the seeded catalog plugins enqueue automatically.
-ALTER TABLE "authz"."outbox" ADD COLUMN "plugin_id" uuid;
-
-ALTER TABLE "authz"."outbox" DROP CONSTRAINT "outbox_ck_single_fk";
-
-ALTER TABLE "authz"."outbox" ADD CONSTRAINT "outbox_ck_single_fk" CHECK (num_nonnulls(
-	project_id,
-	project_member_id,
-	cluster_id,
-	node_pool_id,
-	namespace_id,
-	api_key_id,
-	organization_user_id,
-	plugin_id
-) = 1);
-
-CREATE OR REPLACE FUNCTION authz.plugins_sync_trigger ()
-	RETURNS trigger
-	LANGUAGE plpgsql
-	VOLATILE
-	CALLED ON NULL INPUT
-	SECURITY INVOKER
-	PARALLEL UNSAFE
-	COST 1
-	AS
-$function$
-BEGIN
-    -- Only insert into outbox if this is an INSERT, DELETE, or if data actually changed
-    IF TG_OP = 'INSERT' OR NEW IS DISTINCT FROM OLD THEN
-        INSERT INTO authz.outbox (plugin_id)
-        VALUES (COALESCE(NEW.id, OLD.id));
-    END IF;
-    RETURN COALESCE(NEW, OLD);
-END;
-$function$;
-
-ALTER FUNCTION authz.plugins_sync_trigger() OWNER TO fun_owner;
-
-CREATE OR REPLACE TRIGGER plugins_outbox
-	AFTER INSERT OR UPDATE
-	ON appstore.plugins
-	FOR EACH ROW
-	EXECUTE PROCEDURE authz.plugins_sync_trigger();
-
--- Enqueue an authz sync for every existing plugin. The backfill UPDATE above
--- ran before this trigger existed, so it emitted no outbox rows, and the
--- 0101 catalog seed's ON CONFLICT DO UPDATE is a no-op for these unchanged
--- rows (so the trigger's NEW IS DISTINCT FROM OLD guard suppresses it there
--- too). Without this, plugins that predate org ownership never get their
--- organization -> owner -> plugin tuple in OpenFGA. Runs once with the
--- migration; on a fresh database appstore.plugins is still empty here (seeded
--- afterwards) so this is a no-op and the trigger handles the seed INSERTs.
-INSERT INTO authz.outbox (plugin_id)
-SELECT id FROM appstore.plugins;

--- a/db/migrations/033_org-owned-plugins.up.sql
+++ b/db/migrations/033_org-owned-plugins.up.sql
@@ -132,3 +132,14 @@ CREATE OR REPLACE TRIGGER plugins_outbox
 	ON appstore.plugins
 	FOR EACH ROW
 	EXECUTE PROCEDURE authz.plugins_sync_trigger();
+
+-- Enqueue an authz sync for every existing plugin. The backfill UPDATE above
+-- ran before this trigger existed, so it emitted no outbox rows, and the
+-- 0101 catalog seed's ON CONFLICT DO UPDATE is a no-op for these unchanged
+-- rows (so the trigger's NEW IS DISTINCT FROM OLD guard suppresses it there
+-- too). Without this, plugins that predate org ownership never get their
+-- organization -> owner -> plugin tuple in OpenFGA. Runs once with the
+-- migration; on a fresh database appstore.plugins is still empty here (seeded
+-- afterwards) so this is a no-op and the trigger handles the seed INSERTs.
+INSERT INTO authz.outbox (plugin_id)
+SELECT id FROM appstore.plugins;

--- a/db/seed/0100-system-org.sql
+++ b/db/seed/0100-system-org.sql
@@ -6,5 +6,5 @@
 -- users never see it while the plugins it owns stay globally visible.
 
 INSERT INTO tenant.organizations (id, name, alias) VALUES
-    ('019b4000-1000-7000-8000-000000000001', 'system', 'System')
+    ('019b4000-0000-7000-8000-000000000000', 'system', 'System')
 ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, alias = EXCLUDED.alias;

--- a/db/seed/0100-system-org.sql
+++ b/db/seed/0100-system-org.sql
@@ -1,0 +1,10 @@
+-- System organization — owns first-party (seeded) plugins.
+--
+-- Applied in ALL environments (incl. production) by the db-migrations Job before
+-- the appstore catalog seed, so appstore.plugins.organization_id FK resolves.
+-- Idempotent upsert keyed on the stable UUID below; has no members, so normal
+-- users never see it while the plugins it owns stay globally visible.
+
+INSERT INTO tenant.organizations (id, name, alias) VALUES
+    ('019b4000-1000-7000-8000-000000000001', 'system', 'System')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, alias = EXCLUDED.alias;

--- a/db/seed/0101-appstore-catalog.sql
+++ b/db/seed/0101-appstore-catalog.sql
@@ -276,7 +276,7 @@ OpenFSC brings Federated Service Connectivity (FSC) to Kubernetes. It installs t
 - Inter-organization service connectivity
 - Common Ground / data exchange between government bodies
 - Federated APIs across trust domains', 'Fundament', 'https://fsc-standaard.nl', 'https://gitlab.com/rinis-oss/fsc/open-fsc', ''),
-    ('019b4000-3000-7000-8000-000000000010', 'gateway-api-envoy', 'Gateway API (Envoy Gateway)', 'Gateway API implementation powered by Envoy Gateway', '## Overview
+    ('019b4000-3000-7000-8000-000000000010', '019b4000-1000-7000-8000-000000000001', 'gateway-api-envoy', 'Gateway API (Envoy Gateway)', 'Gateway API implementation powered by Envoy Gateway', '## Overview
 
 The Gateway API plugin powered by Envoy Gateway installs the Envoy Gateway control plane and manages Gateways, HTTPRoutes, GRPCRoutes, TCPRoutes, TLSRoutes, and Envoy Gateway policies.
 

--- a/db/seed/0101-appstore-catalog.sql
+++ b/db/seed/0101-appstore-catalog.sql
@@ -42,7 +42,7 @@ ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
 
 -- Plugins
 INSERT INTO appstore.plugins (id, organization_id, name, display_name, description_short, description, author_name, author_url, repository_url, image) VALUES
-    ('019b4000-3000-7000-8000-000000000001', '019b4000-1000-7000-8000-000000000001', 'grafana-alloy', 'Grafana Alloy', 'OpenTelemetry Collector distribution', '## Overview
+    ('019b4000-3000-7000-8000-000000000001', '019b4000-0000-7000-8000-000000000000', 'grafana-alloy', 'Grafana Alloy', 'OpenTelemetry Collector distribution', '## Overview
 
 Grafana Alloy is a flexible, high-performance OpenTelemetry Collector distribution with native Prometheus support.
 
@@ -58,7 +58,7 @@ Grafana Alloy is a flexible, high-performance OpenTelemetry Collector distributi
 - Unified telemetry collection for metrics, logs, and traces
 - Prometheus metrics collection and forwarding
 - OpenTelemetry instrumentation aggregation', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/alloy', 'docker.io/grafana/alloy:v1.8.3'),
-    ('019b4000-3000-7000-8000-000000000002', '019b4000-1000-7000-8000-000000000001', 'cert-manager', 'cert-manager', 'Automatic TLS certificate management', '## Overview
+    ('019b4000-3000-7000-8000-000000000002', '019b4000-0000-7000-8000-000000000000', 'cert-manager', 'cert-manager', 'Automatic TLS certificate management', '## Overview
 
 cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.
 
@@ -79,7 +79,7 @@ cert-manager adds certificates and certificate issuers as resource types in Kube
     -- prose name "CloudNativePG" to "cloudnativepg". Any cluster already running this
     -- plugin has a CR under that name, so changing it here would orphan the installation
     -- (the Console would show it as not installed and create a second CR on re-install).
-    ('019b4000-3000-7000-8000-000000000003', '019b4000-1000-7000-8000-000000000001', 'cloudnativepg', 'CloudNativePG', 'PostgreSQL operator for Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000003', '019b4000-0000-7000-8000-000000000000', 'cloudnativepg', 'CloudNativePG', 'PostgreSQL operator for Kubernetes', '## Overview
 
 CloudNativePG is an open source operator designed to manage PostgreSQL workloads on Kubernetes, covering the full lifecycle of a PostgreSQL cluster.
 
@@ -95,7 +95,7 @@ CloudNativePG is an open source operator designed to manage PostgreSQL workloads
 - Production PostgreSQL databases on Kubernetes
 - Database-as-a-Service platforms
 - Microservices requiring relational databases', 'CloudNativePG Contributors', 'https://cloudnative-pg.io', 'https://github.com/cloudnative-pg/cloudnative-pg', 'ghcr.io/cloudnative-pg/cloudnative-pg:v1.25.1'),
-    ('019b4000-3000-7000-8000-000000000004', '019b4000-1000-7000-8000-000000000001', 'eck-operator', 'ECK operator', 'Elasticsearch and Kibana on Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000004', '019b4000-0000-7000-8000-000000000000', 'eck-operator', 'ECK operator', 'Elasticsearch and Kibana on Kubernetes', '## Overview
 
 Elastic Cloud on Kubernetes (ECK) automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, and the Elastic Stack on Kubernetes.
 
@@ -111,7 +111,7 @@ Elastic Cloud on Kubernetes (ECK) automates the deployment, provisioning, manage
 - Log aggregation and analysis
 - Application performance monitoring
 - Full-text search infrastructure', 'Elastic', 'https://www.elastic.co', 'https://github.com/elastic/cloud-on-k8s', 'docker.elastic.co/eck/eck-operator:2.16.0'),
-    ('019b4000-3000-7000-8000-000000000005', '019b4000-1000-7000-8000-000000000001', 'grafana', 'Grafana', 'Metrics visualization and alerting', '## Overview
+    ('019b4000-3000-7000-8000-000000000005', '019b4000-0000-7000-8000-000000000000', 'grafana', 'Grafana', 'Metrics visualization and alerting', '## Overview
 
 Grafana is the open source analytics and monitoring solution for every database. It allows you to query, visualize, alert on and understand your metrics no matter where they are stored.
 
@@ -128,7 +128,7 @@ Grafana is the open source analytics and monitoring solution for every database.
 - Application performance monitoring
 - Business analytics
 - IoT data visualization', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/grafana', 'docker.io/grafana/grafana:11.6.0'),
-    ('019b4000-3000-7000-8000-000000000006', '019b4000-1000-7000-8000-000000000001', 'istio-gateway', 'Istio Gateway', 'Ingress gateway for service mesh', '## Overview
+    ('019b4000-3000-7000-8000-000000000006', '019b4000-0000-7000-8000-000000000000', 'istio-gateway', 'Istio Gateway', 'Ingress gateway for service mesh', '## Overview
 
 Istio Gateway provides a dedicated ingress gateway for managing inbound traffic to your service mesh, offering advanced traffic management and security features.
 
@@ -144,7 +144,7 @@ Istio Gateway provides a dedicated ingress gateway for managing inbound traffic 
 - API gateway for microservices
 - Multi-cluster ingress
 - Canary deployments and A/B testing', 'Istio Authors', 'https://istio.io', 'https://github.com/istio/istio', 'docker.io/istio/pilot:1.24.3'),
-    ('019b4000-3000-7000-8000-000000000007', '019b4000-1000-7000-8000-000000000001', 'istio', 'Istio', 'Service mesh for Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000007', '019b4000-0000-7000-8000-000000000000', 'istio', 'Istio', 'Service mesh for Kubernetes', '## Overview
 
 Istio extends Kubernetes to establish a programmable, application-aware network. Working with both Kubernetes and traditional workloads, Istio brings standard, universal traffic management, telemetry, and security to complex deployments.
 
@@ -161,7 +161,7 @@ Istio extends Kubernetes to establish a programmable, application-aware network.
 - Traffic management and load balancing
 - Observability across services
 - Zero-trust networking', 'Istio Authors', 'https://istio.io', 'https://github.com/istio/istio', 'docker.io/istio/pilot:1.24.3'),
-    ('019b4000-3000-7000-8000-000000000008', '019b4000-1000-7000-8000-000000000001', 'keycloak', 'Keycloak', 'Identity and access management', '## Overview
+    ('019b4000-3000-7000-8000-000000000008', '019b4000-0000-7000-8000-000000000000', 'keycloak', 'Keycloak', 'Identity and access management', '## Overview
 
 Keycloak is an open source Identity and Access Management solution aimed at modern applications and services. It provides single sign-on, identity brokering, and user federation.
 
@@ -177,7 +177,7 @@ Keycloak is an open source Identity and Access Management solution aimed at mode
 - Centralized authentication for applications
 - API security and OAuth 2.0 provider
 - User management and self-service registration', 'Red Hat', 'https://www.keycloak.org', 'https://github.com/keycloak/keycloak', 'quay.io/keycloak/keycloak:26.2.0'),
-    ('019b4000-3000-7000-8000-000000000009', '019b4000-1000-7000-8000-000000000001', 'grafana-loki', 'Grafana Loki', 'Log aggregation system', '## Overview
+    ('019b4000-3000-7000-8000-000000000009', '019b4000-0000-7000-8000-000000000000', 'grafana-loki', 'Grafana Loki', 'Log aggregation system', '## Overview
 
 Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. It is designed to be cost effective and easy to operate.
 
@@ -194,7 +194,7 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 - Application log analysis
 - Debugging and troubleshooting
 - Compliance and audit logging', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/loki', 'docker.io/grafana/loki:3.4.3'),
-    ('019b4000-3000-7000-8000-00000000000a', '019b4000-1000-7000-8000-000000000001', 'grafana-mimir', 'Grafana Mimir', 'Long-term Prometheus storage', '## Overview
+    ('019b4000-3000-7000-8000-00000000000a', '019b4000-0000-7000-8000-000000000000', 'grafana-mimir', 'Grafana Mimir', 'Long-term Prometheus storage', '## Overview
 
 Grafana Mimir is an open source, horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus metrics.
 
@@ -211,7 +211,7 @@ Grafana Mimir is an open source, horizontally scalable, highly available, multi-
 - Multi-cluster Prometheus aggregation
 - Metrics-as-a-Service platforms
 - Historical analysis and capacity planning', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/mimir', 'docker.io/grafana/mimir:2.15.0'),
-    ('019b4000-3000-7000-8000-00000000000b', '019b4000-1000-7000-8000-000000000001', 'pinniped', 'Pinniped', 'Kubernetes cluster authentication', '## Overview
+    ('019b4000-3000-7000-8000-00000000000b', '019b4000-0000-7000-8000-000000000000', 'pinniped', 'Pinniped', 'Kubernetes cluster authentication', '## Overview
 
 Pinniped provides identity services for Kubernetes clusters, enabling users to authenticate using external identity providers and providing a consistent login experience across clusters.
 
@@ -227,7 +227,7 @@ Pinniped provides identity services for Kubernetes clusters, enabling users to a
 - Enterprise Kubernetes authentication
 - Multi-cluster identity management
 - Integration with corporate identity providers', 'VMware', 'https://pinniped.dev', 'https://github.com/vmware-tanzu/pinniped', 'ghcr.io/vmware-tanzu/pinniped/pinniped-concierge:v0.35.0'),
-    ('019b4000-3000-7000-8000-00000000000c', '019b4000-1000-7000-8000-000000000001', 'sealed-secrets', 'Sealed Secrets', 'Encrypted secrets for Git', '## Overview
+    ('019b4000-3000-7000-8000-00000000000c', '019b4000-0000-7000-8000-000000000000', 'sealed-secrets', 'Sealed Secrets', 'Encrypted secrets for Git', '## Overview
 
 Sealed Secrets allows you to encrypt your Kubernetes secrets so they can be safely stored in Git repositories. Only the controller running in your cluster can decrypt them.
 
@@ -243,7 +243,7 @@ Sealed Secrets allows you to encrypt your Kubernetes secrets so they can be safe
 - GitOps workflows with sensitive data
 - Secure secret distribution
 - Compliance with secret management policies', 'Bitnami', 'https://bitnami.com', 'https://github.com/bitnami-labs/sealed-secrets', 'ghcr.io/bitnami-labs/sealed-secrets:v0.28.1'),
-    ('019b4000-3000-7000-8000-00000000000d', '019b4000-1000-7000-8000-000000000001', 'grafana-tempo', 'Grafana Tempo', 'Distributed tracing backend', '## Overview
+    ('019b4000-3000-7000-8000-00000000000d', '019b4000-0000-7000-8000-000000000000', 'grafana-tempo', 'Grafana Tempo', 'Distributed tracing backend', '## Overview
 
 Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing backend. Tempo requires only object storage to operate and is deeply integrated with Grafana.
 
@@ -260,7 +260,7 @@ Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing
 - Request flow visualization
 - Performance optimization
 - Root cause analysis', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/tempo', 'docker.io/grafana/tempo:2.7.2'),
-    ('019b4000-3000-7000-8000-00000000000e', '019b4000-1000-7000-8000-000000000001', 'openfsc', 'OpenFSC', 'Federated Service Connectivity', '## Overview
+    ('019b4000-3000-7000-8000-00000000000e', '019b4000-0000-7000-8000-000000000000', 'openfsc', 'OpenFSC', 'Federated Service Connectivity', '## Overview
 
 OpenFSC brings Federated Service Connectivity (FSC) to Kubernetes. It installs the standalone openfsc-operator; each team declares an FSCInstallation in its namespace to run an OpenFSC peer there.
 
@@ -276,7 +276,7 @@ OpenFSC brings Federated Service Connectivity (FSC) to Kubernetes. It installs t
 - Inter-organization service connectivity
 - Common Ground / data exchange between government bodies
 - Federated APIs across trust domains', 'Fundament', 'https://fsc-standaard.nl', 'https://gitlab.com/rinis-oss/fsc/open-fsc', ''),
-    ('019b4000-3000-7000-8000-000000000010', '019b4000-1000-7000-8000-000000000001', 'gateway-api-envoy', 'Gateway API (Envoy Gateway)', 'Gateway API implementation powered by Envoy Gateway', '## Overview
+    ('019b4000-3000-7000-8000-000000000010', '019b4000-0000-7000-8000-000000000000', 'gateway-api-envoy', 'Gateway API (Envoy Gateway)', 'Gateway API implementation powered by Envoy Gateway', '## Overview
 
 The Gateway API plugin powered by Envoy Gateway installs the Envoy Gateway control plane and manages Gateways, HTTPRoutes, GRPCRoutes, TCPRoutes, TLSRoutes, and Envoy Gateway policies.
 

--- a/db/seed/0101-appstore-catalog.sql
+++ b/db/seed/0101-appstore-catalog.sql
@@ -41,8 +41,8 @@ INSERT INTO appstore.tags (id, name) VALUES
 ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
 
 -- Plugins
-INSERT INTO appstore.plugins (id, name, display_name, description_short, description, author_name, author_url, repository_url, image) VALUES
-    ('019b4000-3000-7000-8000-000000000001', 'grafana-alloy', 'Grafana Alloy', 'OpenTelemetry Collector distribution', '## Overview
+INSERT INTO appstore.plugins (id, organization_id, name, display_name, description_short, description, author_name, author_url, repository_url, image) VALUES
+    ('019b4000-3000-7000-8000-000000000001', '019b4000-1000-7000-8000-000000000001', 'grafana-alloy', 'Grafana Alloy', 'OpenTelemetry Collector distribution', '## Overview
 
 Grafana Alloy is a flexible, high-performance OpenTelemetry Collector distribution with native Prometheus support.
 
@@ -58,7 +58,7 @@ Grafana Alloy is a flexible, high-performance OpenTelemetry Collector distributi
 - Unified telemetry collection for metrics, logs, and traces
 - Prometheus metrics collection and forwarding
 - OpenTelemetry instrumentation aggregation', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/alloy', 'docker.io/grafana/alloy:v1.8.3'),
-    ('019b4000-3000-7000-8000-000000000002', 'cert-manager', 'cert-manager', 'Automatic TLS certificate management', '## Overview
+    ('019b4000-3000-7000-8000-000000000002', '019b4000-1000-7000-8000-000000000001', 'cert-manager', 'cert-manager', 'Automatic TLS certificate management', '## Overview
 
 cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.
 
@@ -79,7 +79,7 @@ cert-manager adds certificates and certificate issuers as resource types in Kube
     -- prose name "CloudNativePG" to "cloudnativepg". Any cluster already running this
     -- plugin has a CR under that name, so changing it here would orphan the installation
     -- (the Console would show it as not installed and create a second CR on re-install).
-    ('019b4000-3000-7000-8000-000000000003', 'cloudnativepg', 'CloudNativePG', 'PostgreSQL operator for Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000003', '019b4000-1000-7000-8000-000000000001', 'cloudnativepg', 'CloudNativePG', 'PostgreSQL operator for Kubernetes', '## Overview
 
 CloudNativePG is an open source operator designed to manage PostgreSQL workloads on Kubernetes, covering the full lifecycle of a PostgreSQL cluster.
 
@@ -95,7 +95,7 @@ CloudNativePG is an open source operator designed to manage PostgreSQL workloads
 - Production PostgreSQL databases on Kubernetes
 - Database-as-a-Service platforms
 - Microservices requiring relational databases', 'CloudNativePG Contributors', 'https://cloudnative-pg.io', 'https://github.com/cloudnative-pg/cloudnative-pg', 'ghcr.io/cloudnative-pg/cloudnative-pg:v1.25.1'),
-    ('019b4000-3000-7000-8000-000000000004', 'eck-operator', 'ECK operator', 'Elasticsearch and Kibana on Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000004', '019b4000-1000-7000-8000-000000000001', 'eck-operator', 'ECK operator', 'Elasticsearch and Kibana on Kubernetes', '## Overview
 
 Elastic Cloud on Kubernetes (ECK) automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, and the Elastic Stack on Kubernetes.
 
@@ -111,7 +111,7 @@ Elastic Cloud on Kubernetes (ECK) automates the deployment, provisioning, manage
 - Log aggregation and analysis
 - Application performance monitoring
 - Full-text search infrastructure', 'Elastic', 'https://www.elastic.co', 'https://github.com/elastic/cloud-on-k8s', 'docker.elastic.co/eck/eck-operator:2.16.0'),
-    ('019b4000-3000-7000-8000-000000000005', 'grafana', 'Grafana', 'Metrics visualization and alerting', '## Overview
+    ('019b4000-3000-7000-8000-000000000005', '019b4000-1000-7000-8000-000000000001', 'grafana', 'Grafana', 'Metrics visualization and alerting', '## Overview
 
 Grafana is the open source analytics and monitoring solution for every database. It allows you to query, visualize, alert on and understand your metrics no matter where they are stored.
 
@@ -128,7 +128,7 @@ Grafana is the open source analytics and monitoring solution for every database.
 - Application performance monitoring
 - Business analytics
 - IoT data visualization', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/grafana', 'docker.io/grafana/grafana:11.6.0'),
-    ('019b4000-3000-7000-8000-000000000006', 'istio-gateway', 'Istio Gateway', 'Ingress gateway for service mesh', '## Overview
+    ('019b4000-3000-7000-8000-000000000006', '019b4000-1000-7000-8000-000000000001', 'istio-gateway', 'Istio Gateway', 'Ingress gateway for service mesh', '## Overview
 
 Istio Gateway provides a dedicated ingress gateway for managing inbound traffic to your service mesh, offering advanced traffic management and security features.
 
@@ -144,7 +144,7 @@ Istio Gateway provides a dedicated ingress gateway for managing inbound traffic 
 - API gateway for microservices
 - Multi-cluster ingress
 - Canary deployments and A/B testing', 'Istio Authors', 'https://istio.io', 'https://github.com/istio/istio', 'docker.io/istio/pilot:1.24.3'),
-    ('019b4000-3000-7000-8000-000000000007', 'istio', 'Istio', 'Service mesh for Kubernetes', '## Overview
+    ('019b4000-3000-7000-8000-000000000007', '019b4000-1000-7000-8000-000000000001', 'istio', 'Istio', 'Service mesh for Kubernetes', '## Overview
 
 Istio extends Kubernetes to establish a programmable, application-aware network. Working with both Kubernetes and traditional workloads, Istio brings standard, universal traffic management, telemetry, and security to complex deployments.
 
@@ -161,7 +161,7 @@ Istio extends Kubernetes to establish a programmable, application-aware network.
 - Traffic management and load balancing
 - Observability across services
 - Zero-trust networking', 'Istio Authors', 'https://istio.io', 'https://github.com/istio/istio', 'docker.io/istio/pilot:1.24.3'),
-    ('019b4000-3000-7000-8000-000000000008', 'keycloak', 'Keycloak', 'Identity and access management', '## Overview
+    ('019b4000-3000-7000-8000-000000000008', '019b4000-1000-7000-8000-000000000001', 'keycloak', 'Keycloak', 'Identity and access management', '## Overview
 
 Keycloak is an open source Identity and Access Management solution aimed at modern applications and services. It provides single sign-on, identity brokering, and user federation.
 
@@ -177,7 +177,7 @@ Keycloak is an open source Identity and Access Management solution aimed at mode
 - Centralized authentication for applications
 - API security and OAuth 2.0 provider
 - User management and self-service registration', 'Red Hat', 'https://www.keycloak.org', 'https://github.com/keycloak/keycloak', 'quay.io/keycloak/keycloak:26.2.0'),
-    ('019b4000-3000-7000-8000-000000000009', 'grafana-loki', 'Grafana Loki', 'Log aggregation system', '## Overview
+    ('019b4000-3000-7000-8000-000000000009', '019b4000-1000-7000-8000-000000000001', 'grafana-loki', 'Grafana Loki', 'Log aggregation system', '## Overview
 
 Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. It is designed to be cost effective and easy to operate.
 
@@ -194,7 +194,7 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 - Application log analysis
 - Debugging and troubleshooting
 - Compliance and audit logging', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/loki', 'docker.io/grafana/loki:3.4.3'),
-    ('019b4000-3000-7000-8000-00000000000a', 'grafana-mimir', 'Grafana Mimir', 'Long-term Prometheus storage', '## Overview
+    ('019b4000-3000-7000-8000-00000000000a', '019b4000-1000-7000-8000-000000000001', 'grafana-mimir', 'Grafana Mimir', 'Long-term Prometheus storage', '## Overview
 
 Grafana Mimir is an open source, horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus metrics.
 
@@ -211,7 +211,7 @@ Grafana Mimir is an open source, horizontally scalable, highly available, multi-
 - Multi-cluster Prometheus aggregation
 - Metrics-as-a-Service platforms
 - Historical analysis and capacity planning', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/mimir', 'docker.io/grafana/mimir:2.15.0'),
-    ('019b4000-3000-7000-8000-00000000000b', 'pinniped', 'Pinniped', 'Kubernetes cluster authentication', '## Overview
+    ('019b4000-3000-7000-8000-00000000000b', '019b4000-1000-7000-8000-000000000001', 'pinniped', 'Pinniped', 'Kubernetes cluster authentication', '## Overview
 
 Pinniped provides identity services for Kubernetes clusters, enabling users to authenticate using external identity providers and providing a consistent login experience across clusters.
 
@@ -227,7 +227,7 @@ Pinniped provides identity services for Kubernetes clusters, enabling users to a
 - Enterprise Kubernetes authentication
 - Multi-cluster identity management
 - Integration with corporate identity providers', 'VMware', 'https://pinniped.dev', 'https://github.com/vmware-tanzu/pinniped', 'ghcr.io/vmware-tanzu/pinniped/pinniped-concierge:v0.35.0'),
-    ('019b4000-3000-7000-8000-00000000000c', 'sealed-secrets', 'Sealed Secrets', 'Encrypted secrets for Git', '## Overview
+    ('019b4000-3000-7000-8000-00000000000c', '019b4000-1000-7000-8000-000000000001', 'sealed-secrets', 'Sealed Secrets', 'Encrypted secrets for Git', '## Overview
 
 Sealed Secrets allows you to encrypt your Kubernetes secrets so they can be safely stored in Git repositories. Only the controller running in your cluster can decrypt them.
 
@@ -243,7 +243,7 @@ Sealed Secrets allows you to encrypt your Kubernetes secrets so they can be safe
 - GitOps workflows with sensitive data
 - Secure secret distribution
 - Compliance with secret management policies', 'Bitnami', 'https://bitnami.com', 'https://github.com/bitnami-labs/sealed-secrets', 'ghcr.io/bitnami-labs/sealed-secrets:v0.28.1'),
-    ('019b4000-3000-7000-8000-00000000000d', 'grafana-tempo', 'Grafana Tempo', 'Distributed tracing backend', '## Overview
+    ('019b4000-3000-7000-8000-00000000000d', '019b4000-1000-7000-8000-000000000001', 'grafana-tempo', 'Grafana Tempo', 'Distributed tracing backend', '## Overview
 
 Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing backend. Tempo requires only object storage to operate and is deeply integrated with Grafana.
 
@@ -260,7 +260,7 @@ Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing
 - Request flow visualization
 - Performance optimization
 - Root cause analysis', 'Grafana Labs', 'https://grafana.com', 'https://github.com/grafana/tempo', 'docker.io/grafana/tempo:2.7.2'),
-    ('019b4000-3000-7000-8000-00000000000e', 'openfsc', 'OpenFSC', 'Federated Service Connectivity', '## Overview
+    ('019b4000-3000-7000-8000-00000000000e', '019b4000-1000-7000-8000-000000000001', 'openfsc', 'OpenFSC', 'Federated Service Connectivity', '## Overview
 
 OpenFSC brings Federated Service Connectivity (FSC) to Kubernetes. It installs the standalone openfsc-operator; each team declares an FSCInstallation in its namespace to run an OpenFSC peer there.
 
@@ -293,6 +293,7 @@ The Gateway API plugin powered by Envoy Gateway installs the Envoy Gateway contr
 - Advanced traffic management with Envoy
 - Per-Gateway security and traffic policies', 'Fundament', 'https://gateway.envoyproxy.io', 'https://github.com/envoyproxy/gateway', '')
 ON CONFLICT (id) DO UPDATE SET
+    organization_id = EXCLUDED.organization_id,
     name = EXCLUDED.name,
     display_name = EXCLUDED.display_name,
     description_short = EXCLUDED.description_short,

--- a/db/testdata/033_0101-content.sql
+++ b/db/testdata/033_0101-content.sql
@@ -1,0 +1,8 @@
+-- Platform maintainer: admin of the system org so a login can publish the
+-- first-party plugins' definitions. At 033 because the system org is created there.
+
+INSERT INTO tenant.users (id, name, email, external_ref) VALUES
+    ('019b4000-1000-7000-8000-000000000008', 'Platform Admin', 'platform-admin@fundament.io', 'CiQwMTliNDAwMC0xMDAwLTcwMDAtODAwMC0wMDAwMDAwMDAwMDgSBWxvY2Fs');
+
+INSERT INTO tenant.organizations_users (organization_id, user_id, permission, status) VALUES
+    ('019b4000-1000-7000-8000-000000000001', '019b4000-1000-7000-8000-000000000008', 'admin', 'accepted');

--- a/db/testdata/033_0101-content.sql
+++ b/db/testdata/033_0101-content.sql
@@ -5,4 +5,4 @@ INSERT INTO tenant.users (id, name, email, external_ref) VALUES
     ('019b4000-1000-7000-8000-000000000008', 'Platform Admin', 'platform-admin@fundament.io', 'CiQwMTliNDAwMC0xMDAwLTcwMDAtODAwMC0wMDAwMDAwMDAwMDgSBWxvY2Fs');
 
 INSERT INTO tenant.organizations_users (organization_id, user_id, permission, status) VALUES
-    ('019b4000-1000-7000-8000-000000000001', '019b4000-1000-7000-8000-000000000008', 'admin', 'accepted');
+    ('019b4000-0000-7000-8000-000000000000', '019b4000-1000-7000-8000-000000000008', 'admin', 'accepted');

--- a/organization-api/pkg/organization/main_test.go
+++ b/organization-api/pkg/organization/main_test.go
@@ -214,11 +214,6 @@ func setupTemplateDatabaseWithMigrations(pool *pgxpool.Pool) error {
 }
 
 func applyCatalogSeed(projectRoot string) error {
-	seedSQL, err := os.ReadFile(filepath.Join(projectRoot, "db", "seed", "0101-appstore-catalog.sql"))
-	if err != nil {
-		return fmt.Errorf("failed to read appstore catalog seed: %v", err)
-	}
-
 	conn, err := pgx.Connect(context.Background(),
 		fmt.Sprintf("postgres://postgres:postgres@localhost:%d/fundament?sslmode=disable", testDBPort))
 	if err != nil {
@@ -226,12 +221,16 @@ func applyCatalogSeed(projectRoot string) error {
 	}
 	defer conn.Close(context.Background())
 
-	// The simple protocol runs the whole multi-statement file in one implicit
-	// transaction, matching the Job's `psql --single-transaction`.
-	if _, err := conn.PgConn().Exec(context.Background(), string(seedSQL)).ReadAll(); err != nil {
-		return fmt.Errorf("failed to apply appstore catalog seed: %v", err)
+	for _, name := range []string{"0100-system-org.sql", "0101-appstore-catalog.sql"} {
+		seedSQL, err := os.ReadFile(filepath.Join(projectRoot, "db", "seed", name))
+		if err != nil {
+			return fmt.Errorf("failed to read seed %s: %v", name, err)
+		}
+		// Simple protocol: whole multi-statement file in one implicit transaction.
+		if _, err := conn.PgConn().Exec(context.Background(), string(seedSQL)).ReadAll(); err != nil {
+			return fmt.Errorf("failed to apply seed %s: %v", name, err)
+		}
 	}
-
 	return nil
 }
 

--- a/organization-api/pkg/organization/plugin_definition_put.go
+++ b/organization-api/pkg/organization/plugin_definition_put.go
@@ -50,8 +50,8 @@ func (s *Server) PutPluginDefinition(
 	// pre-existing catalog entry, not a resource this caller just created, so
 	// there is no ownership-sync race to absorb. PutPluginDefinition is
 	// idempotent, so a caller that races a fresh ownership sync can simply retry.
-	// RLS on appstore.plugin_definitions is the backstop (see the insert-error
-	// mapping below); this is the primary gate.
+	// RLS on appstore.plugin_definitions independently enforces the same rule
+	// (see the insert-error mapping below).
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Plugin(pluginID)); err != nil {
 		return nil, err
 	}
@@ -153,8 +153,9 @@ func (s *Server) PutPluginDefinition(
 		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok &&
 			pgErr.Code == pgerrcode.InsufficientPrivilege {
 			// RLS rejected the write: the caller's organization does not own this
-			// plugin. The gate is enforced entirely in the database (row-level
-			// security); we only translate the rejection into a clean API error.
+			// plugin. The OpenFGA check above normally catches this first; reaching
+			// here means the ownership tuple has not synced yet. We only translate
+			// the rejection into a clean API error.
 			return nil, connect.NewError(connect.CodePermissionDenied,
 				fmt.Errorf("organization is not the owner of plugin %s", catalogRow.Name))
 		}

--- a/organization-api/pkg/organization/plugin_definition_put.go
+++ b/organization-api/pkg/organization/plugin_definition_put.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/fundament-oss/fundament/common/authz"
 	"github.com/fundament-oss/fundament/common/dbconst"
 	"github.com/fundament-oss/fundament/common/rollback"
 	db "github.com/fundament-oss/fundament/organization-api/pkg/db/gen"
@@ -42,6 +43,14 @@ func (s *Server) PutPluginDefinition(
 	pluginID, err := uuid.Parse(pluginIDStr)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("plugin_id must be a valid uuid: %w", err))
+	}
+	// Authorization decision: OpenFGA. Publishing/editing a plugin definition
+	// requires can_edit on the plugin, which resolves to admin from the owning
+	// organization. Retry absorbs the eventual consistency of the outbox ->
+	// authz-worker -> OpenFGA sync. RLS on appstore.plugin_definitions is the
+	// backstop (see the insert-error mapping below); this is the primary gate.
+	if err := s.checkPermissionWithRetry(ctx, authz.CanEdit(), authz.Plugin(pluginID)); err != nil {
+		return nil, err
 	}
 	// Strict parse rejects an image-free template (and any malformed manifest):
 	// a stored PluginDefinition must be complete.
@@ -137,6 +146,14 @@ func (s *Server) PutPluginDefinition(
 			pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == dbconst.ConstraintPluginDefinitionsUqPluginVersion {
 			return nil, connect.NewError(connect.CodeFailedPrecondition,
 				fmt.Errorf("plugin definition %s@%s already exists with a different hash; set replace=true to republish", catalogRow.Name, version))
+		}
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok &&
+			pgErr.Code == pgerrcode.InsufficientPrivilege {
+			// RLS rejected the write: the caller's organization does not own this
+			// plugin. The gate is enforced entirely in the database (row-level
+			// security); we only translate the rejection into a clean API error.
+			return nil, connect.NewError(connect.CodePermissionDenied,
+				fmt.Errorf("organization is not the owner of plugin %s", catalogRow.Name))
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("insert plugin definition: %w", err))
 	}

--- a/organization-api/pkg/organization/plugin_definition_put.go
+++ b/organization-api/pkg/organization/plugin_definition_put.go
@@ -46,10 +46,13 @@ func (s *Server) PutPluginDefinition(
 	}
 	// Authorization decision: OpenFGA. Publishing/editing a plugin definition
 	// requires can_edit on the plugin, which resolves to admin from the owning
-	// organization. Retry absorbs the eventual consistency of the outbox ->
-	// authz-worker -> OpenFGA sync. RLS on appstore.plugin_definitions is the
-	// backstop (see the insert-error mapping below); this is the primary gate.
-	if err := s.checkPermissionWithRetry(ctx, authz.CanEdit(), authz.Plugin(pluginID)); err != nil {
+	// organization. No retry here (unlike the create endpoints): the plugin is a
+	// pre-existing catalog entry, not a resource this caller just created, so
+	// there is no ownership-sync race to absorb. PutPluginDefinition is
+	// idempotent, so a caller that races a fresh ownership sync can simply retry.
+	// RLS on appstore.plugin_definitions is the backstop (see the insert-error
+	// mapping below); this is the primary gate.
+	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Plugin(pluginID)); err != nil {
 		return nil, err
 	}
 	// Strict parse rejects an image-free template (and any malformed manifest):

--- a/organization-api/pkg/organization/plugin_definition_test.go
+++ b/organization-api/pkg/organization/plugin_definition_test.go
@@ -629,8 +629,9 @@ func TestGetPluginDefinition_NotFound(t *testing.T) {
 }
 
 // TestPutPluginDefinition_NonOwnerDenied verifies a plugin owned by one org
-// cannot have a definition published from another org's context. The gate is
-// pure RLS; the handler only maps the DB rejection to PermissionDenied.
+// cannot have a definition published from another org's context. The test server
+// has no OpenFGA client (nil authz.Client), so checkPermission is a no-op and
+// this exercises the RLS layer alone; in production OpenFGA denies it first.
 func TestPutPluginDefinition_NonOwnerDenied(t *testing.T) {
 	t.Parallel()
 

--- a/organization-api/pkg/organization/plugin_definition_test.go
+++ b/organization-api/pkg/organization/plugin_definition_test.go
@@ -23,13 +23,13 @@ func newPluginServiceClient(env *testEnv) organizationv1connect.PluginServiceCli
 	return organizationv1connect.NewPluginServiceClient(env.server.Client(), env.server.URL)
 }
 
-// seedCatalogPlugin inserts a row into appstore.plugins and returns its id.
-func seedCatalogPlugin(t *testing.T, env *testEnv, name string) uuid.UUID {
+// seedCatalogPlugin inserts a row into appstore.plugins owned by orgID and returns its id.
+func seedCatalogPlugin(t *testing.T, env *testEnv, name string, orgID uuid.UUID) uuid.UUID {
 	t.Helper()
 	id := uuid.New()
 	_, err := env.adminPool.Exec(t.Context(),
-		"INSERT INTO appstore.plugins (id, name, description) VALUES ($1, $2, $3)",
-		id, name, "test plugin",
+		"INSERT INTO appstore.plugins (id, organization_id, name, description) VALUES ($1, $2, $3, $4)",
+		id, orgID, name, "test plugin",
 	)
 	require.NoError(t, err)
 	return id
@@ -51,7 +51,7 @@ func TestPutPluginDefinition_IdempotentAndConflict(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
@@ -119,7 +119,7 @@ func TestPutPluginDefinition_RequiresOrganization(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
@@ -155,7 +155,7 @@ func TestPutPluginDefinition_RejectsVersionMismatch(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
@@ -190,7 +190,7 @@ func TestPutPluginDefinition_RejectsImagelessTemplate(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
@@ -300,7 +300,7 @@ func TestPutPluginDefinition_RejectsNameMismatch(t *testing.T) {
 	)
 
 	// Catalog plugin has a different name than the manifest's metadata.name.
-	pluginID := seedCatalogPlugin(t, env, "some-other-plugin")
+	pluginID := seedCatalogPlugin(t, env, "some-other-plugin", orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
@@ -336,7 +336,7 @@ func TestPutPluginDefinition_RejectsOversizedManifest(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
@@ -376,7 +376,7 @@ func TestPutPluginDefinition_Replace(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
@@ -433,7 +433,7 @@ func TestListPlugins_SurfacesLatestDefinition(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
@@ -516,7 +516,7 @@ func TestListPluginDefinitions_LatestFirst(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
@@ -577,7 +577,7 @@ func TestGetPluginDefinition_ReturnsBytesHashAndProto(t *testing.T) {
 		}),
 	)
 
-	pluginID := seedCatalogPlugin(t, env, testPluginName)
+	pluginID := seedCatalogPlugin(t, env, testPluginName, orgID)
 
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
@@ -626,4 +626,82 @@ func TestGetPluginDefinition_NotFound(t *testing.T) {
 	_, err := client.GetPluginDefinition(ctx, getReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+// TestPutPluginDefinition_NonOwnerDenied verifies a plugin owned by one org
+// cannot have a definition published from another org's context. The gate is
+// pure RLS; the handler only maps the DB rejection to PermissionDenied.
+func TestPutPluginDefinition_NonOwnerDenied(t *testing.T) {
+	t.Parallel()
+
+	ownerOrgID := uuid.New()
+	otherOrgID := uuid.New()
+	userID := uuid.New()
+
+	env := newTestAPI(t,
+		WithOrganization(ownerOrgID, "owner-org"),
+		WithOrganization(otherOrgID, "other-org"),
+		WithUser(&UserArgs{
+			ID:     userID,
+			Name:   "other-user",
+			Email:  "other@example.com",
+			OrgIDs: []uuid.UUID{otherOrgID},
+		}),
+	)
+
+	// Plugin is owned by ownerOrg; caller acts as otherOrg.
+	pluginID := seedCatalogPlugin(t, env, testPluginName, ownerOrgID)
+	token := env.createAuthnToken(t, userID)
+	client := newPluginServiceClient(env)
+
+	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+		PluginId:      pluginID.String(),
+		PluginVersion: "v1",
+		Manifest:      testManifest,
+	}.Build())
+	putReq.Header().Set("Authorization", "Bearer "+token)
+	putReq.Header().Set("Fun-Organization", otherOrgID.String())
+
+	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+// TestListPlugins_GlobalVisibility verifies a plugin owned by one org is still
+// listed for a member of a different org (catalog visibility is not org-scoped).
+func TestListPlugins_GlobalVisibility(t *testing.T) {
+	t.Parallel()
+
+	ownerOrgID := uuid.New()
+	otherOrgID := uuid.New()
+	userID := uuid.New()
+
+	env := newTestAPI(t,
+		WithOrganization(ownerOrgID, "owner-org"),
+		WithOrganization(otherOrgID, "other-org"),
+		WithUser(&UserArgs{
+			ID:     userID,
+			Name:   "other-user",
+			Email:  "other@example.com",
+			OrgIDs: []uuid.UUID{otherOrgID},
+		}),
+	)
+
+	seedCatalogPlugin(t, env, testPluginName, ownerOrgID)
+	token := env.createAuthnToken(t, userID)
+	client := newPluginServiceClient(env)
+
+	req := connect.NewRequest(organizationv1.ListPluginsRequest_builder{}.Build())
+	req.Header().Set("Authorization", "Bearer "+token)
+	req.Header().Set("Fun-Organization", otherOrgID.String())
+	resp, err := client.ListPlugins(context.Background(), req)
+	require.NoError(t, err)
+
+	var found bool
+	for _, p := range resp.Msg.GetPlugins() {
+		if p.GetName() == testPluginName {
+			found = true
+		}
+	}
+	assert.True(t, found, "plugin owned by another org must still be visible in the catalog")
 }

--- a/organization-api/pkg/organization/plugin_definition_test.go
+++ b/organization-api/pkg/organization/plugin_definition_test.go
@@ -655,15 +655,16 @@ func TestPutPluginDefinition_NonOwnerDenied(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", otherOrgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(context.Background())
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", otherOrgID.String())
 
-	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
@@ -692,14 +693,15 @@ func TestListPlugins_GlobalVisibility(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
-	req := connect.NewRequest(organizationv1.ListPluginsRequest_builder{}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", otherOrgID.String())
-	resp, err := client.ListPlugins(context.Background(), req)
+	req := organizationv1.ListPluginsRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", otherOrgID.String())
+	resp, err := client.ListPlugins(listCtx, req)
 	require.NoError(t, err)
 
 	var found bool
-	for _, p := range resp.Msg.GetPlugins() {
+	for _, p := range resp.GetPlugins() {
 		if p.GetName() == testPluginName {
 			found = true
 		}

--- a/organization-api/pkg/organization/plugin_rls_test.go
+++ b/organization-api/pkg/organization/plugin_rls_test.go
@@ -1,0 +1,76 @@
+package organization_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Plugins_RLS_Policies(t *testing.T) {
+	t.Parallel()
+
+	ownerOrgID := uuid.New()
+	otherOrgID := uuid.New()
+
+	env := newTestAPI(t,
+		WithOrganization(ownerOrgID, "owner-org"),
+		WithOrganization(otherOrgID, "other-org"),
+	)
+
+	pluginID := seedCatalogPlugin(t, env, testPluginName, ownerOrgID)
+
+	// Connect as the RLS-subject role (fun_fundament_api) to this test's DB.
+	dbName := testNameToDbName(t.Name())
+	conn, err := pgx.Connect(t.Context(),
+		fmt.Sprintf("postgres://fun_fundament_api@localhost:%d/%s?sslmode=disable", testDBPort, dbName))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	setOrg := func(orgID string) {
+		_, err := conn.Exec(t.Context(), "SELECT set_config('app.current_organization_id', $1, false)", orgID)
+		require.NoError(t, err)
+	}
+	insertDef := func() error {
+		_, err := conn.Exec(t.Context(),
+			"INSERT INTO appstore.plugin_definitions (plugin_id, plugin_version, manifest, hash) VALUES ($1, 'v1', $2, 'sha256:x')",
+			pluginID, []byte("m"))
+		return err
+	}
+	isRLSDenied := func(err error) bool {
+		var pgErr *pgconn.PgError
+		return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.InsufficientPrivilege
+	}
+
+	// Wrong org → INSERT rejected by RLS.
+	setOrg(otherOrgID.String())
+	err = insertDef()
+	require.Error(t, err)
+	assert.True(t, isRLSDenied(err), "expected 42501, got %v", err)
+
+	// Owner org → INSERT allowed.
+	setOrg(ownerOrgID.String())
+	require.NoError(t, insertDef())
+
+	// GUC unset → global SELECT still returns the plugin row.
+	_, err = conn.Exec(t.Context(), "RESET app.current_organization_id")
+	require.NoError(t, err)
+	var cnt int
+	require.NoError(t, conn.QueryRow(t.Context(),
+		"SELECT count(*) FROM appstore.plugins WHERE id = $1", pluginID).Scan(&cnt))
+	assert.Equal(t, 1, cnt, "SELECT must stay global regardless of org context")
+
+	// No-transfer: owner cannot reassign the plugin to another org (UPDATE WITH CHECK).
+	setOrg(ownerOrgID.String())
+	_, err = conn.Exec(t.Context(),
+		"UPDATE appstore.plugins SET organization_id = $1 WHERE id = $2", otherOrgID, pluginID)
+	require.Error(t, err)
+	assert.True(t, isRLSDenied(err), "expected 42501 on ownership transfer, got %v", err)
+}


### PR DESCRIPTION
## Summary

Give every appstore plugin an **owning organization** and enforce that only an **admin of that org** may publish/edit it. Existing catalog plugins are owned by a newly **seeded system organization**. All schema changes — ownership column + RLS policies, and the `authz.outbox.plugin_id` column + sync trigger — are in a single migration, `033`.

## Layering

OpenFGA decides; RLS guarantees no unauthorized write reaches the DB and that list/update always run over the correct rows. The two layers are independent. Publish/edit is **admin-only** for now; a finer-grained *developer* role is a deliberate future extension.

## Notable design points

- Ownership lives on `appstore.plugins`; `plugin_definitions` inherit it via an `EXISTS` subquery on the parent (no SQL aliases).

## Testing

- Handler: non-owner → `PermissionDenied`; catalog stays visible cross-org.
- DB-level RLS (direct `fun_fundament_api` connection): wrong-org insert rejected (`42501`), owner insert allowed, global `SELECT` with GUC unset, no-transfer `UPDATE` rejected.
- `common`, `authz-worker`, `organization-api` build; `go vet` clean; `go test ./pkg/organization/` green (runs `trek apply` of `033` + seeds).

## Follow-ups (out of scope)

- A *developer* role finer-grained than org admin.