### PR TITLE
fix(cluster-worker): use trust auth in embedded-postgres test harness

### DIFF
--- a/cluster-worker/pkg/handler/cluster/main_test.go
+++ b/cluster-worker/pkg/handler/cluster/main_test.go
@@ -80,6 +80,7 @@ func TestMain(m *testing.M) {
 
 	adminPool := newAdminPool()
 
+	useGlobalTrustAuth(dataDir, adminPool)
 	testdb.CreateRoles(context.Background(), adminPool)
 
 	if err = setupTemplateDatabaseWithMigrations(adminPool); err != nil {
@@ -219,6 +220,23 @@ func findProjectRoot() string {
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// useGlobalTrustAuth switches pg_hba.conf to trust auth so the passwordless
+// roles created by testdb.CreateRoles can connect over TCP.
+func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
+	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
+	content, err := os.ReadFile(pgHBAPath) //nolint:gosec // test helper
+	if err != nil {
+		log.Fatalf("failed to read pg_hba.conf: %v", err)
+	}
+	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
+	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil { //nolint:gosec // test helper
+		log.Fatalf("failed to write pg_hba.conf: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
+		log.Fatalf("failed to reload pg_hba.conf: %v", err)
+	}
 }
 
 func newAdminPool() *pgxpool.Pool {


### PR DESCRIPTION
## Summary

`go test ./cluster-worker/pkg/handler/cluster/` fails on a clean master checkout: `common/testdb.CreateRoles` creates passwordless roles (e.g. `fun_cluster_worker`), but the embedded-postgres `pg_hba.conf` requires password auth over TCP, so every integration test in the package fails with `FATAL: password authentication failed (SQLSTATE 28P01)`.

This adds the same `useGlobalTrustAuth` step the `common/idempotency` harness already uses: switch `pg_hba.conf` to `trust` and reload before creating the roles.

## Test plan

- `go test -count=1 ./cluster-worker/...` — all packages pass, including the 38 previously failing integration tests in `pkg/handler/cluster`.