### PR TITLE
refactor(proto): adopt the connect-go simple API

### DIFF
--- a/authn-api/pkg/authn/auth_test.go
+++ b/authn-api/pkg/authn/auth_test.go
@@ -82,10 +82,10 @@ func TestGetUserInfo_RejectsPluginToken(t *testing.T) {
 	require.NoError(t, err)
 
 	client := authnv1connect.NewAuthnServiceClient(ts.Client(), ts.URL)
-	req := connect.NewRequest(&authnv1.GetUserInfoRequest{})
-	req.Header().Set("Authorization", "Bearer "+tokenStr)
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+tokenStr)
 
-	_, err = client.GetUserInfo(context.Background(), req)
+	_, err = client.GetUserInfo(ctx, &authnv1.GetUserInfoRequest{})
 	require.Error(t, err)
 	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 }

--- a/authn-api/pkg/authn/exchange_token.go
+++ b/authn-api/pkg/authn/exchange_token.go
@@ -24,9 +24,14 @@ const (
 // ExchangeToken exchanges an API token for a short-lived JWT.
 func (s *AuthnServer) ExchangeToken(
 	ctx context.Context,
-	req *connect.Request[authnv1.ExchangeTokenRequest],
-) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
-	token, err := extractBearerToken(req.Header().Get("Authorization"))
+	_ *authnv1.ExchangeTokenRequest,
+) (*authnv1.ExchangeTokenResponse, error) {
+	callInfo, ok := connect.CallInfoForHandlerContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("missing call info in context"))
+	}
+
+	token, err := extractBearerToken(callInfo.RequestHeader().Get("Authorization"))
 	if err != nil {
 		s.logger.Debug("missing or invalid authorization header")
 		return nil, connect.NewError(connect.CodeUnauthenticated, err)
@@ -80,11 +85,11 @@ func (s *AuthnServer) ExchangeToken(
 		"organization_ids", u.OrganizationIDs,
 	)
 
-	return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+	return authnv1.ExchangeTokenResponse_builder{
 		AccessToken: accessToken,
 		TokenType:   "Bearer",
 		ExpiresIn:   int64(APITokenExpiry.Seconds()),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // extractBearerToken extracts the token from a Bearer authorization header.

--- a/authn-api/pkg/authn/get_user_info.go
+++ b/authn-api/pkg/authn/get_user_info.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 
@@ -12,16 +13,21 @@ import (
 // GetUserInfo is the RPC handler for getting user information from a valid JWT.
 func (s *AuthnServer) GetUserInfo(
 	ctx context.Context,
-	req *connect.Request[authnv1.GetUserInfoRequest],
-) (*connect.Response[authnv1.GetUserInfoResponse], error) {
-	claims, err := s.validator.Validate(req.Header())
+	_ *authnv1.GetUserInfoRequest,
+) (*authnv1.GetUserInfoResponse, error) {
+	callInfo, ok := connect.CallInfoForHandlerContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("missing call info in context"))
+	}
+
+	claims, err := s.validator.Validate(callInfo.RequestHeader())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, err)
 	}
 
-	return connect.NewResponse(authnv1.GetUserInfoResponse_builder{
+	return authnv1.GetUserInfoResponse_builder{
 		User: protoUserFromClaims(claims),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // protoUserFromClaims converts JWT claims to a proto User.

--- a/authn-api/pkg/authn/mint_plugin_token.go
+++ b/authn-api/pkg/authn/mint_plugin_token.go
@@ -26,16 +26,21 @@ const PluginTokenExpiry = 15 * time.Minute
 // PluginInstallation CR by kube-api-proxy.
 func (s *AuthnServer) MintPluginToken(
 	ctx context.Context,
-	req *connect.Request[authnv1.MintPluginTokenRequest],
-) (*connect.Response[authnv1.MintPluginTokenResponse], error) {
-	claims, err := s.validator.Validate(req.Header())
+	req *authnv1.MintPluginTokenRequest,
+) (*authnv1.MintPluginTokenResponse, error) {
+	callInfo, ok := connect.CallInfoForHandlerContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("missing call info in context"))
+	}
+
+	claims, err := s.validator.Validate(callInfo.RequestHeader())
 	if err != nil {
 		s.logger.Debug("mint plugin token: user token validation failed", "error", err)
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid user token"))
 	}
 
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
-	installationID := uuid.MustParse(req.Msg.GetInstallationId())
+	clusterID := uuid.MustParse(req.GetClusterId())
+	installationID := uuid.MustParse(req.GetInstallationId())
 	userID := claims.UserID()
 
 	manifest, err := s.resolveInstallation(ctx, userID, clusterID, installationID)
@@ -57,11 +62,11 @@ func (s *AuthnServer) MintPluginToken(
 		"plugin_version", manifest.PluginVersion,
 	)
 
-	return connect.NewResponse(authnv1.MintPluginTokenResponse_builder{
+	return authnv1.MintPluginTokenResponse_builder{
 		AccessToken: accessToken,
 		TokenType:   "Bearer",
 		ExpiresIn:   int64(PluginTokenExpiry.Seconds()),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // resolveInstallation runs the two-gate check: OpenFGA can_view on the

--- a/authn-api/pkg/authn/mint_plugin_token_test.go
+++ b/authn-api/pkg/authn/mint_plugin_token_test.go
@@ -55,6 +55,7 @@ const testJWTSecret = "test-secret"
 
 type mintHarness struct {
 	server                            *AuthnServer
+	client                            authnv1connect.TokenServiceClient
 	secret                            []byte
 	authz                             *fakeAuthz
 	lookup                            *fakeLookup
@@ -77,8 +78,16 @@ func newMintHarness(t *testing.T, allow bool, manifest *InstallationManifest, lo
 		authz:               az,
 		pluginInstallations: lk,
 	}
+
+	mux := http.NewServeMux()
+	path, handler := authnv1connect.NewTokenServiceHandler(server)
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
 	return &mintHarness{
 		server:         server,
+		client:         authnv1connect.NewTokenServiceClient(srv.Client(), srv.URL),
 		secret:         secret,
 		authz:          az,
 		lookup:         lk,
@@ -104,16 +113,16 @@ func (h *mintHarness) userToken(t *testing.T) string {
 	return signed
 }
 
-func (h *mintHarness) request(t *testing.T, authHeader string) *connect.Request[authnv1.MintPluginTokenRequest] {
+func (h *mintHarness) mint(t *testing.T, authHeader string) (*authnv1.MintPluginTokenResponse, error) {
 	t.Helper()
-	req := connect.NewRequest(authnv1.MintPluginTokenRequest_builder{
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	if authHeader != "" {
+		callInfo.RequestHeader().Set("Authorization", authHeader)
+	}
+	return h.client.MintPluginToken(ctx, authnv1.MintPluginTokenRequest_builder{ //nolint:wrapcheck // tests assert on the raw connect error
 		ClusterId:      h.clusterID.String(),
 		InstallationId: h.installationID.String(),
 	}.Build())
-	if authHeader != "" {
-		req.Header().Set("Authorization", authHeader)
-	}
-	return req
 }
 
 const testPluginName = "test-plugin"
@@ -129,15 +138,14 @@ func activeManifest() *InstallationManifest {
 
 func TestMintPluginToken_Success(t *testing.T) {
 	h := newMintHarness(t, true, activeManifest(), nil)
-	req := h.request(t, "Bearer "+h.userToken(t))
 
-	resp, err := h.server.MintPluginToken(context.Background(), req)
+	resp, err := h.mint(t, "Bearer "+h.userToken(t))
 	require.NoError(t, err, "MintPluginToken")
 
-	assert.Equal(t, "Bearer", resp.Msg.GetTokenType())
-	assert.Equal(t, int64(PluginTokenExpiry.Seconds()), resp.Msg.GetExpiresIn())
+	assert.Equal(t, "Bearer", resp.GetTokenType())
+	assert.Equal(t, int64(PluginTokenExpiry.Seconds()), resp.GetExpiresIn())
 
-	claims, err := auth.ParsePluginToken(resp.Msg.GetAccessToken(), h.secret)
+	claims, err := auth.ParsePluginToken(resp.GetAccessToken(), h.secret)
 	require.NoError(t, err, "parse minted token")
 
 	assert.Equal(t, h.userID.String(), claims.Subject)
@@ -151,9 +159,8 @@ func TestMintPluginToken_Success(t *testing.T) {
 
 func TestMintPluginToken_NoAuthorization_Unauthenticated(t *testing.T) {
 	h := newMintHarness(t, true, activeManifest(), nil)
-	req := h.request(t, "")
 
-	_, err := h.server.MintPluginToken(context.Background(), req)
+	_, err := h.mint(t, "")
 	assertConnectCode(t, err, connect.CodeUnauthenticated)
 }
 
@@ -170,17 +177,15 @@ func TestMintPluginToken_PluginAudienceRejected(t *testing.T) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := token.SignedString(h.secret)
 	require.NoError(t, err, "sign")
-	req := h.request(t, "Bearer "+signed)
 
-	_, err = h.server.MintPluginToken(context.Background(), req)
+	_, err = h.mint(t, "Bearer "+signed)
 	assertConnectCode(t, err, connect.CodeUnauthenticated)
 }
 
 func TestMintPluginToken_CanViewDenied_NotFound(t *testing.T) {
 	h := newMintHarness(t, false, activeManifest(), nil)
-	req := h.request(t, "Bearer "+h.userToken(t))
 
-	_, err := h.server.MintPluginToken(context.Background(), req)
+	_, err := h.mint(t, "Bearer "+h.userToken(t))
 	assertConnectCode(t, err, connect.CodeNotFound)
 
 	assert.Equal(t, 0, h.lookup.calls, "installation lookup should not be called when cluster view denied")
@@ -188,9 +193,8 @@ func TestMintPluginToken_CanViewDenied_NotFound(t *testing.T) {
 
 func TestMintPluginToken_InstallationNotFound(t *testing.T) {
 	h := newMintHarness(t, true, nil, ErrInstallationNotFound)
-	req := h.request(t, "Bearer "+h.userToken(t))
 
-	_, err := h.server.MintPluginToken(context.Background(), req)
+	_, err := h.mint(t, "Bearer "+h.userToken(t))
 	assertConnectCode(t, err, connect.CodeNotFound)
 }
 
@@ -199,15 +203,14 @@ func TestMintPluginToken_InstallationNotFound(t *testing.T) {
 // be rejected by a UserToken validator on the audience pin.
 func TestMintedTokenRejectedAsUserToken(t *testing.T) {
 	h := newMintHarness(t, true, activeManifest(), nil)
-	req := h.request(t, "Bearer "+h.userToken(t))
 
-	resp, err := h.server.MintPluginToken(context.Background(), req)
+	resp, err := h.mint(t, "Bearer "+h.userToken(t))
 	require.NoError(t, err, "MintPluginToken")
 
 	userValidator := auth.NewValidatorForAudience(h.secret,
 		auth.ConsoleAuthCookieName, auth.ConsoleIssuer, auth.TokenTypeUser, nil)
 	header := http.Header{}
-	header.Set("Authorization", "Bearer "+resp.Msg.GetAccessToken())
+	header.Set("Authorization", "Bearer "+resp.GetAccessToken())
 	_, err = userValidator.Validate(header)
 	require.Error(t, err, "user validator accepted a PluginToken")
 	assert.Contains(t, err.Error(), "audience", "expected audience-mismatch error")
@@ -227,9 +230,8 @@ func TestMintPluginToken_WrongSecret_Unauthenticated(t *testing.T) {
 	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).
 		SignedString([]byte("different-secret"))
 	require.NoError(t, err, "sign")
-	req := h.request(t, "Bearer "+signed)
 
-	_, err = h.server.MintPluginToken(context.Background(), req)
+	_, err = h.mint(t, "Bearer "+signed)
 	assertConnectCode(t, err, connect.CodeUnauthenticated)
 }
 
@@ -246,9 +248,8 @@ func TestMintPluginToken_ExpiredToken_Unauthenticated(t *testing.T) {
 	}
 	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(h.secret)
 	require.NoError(t, err, "sign")
-	req := h.request(t, "Bearer "+signed)
 
-	_, err = h.server.MintPluginToken(context.Background(), req)
+	_, err = h.mint(t, "Bearer "+signed)
 	assertConnectCode(t, err, connect.CodeUnauthenticated)
 }
 
@@ -265,13 +266,13 @@ func TestMintPluginToken_MalformedUUID_InvalidArgument(t *testing.T) {
 	defer srv.Close()
 
 	client := authnv1connect.NewTokenServiceClient(srv.Client(), srv.URL)
-	req := connect.NewRequest(authnv1.MintPluginTokenRequest_builder{
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+h.userToken(t))
+
+	_, err := client.MintPluginToken(ctx, authnv1.MintPluginTokenRequest_builder{
 		ClusterId:      "not-a-uuid",
 		InstallationId: h.installationID.String(),
 	}.Build())
-	req.Header().Set("Authorization", "Bearer "+h.userToken(t))
-
-	_, err := client.MintPluginToken(context.Background(), req)
 	assertConnectCode(t, err, connect.CodeInvalidArgument)
 
 	assert.Equal(t, 0, h.authz.calls, "authz.Evaluate should not be called when proto validation rejects")
@@ -281,9 +282,8 @@ func TestMintPluginToken_MalformedUUID_InvalidArgument(t *testing.T) {
 func TestMintPluginToken_AuthzError_Internal(t *testing.T) {
 	h := newMintHarness(t, true, activeManifest(), nil)
 	h.authz.err = errors.New("openfga unreachable")
-	req := h.request(t, "Bearer "+h.userToken(t))
 
-	_, err := h.server.MintPluginToken(context.Background(), req)
+	_, err := h.mint(t, "Bearer "+h.userToken(t))
 	assertConnectCode(t, err, connect.CodeInternal)
 }
 

--- a/authn-api/pkg/authn/plugin_installation.go
+++ b/authn-api/pkg/authn/plugin_installation.go
@@ -48,11 +48,11 @@ func NewPluginProxyLookup(client pluginproxyv1connect.PluginInstallationServiceC
 func (l *pluginProxyLookup) GetInstallationManifest(
 	ctx context.Context, clusterID, installationID uuid.UUID,
 ) (*InstallationManifest, error) {
-	resp, err := l.client.GetInstallationManifest(ctx, connect.NewRequest(
+	resp, err := l.client.GetInstallationManifest(ctx,
 		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      clusterID.String(),
 			InstallationId: installationID.String(),
-		}.Build()))
+		}.Build())
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return nil, ErrInstallationNotFound
@@ -60,11 +60,10 @@ func (l *pluginProxyLookup) GetInstallationManifest(
 		return nil, fmt.Errorf("plugin-proxy get installation manifest: %w", err)
 	}
 
-	msg := resp.Msg
 	return &InstallationManifest{
-		InstallationName: msg.GetInstallationName(),
-		PluginName:       msg.GetPluginName(),
-		PluginVersion:    msg.GetPluginVersion(),
-		DefinitionHash:   msg.GetDefinitionHash(),
+		InstallationName: resp.GetInstallationName(),
+		PluginName:       resp.GetPluginName(),
+		PluginVersion:    resp.GetPluginVersion(),
+		DefinitionHash:   resp.GetDefinitionHash(),
 	}, nil
 }

--- a/authn-api/pkg/authn/plugin_installation_test.go
+++ b/authn-api/pkg/authn/plugin_installation_test.go
@@ -25,12 +25,12 @@ var _ pluginproxyv1connect.PluginInstallationServiceClient = (*fakeProxyClient)(
 
 func (f *fakeProxyClient) GetInstallationManifest(
 	_ context.Context,
-	_ *connect.Request[pluginproxyv1.GetInstallationManifestRequest],
-) (*connect.Response[pluginproxyv1.GetInstallationManifestResponse], error) {
+	_ *pluginproxyv1.GetInstallationManifestRequest,
+) (*pluginproxyv1.GetInstallationManifestResponse, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
-	return connect.NewResponse(f.resp), nil
+	return f.resp, nil
 }
 
 func TestPluginProxyLookup_Success(t *testing.T) {

--- a/authn-api/pkg/proto/buf.gen.yaml
+++ b/authn-api/pkg/proto/buf.gen.yaml
@@ -5,4 +5,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple

--- a/authn-api/pkg/proto/gen/authn/v1/authnv1connect/authn.connect.go
+++ b/authn-api/pkg/proto/gen/authn/v1/authnv1connect/authn.connect.go
@@ -50,7 +50,7 @@ const (
 type AuthnServiceClient interface {
 	// GetUserInfo returns the current user's information
 	// Validates the JWT from Authorization header or cookie
-	GetUserInfo(context.Context, *connect.Request[v1.GetUserInfoRequest]) (*connect.Response[v1.GetUserInfoResponse], error)
+	GetUserInfo(context.Context, *v1.GetUserInfoRequest) (*v1.GetUserInfoResponse, error)
 }
 
 // NewAuthnServiceClient constructs a client for the authn.v1.AuthnService service. By default, it
@@ -79,15 +79,19 @@ type authnServiceClient struct {
 }
 
 // GetUserInfo calls authn.v1.AuthnService.GetUserInfo.
-func (c *authnServiceClient) GetUserInfo(ctx context.Context, req *connect.Request[v1.GetUserInfoRequest]) (*connect.Response[v1.GetUserInfoResponse], error) {
-	return c.getUserInfo.CallUnary(ctx, req)
+func (c *authnServiceClient) GetUserInfo(ctx context.Context, req *v1.GetUserInfoRequest) (*v1.GetUserInfoResponse, error) {
+	response, err := c.getUserInfo.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // AuthnServiceHandler is an implementation of the authn.v1.AuthnService service.
 type AuthnServiceHandler interface {
 	// GetUserInfo returns the current user's information
 	// Validates the JWT from Authorization header or cookie
-	GetUserInfo(context.Context, *connect.Request[v1.GetUserInfoRequest]) (*connect.Response[v1.GetUserInfoResponse], error)
+	GetUserInfo(context.Context, *v1.GetUserInfoRequest) (*v1.GetUserInfoResponse, error)
 }
 
 // NewAuthnServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -97,7 +101,7 @@ type AuthnServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewAuthnServiceHandler(svc AuthnServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	authnServiceMethods := v1.File_authn_v1_authn_proto.Services().ByName("AuthnService").Methods()
-	authnServiceGetUserInfoHandler := connect.NewUnaryHandler(
+	authnServiceGetUserInfoHandler := connect.NewUnaryHandlerSimple(
 		AuthnServiceGetUserInfoProcedure,
 		svc.GetUserInfo,
 		connect.WithSchema(authnServiceMethods.ByName("GetUserInfo")),
@@ -116,7 +120,7 @@ func NewAuthnServiceHandler(svc AuthnServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedAuthnServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedAuthnServiceHandler struct{}
 
-func (UnimplementedAuthnServiceHandler) GetUserInfo(context.Context, *connect.Request[v1.GetUserInfoRequest]) (*connect.Response[v1.GetUserInfoResponse], error) {
+func (UnimplementedAuthnServiceHandler) GetUserInfo(context.Context, *v1.GetUserInfoRequest) (*v1.GetUserInfoResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("authn.v1.AuthnService.GetUserInfo is not implemented"))
 }
 
@@ -124,12 +128,12 @@ func (UnimplementedAuthnServiceHandler) GetUserInfo(context.Context, *connect.Re
 type TokenServiceClient interface {
 	// ExchangeToken exchanges an API key for a short-lived JWT
 	// The API key should be provided in the Authorization header as Bearer token
-	ExchangeToken(context.Context, *connect.Request[v1.ExchangeTokenRequest]) (*connect.Response[v1.ExchangeTokenResponse], error)
+	ExchangeToken(context.Context, *v1.ExchangeTokenRequest) (*v1.ExchangeTokenResponse, error)
 	// MintPluginToken issues a short-lived JWT scoped to a specific plugin
 	// installation on a specific cluster. The caller authenticates with a
 	// UserToken. The minted token carries aud=fundament-plugin and is rejected
 	// by every API except kube-api-proxy and plugin-proxy.
-	MintPluginToken(context.Context, *connect.Request[v1.MintPluginTokenRequest]) (*connect.Response[v1.MintPluginTokenResponse], error)
+	MintPluginToken(context.Context, *v1.MintPluginTokenRequest) (*v1.MintPluginTokenResponse, error)
 }
 
 // NewTokenServiceClient constructs a client for the authn.v1.TokenService service. By default, it
@@ -165,25 +169,33 @@ type tokenServiceClient struct {
 }
 
 // ExchangeToken calls authn.v1.TokenService.ExchangeToken.
-func (c *tokenServiceClient) ExchangeToken(ctx context.Context, req *connect.Request[v1.ExchangeTokenRequest]) (*connect.Response[v1.ExchangeTokenResponse], error) {
-	return c.exchangeToken.CallUnary(ctx, req)
+func (c *tokenServiceClient) ExchangeToken(ctx context.Context, req *v1.ExchangeTokenRequest) (*v1.ExchangeTokenResponse, error) {
+	response, err := c.exchangeToken.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // MintPluginToken calls authn.v1.TokenService.MintPluginToken.
-func (c *tokenServiceClient) MintPluginToken(ctx context.Context, req *connect.Request[v1.MintPluginTokenRequest]) (*connect.Response[v1.MintPluginTokenResponse], error) {
-	return c.mintPluginToken.CallUnary(ctx, req)
+func (c *tokenServiceClient) MintPluginToken(ctx context.Context, req *v1.MintPluginTokenRequest) (*v1.MintPluginTokenResponse, error) {
+	response, err := c.mintPluginToken.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // TokenServiceHandler is an implementation of the authn.v1.TokenService service.
 type TokenServiceHandler interface {
 	// ExchangeToken exchanges an API key for a short-lived JWT
 	// The API key should be provided in the Authorization header as Bearer token
-	ExchangeToken(context.Context, *connect.Request[v1.ExchangeTokenRequest]) (*connect.Response[v1.ExchangeTokenResponse], error)
+	ExchangeToken(context.Context, *v1.ExchangeTokenRequest) (*v1.ExchangeTokenResponse, error)
 	// MintPluginToken issues a short-lived JWT scoped to a specific plugin
 	// installation on a specific cluster. The caller authenticates with a
 	// UserToken. The minted token carries aud=fundament-plugin and is rejected
 	// by every API except kube-api-proxy and plugin-proxy.
-	MintPluginToken(context.Context, *connect.Request[v1.MintPluginTokenRequest]) (*connect.Response[v1.MintPluginTokenResponse], error)
+	MintPluginToken(context.Context, *v1.MintPluginTokenRequest) (*v1.MintPluginTokenResponse, error)
 }
 
 // NewTokenServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -193,13 +205,13 @@ type TokenServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewTokenServiceHandler(svc TokenServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	tokenServiceMethods := v1.File_authn_v1_authn_proto.Services().ByName("TokenService").Methods()
-	tokenServiceExchangeTokenHandler := connect.NewUnaryHandler(
+	tokenServiceExchangeTokenHandler := connect.NewUnaryHandlerSimple(
 		TokenServiceExchangeTokenProcedure,
 		svc.ExchangeToken,
 		connect.WithSchema(tokenServiceMethods.ByName("ExchangeToken")),
 		connect.WithHandlerOptions(opts...),
 	)
-	tokenServiceMintPluginTokenHandler := connect.NewUnaryHandler(
+	tokenServiceMintPluginTokenHandler := connect.NewUnaryHandlerSimple(
 		TokenServiceMintPluginTokenProcedure,
 		svc.MintPluginToken,
 		connect.WithSchema(tokenServiceMethods.ByName("MintPluginToken")),
@@ -220,10 +232,10 @@ func NewTokenServiceHandler(svc TokenServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedTokenServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTokenServiceHandler struct{}
 
-func (UnimplementedTokenServiceHandler) ExchangeToken(context.Context, *connect.Request[v1.ExchangeTokenRequest]) (*connect.Response[v1.ExchangeTokenResponse], error) {
+func (UnimplementedTokenServiceHandler) ExchangeToken(context.Context, *v1.ExchangeTokenRequest) (*v1.ExchangeTokenResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("authn.v1.TokenService.ExchangeToken is not implemented"))
 }
 
-func (UnimplementedTokenServiceHandler) MintPluginToken(context.Context, *connect.Request[v1.MintPluginTokenRequest]) (*connect.Response[v1.MintPluginTokenResponse], error) {
+func (UnimplementedTokenServiceHandler) MintPluginToken(context.Context, *v1.MintPluginTokenRequest) (*v1.MintPluginTokenResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("authn.v1.TokenService.MintPluginToken is not implemented"))
 }

--- a/dcim-api/pkg/dcim/asset_create.go
+++ b/dcim-api/pkg/dcim/asset_create.go
@@ -17,41 +17,41 @@ import (
 
 func (s *Server) CreateAsset(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateAssetRequest],
-) (*connect.Response[dcimv1.CreateAssetResponse], error) {
+	req *dcimv1.CreateAssetRequest,
+) (*dcimv1.CreateAssetResponse, error) {
 	params := db.AssetCreateParams{
-		DeviceCatalogID: uuid.MustParse(req.Msg.GetDeviceCatalogId()),
-		Status:          assetStatusToDB(req.Msg.GetStatus()),
+		DeviceCatalogID: uuid.MustParse(req.GetDeviceCatalogId()),
+		Status:          assetStatusToDB(req.GetStatus()),
 	}
 
-	if req.Msg.HasSerialNumber() {
-		params.SerialNumber = pgtype.Text{String: req.Msg.GetSerialNumber(), Valid: true}
+	if req.HasSerialNumber() {
+		params.SerialNumber = pgtype.Text{String: req.GetSerialNumber(), Valid: true}
 	}
 
-	if req.Msg.HasAssetTag() {
-		params.AssetTag = pgtype.Text{String: req.Msg.GetAssetTag(), Valid: true}
+	if req.HasAssetTag() {
+		params.AssetTag = pgtype.Text{String: req.GetAssetTag(), Valid: true}
 	}
 
-	if req.Msg.HasPurchaseDate() {
+	if req.HasPurchaseDate() {
 		params.PurchaseDate = pgtype.Date{
-			Time:  req.Msg.GetPurchaseDate().AsTime(),
+			Time:  req.GetPurchaseDate().AsTime(),
 			Valid: true,
 		}
 	}
 
-	if req.Msg.HasPurchaseOrder() {
-		params.PurchaseOrder = pgtype.Text{String: req.Msg.GetPurchaseOrder(), Valid: true}
+	if req.HasPurchaseOrder() {
+		params.PurchaseOrder = pgtype.Text{String: req.GetPurchaseOrder(), Valid: true}
 	}
 
-	if req.Msg.HasWarrantyExpiry() {
+	if req.HasWarrantyExpiry() {
 		params.WarrantyExpiry = pgtype.Date{
-			Time:  req.Msg.GetWarrantyExpiry().AsTime(),
+			Time:  req.GetWarrantyExpiry().AsTime(),
 			Valid: true,
 		}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	id, err := s.queries.AssetCreate(ctx, params)
@@ -72,7 +72,7 @@ func (s *Server) CreateAsset(
 
 	s.logger.InfoContext(ctx, "asset created", "asset_id", id)
 
-	return connect.NewResponse(dcimv1.CreateAssetResponse_builder{
+	return dcimv1.CreateAssetResponse_builder{
 		AssetId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_delete.go
+++ b/dcim-api/pkg/dcim/asset_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteAsset(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteAssetRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	assetID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteAssetRequest,
+) (*emptypb.Empty, error) {
+	assetID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.AssetDelete(ctx, db.AssetDeleteParams{ID: assetID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteAsset(
 
 	s.logger.InfoContext(ctx, "asset deleted", "asset_id", assetID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/asset_events.go
+++ b/dcim-api/pkg/dcim/asset_events.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) GetAssetEvents(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetAssetEventsRequest],
-) (*connect.Response[dcimv1.GetAssetEventsResponse], error) {
-	assetID := uuid.MustParse(req.Msg.GetAssetId())
+	req *dcimv1.GetAssetEventsRequest,
+) (*dcimv1.GetAssetEventsResponse, error) {
+	assetID := uuid.MustParse(req.GetAssetId())
 
 	rows, err := s.queries.AssetEventList(ctx, db.AssetEventListParams{AssetID: assetID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetAssetEvents(
 		events = append(events, assetEventFromRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.GetAssetEventsResponse_builder{
+	return dcimv1.GetAssetEventsResponse_builder{
 		Events: events,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_get.go
+++ b/dcim-api/pkg/dcim/asset_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetAsset(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetAssetRequest],
-) (*connect.Response[dcimv1.GetAssetResponse], error) {
-	assetID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetAssetRequest,
+) (*dcimv1.GetAssetResponse, error) {
+	assetID := uuid.MustParse(req.GetId())
 
 	row, err := s.queries.AssetGetByID(ctx, db.AssetGetByIDParams{ID: assetID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetAsset(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get asset: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetAssetResponse_builder{
+	return dcimv1.GetAssetResponse_builder{
 		Asset: assetFromGetRow(&row),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_list.go
+++ b/dcim-api/pkg/dcim/asset_list.go
@@ -14,25 +14,25 @@ import (
 
 func (s *Server) ListAssets(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListAssetsRequest],
-) (*connect.Response[dcimv1.ListAssetsResponse], error) {
+	req *dcimv1.ListAssetsRequest,
+) (*dcimv1.ListAssetsResponse, error) {
 	params := db.AssetListParams{}
 
-	if req.Msg.GetIncludeDeleted() {
+	if req.GetIncludeDeleted() {
 		params.IncludeDeleted = pgtype.Bool{Bool: true, Valid: true}
 	}
 
-	if req.Msg.HasStatusFilter() {
-		params.Status = pgtype.Text{String: assetStatusToDB(req.Msg.GetStatusFilter()), Valid: true}
+	if req.HasStatusFilter() {
+		params.Status = pgtype.Text{String: assetStatusToDB(req.GetStatusFilter()), Valid: true}
 	}
 
-	if req.Msg.HasDeviceCatalogId() {
-		catalogID := uuid.MustParse(req.Msg.GetDeviceCatalogId())
+	if req.HasDeviceCatalogId() {
+		catalogID := uuid.MustParse(req.GetDeviceCatalogId())
 		params.DeviceCatalogID = pgtype.UUID{Bytes: catalogID, Valid: true}
 	}
 
-	if req.Msg.HasSearch() {
-		params.Search = pgtype.Text{String: req.Msg.GetSearch(), Valid: true}
+	if req.HasSearch() {
+		params.Search = pgtype.Text{String: req.GetSearch(), Valid: true}
 	}
 
 	rows, err := s.queries.AssetList(ctx, params)
@@ -45,7 +45,7 @@ func (s *Server) ListAssets(
 		assets = append(assets, assetFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListAssetsResponse_builder{
+	return dcimv1.ListAssetsResponse_builder{
 		Assets: assets,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_location.go
+++ b/dcim-api/pkg/dcim/asset_location.go
@@ -18,9 +18,9 @@ import (
 // (rack -> rack_row -> room -> site) to human-readable names.
 func (s *Server) GetAssetLocation(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetAssetLocationRequest],
-) (*connect.Response[dcimv1.GetAssetLocationResponse], error) {
-	assetID := uuid.MustParse(req.Msg.GetAssetId())
+	req *dcimv1.GetAssetLocationRequest,
+) (*dcimv1.GetAssetLocationResponse, error) {
+	assetID := uuid.MustParse(req.GetAssetId())
 
 	loc, err := s.queries.PlacementResolveLocationByAsset(ctx, db.PlacementResolveLocationByAssetParams{
 		AssetID: assetID,
@@ -40,12 +40,12 @@ func (s *Server) GetAssetLocation(
 					"rack_id", uuid.UUID(rackRef.RackID.Bytes),
 				)
 			}
-			return connect.NewResponse(dcimv1.GetAssetLocationResponse_builder{}.Build()), nil
+			return dcimv1.GetAssetLocationResponse_builder{}.Build(), nil
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to resolve asset location: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetAssetLocationResponse_builder{
+	return dcimv1.GetAssetLocationResponse_builder{
 		Location: dcimv1.AssetLocation_builder{
 			SiteName:      loc.SiteName,
 			RoomName:      loc.RoomName,
@@ -55,5 +55,5 @@ func (s *Server) GetAssetLocation(
 			RackId:        uuid.UUID(loc.RackID.Bytes).String(),
 			RackSlotType:  rackSlotTypeToProto(loc.SlotType.String),
 		}.Build(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_location_test.go
+++ b/dcim-api/pkg/dcim/asset_location_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -26,12 +25,12 @@ func TestAssetService_GetAssetLocation_Rack(t *testing.T) {
 	assetID := createAsset(t, env, catalogID)
 	placeAssetInRack(t, env, assetID, rackID, 5)
 
-	resp, err := client.GetAssetLocation(context.Background(), connect.NewRequest(
+	resp, err := client.GetAssetLocation(context.Background(),
 		(&dcimv1.GetAssetLocationRequest_builder{AssetId: assetID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	loc := resp.Msg.GetLocation()
+	loc := resp.GetLocation()
 	require.NotNil(t, loc)
 	assert.Equal(t, "Loc site", loc.GetSiteName())
 	assert.Equal(t, "Loc room", loc.GetRoomName())
@@ -62,26 +61,26 @@ func TestAssetService_GetAssetLocation_SubComponentResolvesToHostRack(t *testing
 	// Define a port on the host so the sub-component placement has a real
 	// parent_port_definition_id to point at.
 	catalogClient := dcimv1connect.NewCatalogServiceClient(env.client(), env.server.URL)
-	portResp, err := catalogClient.CreatePortDefinition(context.Background(), connect.NewRequest(
+	portResp, err := catalogClient.CreatePortDefinition(context.Background(),
 		(&dcimv1.CreatePortDefinitionRequest_builder{
 			DeviceCatalogId: hostCatalogID,
 			Name:            "slot0",
 			PortType:        dcimv1.PortType_PORT_TYPE_SLOT,
 			Direction:       dcimv1.PortDirection_PORT_DIRECTION_BIDIR,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	componentCatalogID := createCatalogEntry(t, env, "Component model")
 	componentAssetID := createAsset(t, env, componentCatalogID)
-	placeAssetInSubComponent(t, env, componentAssetID, hostPlacementID, portResp.Msg.GetPortDefinitionId())
+	placeAssetInSubComponent(t, env, componentAssetID, hostPlacementID, portResp.GetPortDefinitionId())
 
-	resp, err := client.GetAssetLocation(context.Background(), connect.NewRequest(
+	resp, err := client.GetAssetLocation(context.Background(),
 		(&dcimv1.GetAssetLocationRequest_builder{AssetId: componentAssetID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	loc := resp.Msg.GetLocation()
+	loc := resp.GetLocation()
 	require.NotNil(t, loc)
 	assert.Equal(t, "Nested rack", loc.GetRackName())
 	assert.Equal(t, rackID, loc.GetRackId())
@@ -97,11 +96,11 @@ func TestAssetService_GetAssetLocation_Unplaced(t *testing.T) {
 	catalogID := createCatalogEntry(t, env, "Unplaced model")
 	assetID := createAsset(t, env, catalogID)
 
-	resp, err := client.GetAssetLocation(context.Background(), connect.NewRequest(
+	resp, err := client.GetAssetLocation(context.Background(),
 		(&dcimv1.GetAssetLocationRequest_builder{AssetId: assetID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	// No location means the rack id is empty.
-	assert.Empty(t, resp.Msg.GetLocation().GetRackId())
+	assert.Empty(t, resp.GetLocation().GetRackId())
 }

--- a/dcim-api/pkg/dcim/asset_stats.go
+++ b/dcim-api/pkg/dcim/asset_stats.go
@@ -11,14 +11,14 @@ import (
 
 func (s *Server) GetAssetStats(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetAssetStatsRequest],
-) (*connect.Response[dcimv1.GetAssetStatsResponse], error) {
+	req *dcimv1.GetAssetStatsRequest,
+) (*dcimv1.GetAssetStatsResponse, error) {
 	row, err := s.queries.AssetStats(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get asset stats: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetAssetStatsResponse_builder{
+	return dcimv1.GetAssetStatsResponse_builder{
 		Stats: dcimv1.AssetStats_builder{
 			Total:          row.Total,
 			Available:      row.Available,
@@ -28,5 +28,5 @@ func (s *Server) GetAssetStats(
 			Requested:      row.Requested,
 			Decommissioned: row.Decommissioned,
 		}.Build(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/asset_update.go
+++ b/dcim-api/pkg/dcim/asset_update.go
@@ -18,35 +18,35 @@ import (
 
 func (s *Server) UpdateAsset(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateAssetRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	assetID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateAssetRequest,
+) (*emptypb.Empty, error) {
+	assetID := uuid.MustParse(req.GetId())
 
 	params := db.AssetUpdateParams{
 		ID: assetID,
 	}
 
-	if req.Msg.HasStatus() {
-		params.Status = pgtype.Text{String: assetStatusToDB(req.Msg.GetStatus()), Valid: true}
+	if req.HasStatus() {
+		params.Status = pgtype.Text{String: assetStatusToDB(req.GetStatus()), Valid: true}
 	}
 
-	if req.Msg.HasSerialNumber() {
-		params.SerialNumber = pgtype.Text{String: req.Msg.GetSerialNumber(), Valid: true}
+	if req.HasSerialNumber() {
+		params.SerialNumber = pgtype.Text{String: req.GetSerialNumber(), Valid: true}
 	}
 
-	if req.Msg.HasAssetTag() {
-		params.AssetTag = pgtype.Text{String: req.Msg.GetAssetTag(), Valid: true}
+	if req.HasAssetTag() {
+		params.AssetTag = pgtype.Text{String: req.GetAssetTag(), Valid: true}
 	}
 
-	if req.Msg.HasWarrantyExpiry() {
+	if req.HasWarrantyExpiry() {
 		params.WarrantyExpiry = pgtype.Date{
-			Time:  req.Msg.GetWarrantyExpiry().AsTime(),
+			Time:  req.GetWarrantyExpiry().AsTime(),
 			Valid: true,
 		}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.AssetUpdate(ctx, params)
@@ -69,5 +69,5 @@ func (s *Server) UpdateAsset(
 
 	s.logger.InfoContext(ctx, "asset updated", "asset_id", assetID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/catalog_create.go
+++ b/dcim-api/pkg/dcim/catalog_create.go
@@ -16,30 +16,30 @@ import (
 
 func (s *Server) CreateCatalogEntry(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateCatalogEntryRequest],
-) (*connect.Response[dcimv1.CreateCatalogEntryResponse], error) {
+	req *dcimv1.CreateCatalogEntryRequest,
+) (*dcimv1.CreateCatalogEntryResponse, error) {
 	params := db.DeviceCatalogCreateParams{
-		Manufacturer: req.Msg.GetManufacturer(),
-		Model:        req.Msg.GetModel(),
-		PartNumber:   pgtype.Text{String: req.Msg.GetPartNumber(), Valid: true},
-		Category:     assetCategoryToDB(req.Msg.GetCategory()),
-		Specs:        specsToDB(req.Msg.GetSpecs()),
+		Manufacturer: req.GetManufacturer(),
+		Model:        req.GetModel(),
+		PartNumber:   pgtype.Text{String: req.GetPartNumber(), Valid: true},
+		Category:     assetCategoryToDB(req.GetCategory()),
+		Specs:        specsToDB(req.GetSpecs()),
 	}
 
-	if req.Msg.HasFormFactor() {
-		params.FormFactor = pgtype.Text{String: req.Msg.GetFormFactor(), Valid: true}
+	if req.HasFormFactor() {
+		params.FormFactor = pgtype.Text{String: req.GetFormFactor(), Valid: true}
 	}
 
-	if req.Msg.HasRackUnits() {
-		params.RackUnits = pgtype.Int4{Int32: req.Msg.GetRackUnits(), Valid: true}
+	if req.HasRackUnits() {
+		params.RackUnits = pgtype.Int4{Int32: req.GetRackUnits(), Valid: true}
 	}
 
-	if req.Msg.GetWeightKg() != 0 {
-		params.WeightKg = float64ToNumeric(req.Msg.GetWeightKg())
+	if req.GetWeightKg() != 0 {
+		params.WeightKg = float64ToNumeric(req.GetWeightKg())
 	}
 
-	if req.Msg.GetPowerDrawW() != 0 {
-		params.PowerDrawW = float64ToNumeric(req.Msg.GetPowerDrawW())
+	if req.GetPowerDrawW() != 0 {
+		params.PowerDrawW = float64ToNumeric(req.GetPowerDrawW())
 	}
 
 	id, err := s.queries.DeviceCatalogCreate(ctx, params)
@@ -53,7 +53,7 @@ func (s *Server) CreateCatalogEntry(
 
 	s.logger.InfoContext(ctx, "catalog entry created", "catalog_entry_id", id)
 
-	return connect.NewResponse(dcimv1.CreateCatalogEntryResponse_builder{
+	return dcimv1.CreateCatalogEntryResponse_builder{
 		CatalogEntryId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/catalog_delete.go
+++ b/dcim-api/pkg/dcim/catalog_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteCatalogEntry(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteCatalogEntryRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	catalogID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteCatalogEntryRequest,
+) (*emptypb.Empty, error) {
+	catalogID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.DeviceCatalogDelete(ctx, db.DeviceCatalogDeleteParams{ID: catalogID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteCatalogEntry(
 
 	s.logger.InfoContext(ctx, "catalog entry deleted", "catalog_entry_id", catalogID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/catalog_get.go
+++ b/dcim-api/pkg/dcim/catalog_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetCatalogEntry(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetCatalogEntryRequest],
-) (*connect.Response[dcimv1.GetCatalogEntryResponse], error) {
-	catalogID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetCatalogEntryRequest,
+) (*dcimv1.GetCatalogEntryResponse, error) {
+	catalogID := uuid.MustParse(req.GetId())
 
 	row, err := s.queries.DeviceCatalogGetByID(ctx, db.DeviceCatalogGetByIDParams{ID: catalogID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetCatalogEntry(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get catalog entry: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetCatalogEntryResponse_builder{
+	return dcimv1.GetCatalogEntryResponse_builder{
 		Entry: catalogFromGetRow(&row),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/catalog_list.go
+++ b/dcim-api/pkg/dcim/catalog_list.go
@@ -14,16 +14,16 @@ import (
 
 func (s *Server) ListCatalog(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListCatalogRequest],
-) (*connect.Response[dcimv1.ListCatalogResponse], error) {
+	req *dcimv1.ListCatalogRequest,
+) (*dcimv1.ListCatalogResponse, error) {
 	params := db.DeviceCatalogListParams{}
 
-	if req.Msg.HasCategoryFilter() {
-		params.Category = pgtype.Text{String: assetCategoryToDB(req.Msg.GetCategoryFilter()), Valid: true}
+	if req.HasCategoryFilter() {
+		params.Category = pgtype.Text{String: assetCategoryToDB(req.GetCategoryFilter()), Valid: true}
 	}
 
-	if req.Msg.HasSearch() {
-		params.Search = pgtype.Text{String: req.Msg.GetSearch(), Valid: true}
+	if req.HasSearch() {
+		params.Search = pgtype.Text{String: req.GetSearch(), Valid: true}
 	}
 
 	rows, err := s.queries.DeviceCatalogList(ctx, params)
@@ -62,7 +62,7 @@ func (s *Server) ListCatalog(
 		entries = append(entries, summary.Build())
 	}
 
-	return connect.NewResponse(dcimv1.ListCatalogResponse_builder{
+	return dcimv1.ListCatalogResponse_builder{
 		Entries: entries,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/catalog_list_assets.go
+++ b/dcim-api/pkg/dcim/catalog_list_assets.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListAssetsByCatalogEntry(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListAssetsByCatalogEntryRequest],
-) (*connect.Response[dcimv1.ListAssetsByCatalogEntryResponse], error) {
-	catalogID := uuid.MustParse(req.Msg.GetDeviceCatalogId())
+	req *dcimv1.ListAssetsByCatalogEntryRequest,
+) (*dcimv1.ListAssetsByCatalogEntryResponse, error) {
+	catalogID := uuid.MustParse(req.GetDeviceCatalogId())
 
 	rows, err := s.queries.AssetListByCatalogID(ctx, db.AssetListByCatalogIDParams{DeviceCatalogID: catalogID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) ListAssetsByCatalogEntry(
 		assets = append(assets, assetFromListByCatalogRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListAssetsByCatalogEntryResponse_builder{
+	return dcimv1.ListAssetsByCatalogEntryResponse_builder{
 		Assets: assets,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/catalog_update.go
+++ b/dcim-api/pkg/dcim/catalog_update.go
@@ -18,48 +18,48 @@ import (
 
 func (s *Server) UpdateCatalogEntry(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateCatalogEntryRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	catalogID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateCatalogEntryRequest,
+) (*emptypb.Empty, error) {
+	catalogID := uuid.MustParse(req.GetId())
 
 	params := db.DeviceCatalogUpdateParams{
 		ID: catalogID,
 	}
 
-	if req.Msg.HasManufacturer() {
-		params.Manufacturer = pgtype.Text{String: req.Msg.GetManufacturer(), Valid: true}
+	if req.HasManufacturer() {
+		params.Manufacturer = pgtype.Text{String: req.GetManufacturer(), Valid: true}
 	}
 
-	if req.Msg.HasModel() {
-		params.Model = pgtype.Text{String: req.Msg.GetModel(), Valid: true}
+	if req.HasModel() {
+		params.Model = pgtype.Text{String: req.GetModel(), Valid: true}
 	}
 
-	if req.Msg.HasPartNumber() {
-		params.PartNumber = pgtype.Text{String: req.Msg.GetPartNumber(), Valid: true}
+	if req.HasPartNumber() {
+		params.PartNumber = pgtype.Text{String: req.GetPartNumber(), Valid: true}
 	}
 
-	if req.Msg.GetCategory() != dcimv1.AssetCategory_ASSET_CATEGORY_UNSPECIFIED {
-		params.Category = pgtype.Text{String: assetCategoryToDB(req.Msg.GetCategory()), Valid: true}
+	if req.GetCategory() != dcimv1.AssetCategory_ASSET_CATEGORY_UNSPECIFIED {
+		params.Category = pgtype.Text{String: assetCategoryToDB(req.GetCategory()), Valid: true}
 	}
 
-	if req.Msg.HasFormFactor() {
-		params.FormFactor = pgtype.Text{String: req.Msg.GetFormFactor(), Valid: true}
+	if req.HasFormFactor() {
+		params.FormFactor = pgtype.Text{String: req.GetFormFactor(), Valid: true}
 	}
 
-	if req.Msg.HasRackUnits() {
-		params.RackUnits = pgtype.Int4{Int32: req.Msg.GetRackUnits(), Valid: true}
+	if req.HasRackUnits() {
+		params.RackUnits = pgtype.Int4{Int32: req.GetRackUnits(), Valid: true}
 	}
 
-	if req.Msg.HasWeightKg() {
-		params.WeightKg = float64ToNumeric(req.Msg.GetWeightKg())
+	if req.HasWeightKg() {
+		params.WeightKg = float64ToNumeric(req.GetWeightKg())
 	}
 
-	if req.Msg.HasPowerDrawW() {
-		params.PowerDrawW = float64ToNumeric(req.Msg.GetPowerDrawW())
+	if req.HasPowerDrawW() {
+		params.PowerDrawW = float64ToNumeric(req.GetPowerDrawW())
 	}
 
-	if len(req.Msg.GetSpecs()) > 0 {
-		params.Specs = specsToDB(req.Msg.GetSpecs())
+	if len(req.GetSpecs()) > 0 {
+		params.Specs = specsToDB(req.GetSpecs())
 	}
 
 	rowsAffected, err := s.queries.DeviceCatalogUpdate(ctx, params)
@@ -77,5 +77,5 @@ func (s *Server) UpdateCatalogEntry(
 
 	s.logger.InfoContext(ctx, "catalog entry updated", "catalog_entry_id", catalogID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/design_create.go
+++ b/dcim-api/pkg/dcim/design_create.go
@@ -17,14 +17,14 @@ import (
 
 func (s *Server) CreateDesign(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateDesignRequest],
-) (*connect.Response[dcimv1.CreateDesignResponse], error) {
+	req *dcimv1.CreateDesignRequest,
+) (*dcimv1.CreateDesignResponse, error) {
 	params := db.LogicalDesignCreateParams{
-		Name: req.Msg.GetName(),
+		Name: req.GetName(),
 	}
 
-	if req.Msg.HasDescription() {
-		params.Description = pgtype.Text{String: req.Msg.GetDescription(), Valid: true}
+	if req.HasDescription() {
+		params.Description = pgtype.Text{String: req.GetDescription(), Valid: true}
 	}
 
 	id, err := s.queries.LogicalDesignCreate(ctx, params)
@@ -38,7 +38,7 @@ func (s *Server) CreateDesign(
 
 	s.logger.InfoContext(ctx, "design created", "design_id", id)
 
-	return connect.NewResponse(dcimv1.CreateDesignResponse_builder{
+	return dcimv1.CreateDesignResponse_builder{
 		DesignId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/design_delete.go
+++ b/dcim-api/pkg/dcim/design_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteDesign(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteDesignRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	designID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteDesignRequest,
+) (*emptypb.Empty, error) {
+	designID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.LogicalDesignDelete(ctx, db.LogicalDesignDeleteParams{ID: designID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteDesign(
 
 	s.logger.InfoContext(ctx, "design deleted", "design_id", designID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/design_get.go
+++ b/dcim-api/pkg/dcim/design_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetDesign(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetDesignRequest],
-) (*connect.Response[dcimv1.GetDesignResponse], error) {
-	designID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetDesignRequest,
+) (*dcimv1.GetDesignResponse, error) {
+	designID := uuid.MustParse(req.GetId())
 
 	design, err := s.queries.LogicalDesignGetByID(ctx, db.LogicalDesignGetByIDParams{ID: designID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetDesign(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get design: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetDesignResponse_builder{
+	return dcimv1.GetDesignResponse_builder{
 		Design: designFromRow(&design),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/design_list.go
+++ b/dcim-api/pkg/dcim/design_list.go
@@ -10,8 +10,8 @@ import (
 
 func (s *Server) ListDesigns(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListDesignsRequest],
-) (*connect.Response[dcimv1.ListDesignsResponse], error) {
+	req *dcimv1.ListDesignsRequest,
+) (*dcimv1.ListDesignsResponse, error) {
 	rows, err := s.queries.LogicalDesignList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list designs: %w", err))
@@ -22,7 +22,7 @@ func (s *Server) ListDesigns(
 		designs = append(designs, designFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListDesignsResponse_builder{
+	return dcimv1.ListDesignsResponse_builder{
 		Designs: designs,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/design_update.go
+++ b/dcim-api/pkg/dcim/design_update.go
@@ -19,24 +19,24 @@ import (
 
 func (s *Server) UpdateDesign(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateDesignRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	designID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateDesignRequest,
+) (*emptypb.Empty, error) {
+	designID := uuid.MustParse(req.GetId())
 
 	params := db.LogicalDesignUpdateParams{
 		ID: designID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasDescription() {
-		params.Description = pgtype.Text{String: req.Msg.GetDescription(), Valid: true}
+	if req.HasDescription() {
+		params.Description = pgtype.Text{String: req.GetDescription(), Valid: true}
 	}
 
-	if req.Msg.HasStatus() {
-		params.Status = pgtype.Text{String: logicalDesignStatusToDB(req.Msg.GetStatus()), Valid: true}
+	if req.HasStatus() {
+		params.Status = pgtype.Text{String: logicalDesignStatusToDB(req.GetStatus()), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.LogicalDesignUpdate(ctx, params)
@@ -59,5 +59,5 @@ func (s *Server) UpdateDesign(
 
 	s.logger.InfoContext(ctx, "design updated", "design_id", designID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/helpers_test.go
+++ b/dcim-api/pkg/dcim/helpers_test.go
@@ -168,14 +168,14 @@ func createSite(t *testing.T, env *testEnv, name string) string {
 
 	client := dcimv1connect.NewSiteServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateSite(context.Background(), connect.NewRequest(
+	resp, err := client.CreateSite(context.Background(),
 		(&dcimv1.CreateSiteRequest_builder{Name: name}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetSiteId())
+	require.NotEmpty(t, resp.GetSiteId())
 
-	return resp.Msg.GetSiteId()
+	return resp.GetSiteId()
 }
 
 func createRoom(t *testing.T, env *testEnv, siteID, name string) string {
@@ -183,14 +183,14 @@ func createRoom(t *testing.T, env *testEnv, siteID, name string) string {
 
 	client := dcimv1connect.NewRoomServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateRoom(context.Background(), connect.NewRequest(
+	resp, err := client.CreateRoom(context.Background(),
 		(&dcimv1.CreateRoomRequest_builder{SiteId: siteID, Name: name}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetRoomId())
+	require.NotEmpty(t, resp.GetRoomId())
 
-	return resp.Msg.GetRoomId()
+	return resp.GetRoomId()
 }
 
 func createRackRow(t *testing.T, env *testEnv, roomID, name string) string {
@@ -198,14 +198,14 @@ func createRackRow(t *testing.T, env *testEnv, roomID, name string) string {
 
 	client := dcimv1connect.NewRackRowServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateRackRow(context.Background(), connect.NewRequest(
+	resp, err := client.CreateRackRow(context.Background(),
 		(&dcimv1.CreateRackRowRequest_builder{RoomId: roomID, Name: name}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetRackRowId())
+	require.NotEmpty(t, resp.GetRackRowId())
 
-	return resp.Msg.GetRackRowId()
+	return resp.GetRackRowId()
 }
 
 // createRackRowFixture bootstraps a site → room → rack row chain and returns
@@ -225,18 +225,18 @@ func createRack(t *testing.T, env *testEnv, rowID, name string, totalUnits int32
 
 	client := dcimv1connect.NewRackServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateRack(context.Background(), connect.NewRequest(
+	resp, err := client.CreateRack(context.Background(),
 		(&dcimv1.CreateRackRequest_builder{
 			RowId:      rowID,
 			Name:       name,
 			TotalUnits: totalUnits,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetRackId())
+	require.NotEmpty(t, resp.GetRackId())
 
-	return resp.Msg.GetRackId()
+	return resp.GetRackId()
 }
 
 func createCatalogEntry(t *testing.T, env *testEnv, model string) string {
@@ -244,19 +244,19 @@ func createCatalogEntry(t *testing.T, env *testEnv, model string) string {
 
 	client := dcimv1connect.NewCatalogServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateCatalogEntry(context.Background(), connect.NewRequest(
+	resp, err := client.CreateCatalogEntry(context.Background(),
 		(&dcimv1.CreateCatalogEntryRequest_builder{
 			Manufacturer: "Test Mfr",
 			Model:        model,
 			PartNumber:   model + "-PN",
 			Category:     dcimv1.AssetCategory_ASSET_CATEGORY_SERVER,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetCatalogEntryId())
+	require.NotEmpty(t, resp.GetCatalogEntryId())
 
-	return resp.Msg.GetCatalogEntryId()
+	return resp.GetCatalogEntryId()
 }
 
 func createAsset(t *testing.T, env *testEnv, catalogID string) string {
@@ -264,17 +264,17 @@ func createAsset(t *testing.T, env *testEnv, catalogID string) string {
 
 	client := dcimv1connect.NewAssetServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateAsset(context.Background(), connect.NewRequest(
+	resp, err := client.CreateAsset(context.Background(),
 		(&dcimv1.CreateAssetRequest_builder{
 			DeviceCatalogId: catalogID,
 			Status:          dcimv1.AssetStatus_ASSET_STATUS_DEPLOYED,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetAssetId())
+	require.NotEmpty(t, resp.GetAssetId())
 
-	return resp.Msg.GetAssetId()
+	return resp.GetAssetId()
 }
 
 func placeAssetInRack(t *testing.T, env *testEnv, assetID, rackID string, unit int32) string {
@@ -282,7 +282,7 @@ func placeAssetInRack(t *testing.T, env *testEnv, assetID, rackID string, unit i
 
 	client := dcimv1connect.NewPlacementServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreatePlacement(context.Background(), connect.NewRequest(
+	resp, err := client.CreatePlacement(context.Background(),
 		(&dcimv1.CreatePlacementRequest_builder{
 			AssetId: assetID,
 			Rack: (&dcimv1.RackLocation_builder{
@@ -291,12 +291,12 @@ func placeAssetInRack(t *testing.T, env *testEnv, assetID, rackID string, unit i
 				RackSlotType:  dcimv1.RackSlotType_RACK_SLOT_TYPE_UNIT,
 			}).Build(),
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetPlacementId())
+	require.NotEmpty(t, resp.GetPlacementId())
 
-	return resp.Msg.GetPlacementId()
+	return resp.GetPlacementId()
 }
 
 // createUser seeds a directory entry. There is no CreateUser RPC — the DCIM API
@@ -325,12 +325,12 @@ func createTask(t *testing.T, env *testEnv, req *dcimv1.CreateTaskRequest) strin
 
 	client := dcimv1connect.NewTaskServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateTask(context.Background(), connect.NewRequest(req))
+	resp, err := client.CreateTask(context.Background(), req)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetTaskId())
+	require.NotEmpty(t, resp.GetTaskId())
 
-	return resp.Msg.GetTaskId()
+	return resp.GetTaskId()
 }
 
 func placeAssetInSubComponent(t *testing.T, env *testEnv, assetID, parentPlacementID, parentPortDefinitionID string) string {
@@ -338,7 +338,7 @@ func placeAssetInSubComponent(t *testing.T, env *testEnv, assetID, parentPlaceme
 
 	client := dcimv1connect.NewPlacementServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreatePlacement(context.Background(), connect.NewRequest(
+	resp, err := client.CreatePlacement(context.Background(),
 		(&dcimv1.CreatePlacementRequest_builder{
 			AssetId: assetID,
 			SubComponent: (&dcimv1.SubComponentLocation_builder{
@@ -346,10 +346,10 @@ func placeAssetInSubComponent(t *testing.T, env *testEnv, assetID, parentPlaceme
 				ParentPortDefinitionId: parentPortDefinitionID,
 			}).Build(),
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetPlacementId())
+	require.NotEmpty(t, resp.GetPlacementId())
 
-	return resp.Msg.GetPlacementId()
+	return resp.GetPlacementId()
 }

--- a/dcim-api/pkg/dcim/layout_delete.go
+++ b/dcim-api/pkg/dcim/layout_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteLayout(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteLayoutRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	designID := uuid.MustParse(req.Msg.GetDesignId())
+	req *dcimv1.DeleteLayoutRequest,
+) (*emptypb.Empty, error) {
+	designID := uuid.MustParse(req.GetDesignId())
 
 	err := s.queries.LogicalDeviceLayoutDeleteByDesign(ctx, db.LogicalDeviceLayoutDeleteByDesignParams{LogicalDesignID: designID})
 	if err != nil {
@@ -25,5 +25,5 @@ func (s *Server) DeleteLayout(
 
 	s.logger.InfoContext(ctx, "layout deleted", "design_id", designID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/layout_get.go
+++ b/dcim-api/pkg/dcim/layout_get.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) GetLayout(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetLayoutRequest],
-) (*connect.Response[dcimv1.GetLayoutResponse], error) {
-	designID := uuid.MustParse(req.Msg.GetDesignId())
+	req *dcimv1.GetLayoutRequest,
+) (*dcimv1.GetLayoutResponse, error) {
+	designID := uuid.MustParse(req.GetDesignId())
 
 	rows, err := s.queries.LogicalDeviceLayoutGetByDesign(ctx, db.LogicalDeviceLayoutGetByDesignParams{LogicalDesignID: designID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetLayout(
 		positions = append(positions, layoutFromRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.GetLayoutResponse_builder{
+	return dcimv1.GetLayoutResponse_builder{
 		Positions: positions,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/layout_save.go
+++ b/dcim-api/pkg/dcim/layout_save.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) SaveLayout(
 	ctx context.Context,
-	req *connect.Request[dcimv1.SaveLayoutRequest],
-) (*connect.Response[dcimv1.SaveLayoutResponse], error) {
-	designID := uuid.MustParse(req.Msg.GetDesignId())
+	req *dcimv1.SaveLayoutRequest,
+) (*dcimv1.SaveLayoutResponse, error) {
+	designID := uuid.MustParse(req.GetDesignId())
 
 	tx, err := s.db.Pool.Begin(ctx)
 	if err != nil {
@@ -36,16 +36,16 @@ func (s *Server) SaveLayout(
 		allowed[d.ID] = struct{}{}
 	}
 
-	for _, pos := range req.Msg.GetPositions() {
+	for _, pos := range req.GetPositions() {
 		deviceID := uuid.MustParse(pos.GetDeviceId())
 		if _, ok := allowed[deviceID]; !ok {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("device %s does not belong to design %s", deviceID, designID))
 		}
 	}
 
-	keep := make([]uuid.UUID, 0, len(req.Msg.GetPositions()))
-	positions := make([]*dcimv1.LogicalDeviceLayout, 0, len(req.Msg.GetPositions()))
-	for _, pos := range req.Msg.GetPositions() {
+	keep := make([]uuid.UUID, 0, len(req.GetPositions()))
+	positions := make([]*dcimv1.LogicalDeviceLayout, 0, len(req.GetPositions()))
+	for _, pos := range req.GetPositions() {
 		deviceID := uuid.MustParse(pos.GetDeviceId())
 		row, err := qtx.LogicalDeviceLayoutUpsert(ctx, db.LogicalDeviceLayoutUpsertParams{
 			LogicalDeviceID: deviceID,
@@ -73,7 +73,7 @@ func (s *Server) SaveLayout(
 
 	s.logger.InfoContext(ctx, "layout saved", "design_id", designID)
 
-	return connect.NewResponse(dcimv1.SaveLayoutResponse_builder{
+	return dcimv1.SaveLayoutResponse_builder{
 		Positions: positions,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_connection_create.go
+++ b/dcim-api/pkg/dcim/logical_connection_create.go
@@ -18,23 +18,23 @@ import (
 
 func (s *Server) CreateConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateConnectionRequest],
-) (*connect.Response[dcimv1.CreateConnectionResponse], error) {
+	req *dcimv1.CreateConnectionRequest,
+) (*dcimv1.CreateConnectionResponse, error) {
 	params := db.LogicalConnectionCreateParams{
-		LogicalDesignID:  uuid.MustParse(req.Msg.GetDesignId()),
-		ALogicalDeviceID: uuid.MustParse(req.Msg.GetSourceDeviceId()),
-		APortRole:        pgtype.Text{String: req.Msg.GetSourcePortRole(), Valid: true},
-		BLogicalDeviceID: uuid.MustParse(req.Msg.GetTargetDeviceId()),
-		BPortRole:        pgtype.Text{String: req.Msg.GetTargetPortRole(), Valid: true},
-		ConnectionType:   logicalConnectionTypeToDB(req.Msg.GetConnectionType()),
+		LogicalDesignID:  uuid.MustParse(req.GetDesignId()),
+		ALogicalDeviceID: uuid.MustParse(req.GetSourceDeviceId()),
+		APortRole:        pgtype.Text{String: req.GetSourcePortRole(), Valid: true},
+		BLogicalDeviceID: uuid.MustParse(req.GetTargetDeviceId()),
+		BPortRole:        pgtype.Text{String: req.GetTargetPortRole(), Valid: true},
+		ConnectionType:   logicalConnectionTypeToDB(req.GetConnectionType()),
 	}
 
-	if req.Msg.HasRequirements() {
-		params.Requirements = pgtype.Text{String: req.Msg.GetRequirements(), Valid: true}
+	if req.HasRequirements() {
+		params.Requirements = pgtype.Text{String: req.GetRequirements(), Valid: true}
 	}
 
-	if req.Msg.HasLabel() {
-		params.Label = pgtype.Text{String: req.Msg.GetLabel(), Valid: true}
+	if req.HasLabel() {
+		params.Label = pgtype.Text{String: req.GetLabel(), Valid: true}
 	}
 
 	id, err := s.queries.LogicalConnectionCreate(ctx, params)
@@ -57,7 +57,7 @@ func (s *Server) CreateConnection(
 
 	s.logger.InfoContext(ctx, "connection created", "connection_id", id)
 
-	return connect.NewResponse(dcimv1.CreateConnectionResponse_builder{
+	return dcimv1.CreateConnectionResponse_builder{
 		ConnectionId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_connection_delete.go
+++ b/dcim-api/pkg/dcim/logical_connection_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteConnectionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteConnectionRequest,
+) (*emptypb.Empty, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.LogicalConnectionDelete(ctx, db.LogicalConnectionDeleteParams{ID: connID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteConnection(
 
 	s.logger.InfoContext(ctx, "connection deleted", "connection_id", connID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/logical_connection_get.go
+++ b/dcim-api/pkg/dcim/logical_connection_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetConnectionRequest],
-) (*connect.Response[dcimv1.GetConnectionResponse], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetConnectionRequest,
+) (*dcimv1.GetConnectionResponse, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	conn, err := s.queries.LogicalConnectionGetByID(ctx, db.LogicalConnectionGetByIDParams{ID: connID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetConnection(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get connection: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetConnectionResponse_builder{
+	return dcimv1.GetConnectionResponse_builder{
 		Connection: logicalConnectionFromRow(&conn),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_connection_list.go
+++ b/dcim-api/pkg/dcim/logical_connection_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListConnections(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListConnectionsRequest],
-) (*connect.Response[dcimv1.ListConnectionsResponse], error) {
-	designID := uuid.MustParse(req.Msg.GetDesignId())
+	req *dcimv1.ListConnectionsRequest,
+) (*dcimv1.ListConnectionsResponse, error) {
+	designID := uuid.MustParse(req.GetDesignId())
 
 	rows, err := s.queries.LogicalConnectionList(ctx, db.LogicalConnectionListParams{LogicalDesignID: designID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) ListConnections(
 		connections = append(connections, logicalConnectionFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListConnectionsResponse_builder{
+	return dcimv1.ListConnectionsResponse_builder{
 		Connections: connections,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_connection_update.go
+++ b/dcim-api/pkg/dcim/logical_connection_update.go
@@ -19,32 +19,32 @@ import (
 
 func (s *Server) UpdateConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateConnectionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateConnectionRequest,
+) (*emptypb.Empty, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	params := db.LogicalConnectionUpdateParams{
 		ID: connID,
 	}
 
-	if req.Msg.HasSourcePortRole() {
-		params.APortRole = pgtype.Text{String: req.Msg.GetSourcePortRole(), Valid: true}
+	if req.HasSourcePortRole() {
+		params.APortRole = pgtype.Text{String: req.GetSourcePortRole(), Valid: true}
 	}
 
-	if req.Msg.HasTargetPortRole() {
-		params.BPortRole = pgtype.Text{String: req.Msg.GetTargetPortRole(), Valid: true}
+	if req.HasTargetPortRole() {
+		params.BPortRole = pgtype.Text{String: req.GetTargetPortRole(), Valid: true}
 	}
 
-	if req.Msg.HasConnectionType() {
-		params.ConnectionType = pgtype.Text{String: logicalConnectionTypeToDB(req.Msg.GetConnectionType()), Valid: true}
+	if req.HasConnectionType() {
+		params.ConnectionType = pgtype.Text{String: logicalConnectionTypeToDB(req.GetConnectionType()), Valid: true}
 	}
 
-	if req.Msg.HasRequirements() {
-		params.Requirements = pgtype.Text{String: req.Msg.GetRequirements(), Valid: true}
+	if req.HasRequirements() {
+		params.Requirements = pgtype.Text{String: req.GetRequirements(), Valid: true}
 	}
 
-	if req.Msg.HasLabel() {
-		params.Label = pgtype.Text{String: req.Msg.GetLabel(), Valid: true}
+	if req.HasLabel() {
+		params.Label = pgtype.Text{String: req.GetLabel(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.LogicalConnectionUpdate(ctx, params)
@@ -62,5 +62,5 @@ func (s *Server) UpdateConnection(
 
 	s.logger.InfoContext(ctx, "connection updated", "connection_id", connID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/logical_device_create.go
+++ b/dcim-api/pkg/dcim/logical_device_create.go
@@ -18,24 +18,24 @@ import (
 
 func (s *Server) CreateDevice(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateDeviceRequest],
-) (*connect.Response[dcimv1.CreateDeviceResponse], error) {
+	req *dcimv1.CreateDeviceRequest,
+) (*dcimv1.CreateDeviceResponse, error) {
 	params := db.LogicalDeviceCreateParams{
-		LogicalDesignID: uuid.MustParse(req.Msg.GetDesignId()),
-		Label:           req.Msg.GetLabel(),
-		Role:            logicalDeviceRoleToDB(req.Msg.GetRole()),
+		LogicalDesignID: uuid.MustParse(req.GetDesignId()),
+		Label:           req.GetLabel(),
+		Role:            logicalDeviceRoleToDB(req.GetRole()),
 	}
 
-	if req.Msg.HasDeviceCatalogId() {
-		params.DeviceCatalogID = pgtype.UUID{Bytes: uuid.MustParse(req.Msg.GetDeviceCatalogId()), Valid: true}
+	if req.HasDeviceCatalogId() {
+		params.DeviceCatalogID = pgtype.UUID{Bytes: uuid.MustParse(req.GetDeviceCatalogId()), Valid: true}
 	}
 
-	if req.Msg.HasRequirements() {
-		params.Requirements = pgtype.Text{String: req.Msg.GetRequirements(), Valid: true}
+	if req.HasRequirements() {
+		params.Requirements = pgtype.Text{String: req.GetRequirements(), Valid: true}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	id, err := s.queries.LogicalDeviceCreate(ctx, params)
@@ -58,7 +58,7 @@ func (s *Server) CreateDevice(
 
 	s.logger.InfoContext(ctx, "device created", "device_id", id)
 
-	return connect.NewResponse(dcimv1.CreateDeviceResponse_builder{
+	return dcimv1.CreateDeviceResponse_builder{
 		DeviceId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_device_delete.go
+++ b/dcim-api/pkg/dcim/logical_device_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteDevice(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteDeviceRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	deviceID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteDeviceRequest,
+) (*emptypb.Empty, error) {
+	deviceID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.LogicalDeviceDelete(ctx, db.LogicalDeviceDeleteParams{ID: deviceID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteDevice(
 
 	s.logger.InfoContext(ctx, "device deleted", "device_id", deviceID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/logical_device_get.go
+++ b/dcim-api/pkg/dcim/logical_device_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetDevice(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetDeviceRequest],
-) (*connect.Response[dcimv1.GetDeviceResponse], error) {
-	deviceID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetDeviceRequest,
+) (*dcimv1.GetDeviceResponse, error) {
+	deviceID := uuid.MustParse(req.GetId())
 
 	device, err := s.queries.LogicalDeviceGetByID(ctx, db.LogicalDeviceGetByIDParams{ID: deviceID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetDevice(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get device: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetDeviceResponse_builder{
+	return dcimv1.GetDeviceResponse_builder{
 		Device: logicalDeviceFromRow(&device),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_device_list.go
+++ b/dcim-api/pkg/dcim/logical_device_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListDevices(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListDevicesRequest],
-) (*connect.Response[dcimv1.ListDevicesResponse], error) {
-	designID := uuid.MustParse(req.Msg.GetDesignId())
+	req *dcimv1.ListDevicesRequest,
+) (*dcimv1.ListDevicesResponse, error) {
+	designID := uuid.MustParse(req.GetDesignId())
 
 	rows, err := s.queries.LogicalDeviceList(ctx, db.LogicalDeviceListParams{LogicalDesignID: designID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) ListDevices(
 		devices = append(devices, logicalDeviceFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListDevicesResponse_builder{
+	return dcimv1.ListDevicesResponse_builder{
 		Devices: devices,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/logical_device_update.go
+++ b/dcim-api/pkg/dcim/logical_device_update.go
@@ -19,32 +19,32 @@ import (
 
 func (s *Server) UpdateDevice(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateDeviceRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	deviceID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateDeviceRequest,
+) (*emptypb.Empty, error) {
+	deviceID := uuid.MustParse(req.GetId())
 
 	params := db.LogicalDeviceUpdateParams{
 		ID: deviceID,
 	}
 
-	if req.Msg.HasLabel() {
-		params.Label = pgtype.Text{String: req.Msg.GetLabel(), Valid: true}
+	if req.HasLabel() {
+		params.Label = pgtype.Text{String: req.GetLabel(), Valid: true}
 	}
 
-	if req.Msg.HasRole() {
-		params.Role = pgtype.Text{String: logicalDeviceRoleToDB(req.Msg.GetRole()), Valid: true}
+	if req.HasRole() {
+		params.Role = pgtype.Text{String: logicalDeviceRoleToDB(req.GetRole()), Valid: true}
 	}
 
-	if req.Msg.HasDeviceCatalogId() {
-		params.DeviceCatalogID = pgtype.UUID{Bytes: uuid.MustParse(req.Msg.GetDeviceCatalogId()), Valid: true}
+	if req.HasDeviceCatalogId() {
+		params.DeviceCatalogID = pgtype.UUID{Bytes: uuid.MustParse(req.GetDeviceCatalogId()), Valid: true}
 	}
 
-	if req.Msg.HasRequirements() {
-		params.Requirements = pgtype.Text{String: req.Msg.GetRequirements(), Valid: true}
+	if req.HasRequirements() {
+		params.Requirements = pgtype.Text{String: req.GetRequirements(), Valid: true}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.LogicalDeviceUpdate(ctx, params)
@@ -69,5 +69,5 @@ func (s *Server) UpdateDevice(
 
 	s.logger.InfoContext(ctx, "device updated", "device_id", deviceID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/note_create.go
+++ b/dcim-api/pkg/dcim/note_create.go
@@ -13,10 +13,10 @@ import (
 
 func (s *Server) CreateNote(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateNoteRequest],
-) (*connect.Response[dcimv1.CreateNoteResponse], error) {
-	entityID := uuid.MustParse(req.Msg.GetEntityId())
-	params, err := noteEntityToCreateParams(req.Msg.GetEntityType(), entityID)
+	req *dcimv1.CreateNoteRequest,
+) (*dcimv1.CreateNoteResponse, error) {
+	entityID := uuid.MustParse(req.GetEntityId())
+	params, err := noteEntityToCreateParams(req.GetEntityType(), entityID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -30,7 +30,7 @@ func (s *Server) CreateNote(
 		return nil, err
 	}
 
-	params.Body = req.Msg.GetBody()
+	params.Body = req.GetBody()
 	if found {
 		params.CreatedByID = pgtype.UUID{Bytes: author.ID, Valid: true}
 	}
@@ -46,7 +46,7 @@ func (s *Server) CreateNote(
 
 	s.logger.InfoContext(ctx, "note created", "note_id", id)
 
-	return connect.NewResponse(dcimv1.CreateNoteResponse_builder{
+	return dcimv1.CreateNoteResponse_builder{
 		NoteId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/note_create_test.go
+++ b/dcim-api/pkg/dcim/note_create_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,15 +27,15 @@ func listTaskNotes(t *testing.T, env *testEnv, taskID string) []*dcimv1.Note {
 
 	client := dcimv1connect.NewNoteServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.ListNotes(context.Background(), connect.NewRequest(
+	resp, err := client.ListNotes(context.Background(),
 		(&dcimv1.ListNotesRequest_builder{
 			EntityType: dcimv1.NoteEntityType_NOTE_ENTITY_TYPE_TASK,
 			EntityId:   taskID,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	return resp.Msg.GetNotes()
+	return resp.GetNotes()
 }
 
 // The author is resolved from the JWT, never from the request, so a note is
@@ -54,13 +53,13 @@ func TestNoteService_CreateNote_AttributesToCaller(t *testing.T) {
 
 	taskID := createTaskForNote(t, env, "Task With Notes")
 
-	_, err := client.CreateNote(context.Background(), connect.NewRequest(
+	_, err := client.CreateNote(context.Background(),
 		(&dcimv1.CreateNoteRequest_builder{
 			EntityType: dcimv1.NoteEntityType_NOTE_ENTITY_TYPE_TASK,
 			EntityId:   taskID,
 			Body:       "disk swapped",
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	notes := listTaskNotes(t, env, taskID)
@@ -85,13 +84,13 @@ func TestNoteService_CreateNote_NoDirectoryEntry(t *testing.T) {
 
 	taskID := createTaskForNote(t, env, "Task Noted By A Stranger")
 
-	_, err := client.CreateNote(context.Background(), connect.NewRequest(
+	_, err := client.CreateNote(context.Background(),
 		(&dcimv1.CreateNoteRequest_builder{
 			EntityType: dcimv1.NoteEntityType_NOTE_ENTITY_TYPE_TASK,
 			EntityId:   taskID,
 			Body:       "no roster entry here",
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	notes := listTaskNotes(t, env, taskID)
@@ -116,13 +115,13 @@ func TestNoteService_CreateNote_SoftDeletedAuthor(t *testing.T) {
 
 	taskID := createTaskForNote(t, env, "Task Noted After Deletion")
 
-	_, err = client.CreateNote(context.Background(), connect.NewRequest(
+	_, err = client.CreateNote(context.Background(),
 		(&dcimv1.CreateNoteRequest_builder{
 			EntityType: dcimv1.NoteEntityType_NOTE_ENTITY_TYPE_TASK,
 			EntityId:   taskID,
 			Body:       "written after the author was removed",
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	notes := listTaskNotes(t, env, taskID)

--- a/dcim-api/pkg/dcim/note_delete.go
+++ b/dcim-api/pkg/dcim/note_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteNote(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteNoteRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	noteID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteNoteRequest,
+) (*emptypb.Empty, error) {
+	noteID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.NoteDelete(ctx, db.NoteDeleteParams{ID: noteID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteNote(
 
 	s.logger.InfoContext(ctx, "note deleted", "note_id", noteID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/note_list.go
+++ b/dcim-api/pkg/dcim/note_list.go
@@ -12,10 +12,10 @@ import (
 
 func (s *Server) ListNotes(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListNotesRequest],
-) (*connect.Response[dcimv1.ListNotesResponse], error) {
-	entityID := uuid.MustParse(req.Msg.GetEntityId())
-	params, err := noteEntityToListParams(req.Msg.GetEntityType(), entityID)
+	req *dcimv1.ListNotesRequest,
+) (*dcimv1.ListNotesResponse, error) {
+	entityID := uuid.MustParse(req.GetEntityId())
+	params, err := noteEntityToListParams(req.GetEntityType(), entityID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -30,7 +30,7 @@ func (s *Server) ListNotes(
 		notes = append(notes, noteFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListNotesResponse_builder{
+	return dcimv1.ListNotesResponse_builder{
 		Notes: notes,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/physical_connection_create.go
+++ b/dcim-api/pkg/dcim/physical_connection_create.go
@@ -18,25 +18,25 @@ import (
 
 func (s *Server) CreatePhysicalConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreatePhysicalConnectionRequest],
-) (*connect.Response[dcimv1.CreatePhysicalConnectionResponse], error) {
+	req *dcimv1.CreatePhysicalConnectionRequest,
+) (*dcimv1.CreatePhysicalConnectionResponse, error) {
 	params := db.PhysicalConnectionCreateParams{
-		APlacementID:      uuid.MustParse(req.Msg.GetSourcePlacementId()),
-		APortDefinitionID: uuid.MustParse(req.Msg.GetSourcePortDefinitionId()),
-		BPlacementID:      uuid.MustParse(req.Msg.GetTargetPlacementId()),
-		BPortDefinitionID: uuid.MustParse(req.Msg.GetTargetPortDefinitionId()),
-		CableType:         cableTypeToDB(req.Msg.GetCableType()),
-		Status:            cableStatusToDB(req.Msg.GetStatus()),
-		Color:             cableColorToDB(req.Msg.GetColor()),
-		Label:             pgtype.Text{String: req.Msg.GetLabel(), Valid: req.Msg.GetLabel() != ""},
+		APlacementID:      uuid.MustParse(req.GetSourcePlacementId()),
+		APortDefinitionID: uuid.MustParse(req.GetSourcePortDefinitionId()),
+		BPlacementID:      uuid.MustParse(req.GetTargetPlacementId()),
+		BPortDefinitionID: uuid.MustParse(req.GetTargetPortDefinitionId()),
+		CableType:         cableTypeToDB(req.GetCableType()),
+		Status:            cableStatusToDB(req.GetStatus()),
+		Color:             cableColorToDB(req.GetColor()),
+		Label:             pgtype.Text{String: req.GetLabel(), Valid: req.GetLabel() != ""},
 	}
 
-	if req.Msg.HasCableAssetId() {
-		params.CableAssetID = pgtype.UUID{Bytes: uuid.MustParse(req.Msg.GetCableAssetId()), Valid: true}
+	if req.HasCableAssetId() {
+		params.CableAssetID = pgtype.UUID{Bytes: uuid.MustParse(req.GetCableAssetId()), Valid: true}
 	}
 
-	if req.Msg.HasLogicalConnectionId() {
-		params.LogicalConnectionID = pgtype.UUID{Bytes: uuid.MustParse(req.Msg.GetLogicalConnectionId()), Valid: true}
+	if req.HasLogicalConnectionId() {
+		params.LogicalConnectionID = pgtype.UUID{Bytes: uuid.MustParse(req.GetLogicalConnectionId()), Valid: true}
 	}
 
 	id, err := s.queries.PhysicalConnectionCreate(ctx, params)
@@ -63,7 +63,7 @@ func (s *Server) CreatePhysicalConnection(
 
 	s.logger.InfoContext(ctx, "physical connection created", "connection_id", id)
 
-	return connect.NewResponse(dcimv1.CreatePhysicalConnectionResponse_builder{
+	return dcimv1.CreatePhysicalConnectionResponse_builder{
 		ConnectionId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/physical_connection_delete.go
+++ b/dcim-api/pkg/dcim/physical_connection_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeletePhysicalConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeletePhysicalConnectionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeletePhysicalConnectionRequest,
+) (*emptypb.Empty, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.PhysicalConnectionDelete(ctx, db.PhysicalConnectionDeleteParams{ID: connID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeletePhysicalConnection(
 
 	s.logger.InfoContext(ctx, "physical connection deleted", "connection_id", connID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/physical_connection_get.go
+++ b/dcim-api/pkg/dcim/physical_connection_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetPhysicalConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetPhysicalConnectionRequest],
-) (*connect.Response[dcimv1.GetPhysicalConnectionResponse], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetPhysicalConnectionRequest,
+) (*dcimv1.GetPhysicalConnectionResponse, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	conn, err := s.queries.PhysicalConnectionGetByID(ctx, db.PhysicalConnectionGetByIDParams{ID: connID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetPhysicalConnection(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get physical connection: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetPhysicalConnectionResponse_builder{
+	return dcimv1.GetPhysicalConnectionResponse_builder{
 		Connection: physicalConnectionFromRow(&conn),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/physical_connection_list.go
+++ b/dcim-api/pkg/dcim/physical_connection_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListConnectionsByPlacement(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListConnectionsByPlacementRequest],
-) (*connect.Response[dcimv1.ListConnectionsByPlacementResponse], error) {
-	placementID := uuid.MustParse(req.Msg.GetPlacementId())
+	req *dcimv1.ListConnectionsByPlacementRequest,
+) (*dcimv1.ListConnectionsByPlacementResponse, error) {
+	placementID := uuid.MustParse(req.GetPlacementId())
 
 	rows, err := s.queries.PhysicalConnectionListByPlacement(ctx, db.PhysicalConnectionListByPlacementParams{
 		APlacementID: placementID,
@@ -29,16 +29,16 @@ func (s *Server) ListConnectionsByPlacement(
 		connections = append(connections, physicalConnectionFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListConnectionsByPlacementResponse_builder{
+	return dcimv1.ListConnectionsByPlacementResponse_builder{
 		Connections: connections,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) ListConnectionsBySite(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListConnectionsBySiteRequest],
-) (*connect.Response[dcimv1.ListConnectionsBySiteResponse], error) {
-	siteID := uuid.MustParse(req.Msg.GetSiteId())
+	req *dcimv1.ListConnectionsBySiteRequest,
+) (*dcimv1.ListConnectionsBySiteResponse, error) {
+	siteID := uuid.MustParse(req.GetSiteId())
 
 	rows, err := s.queries.PhysicalConnectionListBySite(ctx, db.PhysicalConnectionListBySiteParams{
 		SiteID: siteID,
@@ -52,7 +52,7 @@ func (s *Server) ListConnectionsBySite(
 		connections = append(connections, physicalConnectionFromListBySiteRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListConnectionsBySiteResponse_builder{
+	return dcimv1.ListConnectionsBySiteResponse_builder{
 		Connections: connections,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/physical_connection_test.go
+++ b/dcim-api/pkg/dcim/physical_connection_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestPhysicalConnectionService_CableAttributesRoundTrip(t *testing.T) {
 
 	aPlacement, aPort, bPlacement, bPort := physicalConnectionFixture(t, env)
 
-	createResp, err := client.CreatePhysicalConnection(context.Background(), connect.NewRequest(
+	createResp, err := client.CreatePhysicalConnection(context.Background(),
 		(&dcimv1.CreatePhysicalConnectionRequest_builder{
 			SourcePlacementId:      aPlacement,
 			SourcePortDefinitionId: aPort,
@@ -54,18 +53,18 @@ func TestPhysicalConnectionService_CableAttributesRoundTrip(t *testing.T) {
 			Color:                  dcimv1.CableColor_CABLE_COLOR_BLUE,
 			Label:                  "srv01-data",
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
-	require.NotEmpty(t, createResp.Msg.GetConnectionId())
+	require.NotEmpty(t, createResp.GetConnectionId())
 
-	connID := createResp.Msg.GetConnectionId()
+	connID := createResp.GetConnectionId()
 
-	getResp, err := client.GetPhysicalConnection(context.Background(), connect.NewRequest(
+	getResp, err := client.GetPhysicalConnection(context.Background(),
 		(&dcimv1.GetPhysicalConnectionRequest_builder{Id: connID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	conn := getResp.Msg.GetConnection()
+	conn := getResp.GetConnection()
 	require.NotNil(t, conn)
 	assert.Equal(t, dcimv1.CableType_CABLE_TYPE_CAT6A, conn.GetCableType())
 	assert.Equal(t, dcimv1.CableStatus_CABLE_STATUS_CONNECTED, conn.GetStatus())
@@ -78,7 +77,7 @@ func TestPhysicalConnectionService_CableAttributesRoundTrip(t *testing.T) {
 	updatedStatus := dcimv1.CableStatus_CABLE_STATUS_PLANNED
 	updatedColor := dcimv1.CableColor_CABLE_COLOR_TEAL
 	updatedLabel := "spine-uplink"
-	_, err = client.UpdatePhysicalConnection(context.Background(), connect.NewRequest(
+	_, err = client.UpdatePhysicalConnection(context.Background(),
 		(&dcimv1.UpdatePhysicalConnectionRequest_builder{
 			Id:        connID,
 			CableType: &updatedType,
@@ -86,15 +85,15 @@ func TestPhysicalConnectionService_CableAttributesRoundTrip(t *testing.T) {
 			Color:     &updatedColor,
 			Label:     &updatedLabel,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	getResp, err = client.GetPhysicalConnection(context.Background(), connect.NewRequest(
+	getResp, err = client.GetPhysicalConnection(context.Background(),
 		(&dcimv1.GetPhysicalConnectionRequest_builder{Id: connID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	conn = getResp.Msg.GetConnection()
+	conn = getResp.GetConnection()
 	require.NotNil(t, conn)
 	assert.Equal(t, dcimv1.CableType_CABLE_TYPE_DAC, conn.GetCableType())
 	assert.Equal(t, dcimv1.CableStatus_CABLE_STATUS_PLANNED, conn.GetStatus())
@@ -114,24 +113,24 @@ func TestPhysicalConnectionService_CableAttributesOptional(t *testing.T) {
 
 	aPlacement, aPort, bPlacement, bPort := physicalConnectionFixture(t, env)
 
-	createResp, err := client.CreatePhysicalConnection(context.Background(), connect.NewRequest(
+	createResp, err := client.CreatePhysicalConnection(context.Background(),
 		(&dcimv1.CreatePhysicalConnectionRequest_builder{
 			SourcePlacementId:      aPlacement,
 			SourcePortDefinitionId: aPort,
 			TargetPlacementId:      bPlacement,
 			TargetPortDefinitionId: bPort,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	connID := createResp.Msg.GetConnectionId()
+	connID := createResp.GetConnectionId()
 
-	getResp, err := client.GetPhysicalConnection(context.Background(), connect.NewRequest(
+	getResp, err := client.GetPhysicalConnection(context.Background(),
 		(&dcimv1.GetPhysicalConnectionRequest_builder{Id: connID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	conn := getResp.Msg.GetConnection()
+	conn := getResp.GetConnection()
 	require.NotNil(t, conn)
 	assert.Equal(t, dcimv1.CableType_CABLE_TYPE_UNSPECIFIED, conn.GetCableType())
 	assert.Equal(t, dcimv1.CableStatus_CABLE_STATUS_UNSPECIFIED, conn.GetStatus())
@@ -140,20 +139,20 @@ func TestPhysicalConnectionService_CableAttributesOptional(t *testing.T) {
 
 	// Update only the status; the other attributes must stay unset.
 	updatedStatus := dcimv1.CableStatus_CABLE_STATUS_DECOMMISSIONED
-	_, err = client.UpdatePhysicalConnection(context.Background(), connect.NewRequest(
+	_, err = client.UpdatePhysicalConnection(context.Background(),
 		(&dcimv1.UpdatePhysicalConnectionRequest_builder{
 			Id:     connID,
 			Status: &updatedStatus,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	getResp, err = client.GetPhysicalConnection(context.Background(), connect.NewRequest(
+	getResp, err = client.GetPhysicalConnection(context.Background(),
 		(&dcimv1.GetPhysicalConnectionRequest_builder{Id: connID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	conn = getResp.Msg.GetConnection()
+	conn = getResp.GetConnection()
 	require.NotNil(t, conn)
 	assert.Equal(t, dcimv1.CableStatus_CABLE_STATUS_DECOMMISSIONED, conn.GetStatus())
 	assert.Equal(t, dcimv1.CableType_CABLE_TYPE_UNSPECIFIED, conn.GetCableType())
@@ -171,7 +170,7 @@ func TestPhysicalConnectionService_CableAttributesClear(t *testing.T) {
 
 	aPlacement, aPort, bPlacement, bPort := physicalConnectionFixture(t, env)
 
-	createResp, err := client.CreatePhysicalConnection(context.Background(), connect.NewRequest(
+	createResp, err := client.CreatePhysicalConnection(context.Background(),
 		(&dcimv1.CreatePhysicalConnectionRequest_builder{
 			SourcePlacementId:      aPlacement,
 			SourcePortDefinitionId: aPort,
@@ -182,10 +181,10 @@ func TestPhysicalConnectionService_CableAttributesClear(t *testing.T) {
 			Color:                  dcimv1.CableColor_CABLE_COLOR_RED,
 			Label:                  "to-clear",
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	connID := createResp.Msg.GetConnectionId()
+	connID := createResp.GetConnectionId()
 
 	// Explicitly set every attribute to its empty sentinel: this must null the
 	// columns rather than be ignored.
@@ -193,7 +192,7 @@ func TestPhysicalConnectionService_CableAttributesClear(t *testing.T) {
 	clearStatus := dcimv1.CableStatus_CABLE_STATUS_UNSPECIFIED
 	clearColor := dcimv1.CableColor_CABLE_COLOR_UNSPECIFIED
 	clearLabel := ""
-	_, err = client.UpdatePhysicalConnection(context.Background(), connect.NewRequest(
+	_, err = client.UpdatePhysicalConnection(context.Background(),
 		(&dcimv1.UpdatePhysicalConnectionRequest_builder{
 			Id:        connID,
 			CableType: &clearType,
@@ -201,15 +200,15 @@ func TestPhysicalConnectionService_CableAttributesClear(t *testing.T) {
 			Color:     &clearColor,
 			Label:     &clearLabel,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	getResp, err := client.GetPhysicalConnection(context.Background(), connect.NewRequest(
+	getResp, err := client.GetPhysicalConnection(context.Background(),
 		(&dcimv1.GetPhysicalConnectionRequest_builder{Id: connID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	conn := getResp.Msg.GetConnection()
+	conn := getResp.GetConnection()
 	require.NotNil(t, conn)
 	assert.Equal(t, dcimv1.CableType_CABLE_TYPE_UNSPECIFIED, conn.GetCableType())
 	assert.Equal(t, dcimv1.CableStatus_CABLE_STATUS_UNSPECIFIED, conn.GetStatus())
@@ -238,36 +237,36 @@ func TestPhysicalConnectionService_ListConnectionsBySite(t *testing.T) {
 	aPlacement := placeAssetInRack(t, env, createAsset(t, env, catalogID), rackID, 1)
 	bPlacement := placeAssetInRack(t, env, createAsset(t, env, catalogID), rackID, 2)
 
-	createResp, err := client.CreatePhysicalConnection(context.Background(), connect.NewRequest(
+	createResp, err := client.CreatePhysicalConnection(context.Background(),
 		(&dcimv1.CreatePhysicalConnectionRequest_builder{
 			SourcePlacementId:      aPlacement,
 			SourcePortDefinitionId: aPort,
 			TargetPlacementId:      bPlacement,
 			TargetPortDefinitionId: bPort,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
-	wantConnID := createResp.Msg.GetConnectionId()
+	wantConnID := createResp.GetConnectionId()
 
 	// A second site with its own connection that must not appear in the result.
 	otherPlacementA, otherPortA, otherPlacementB, otherPortB := physicalConnectionFixture(t, env)
-	_, err = client.CreatePhysicalConnection(context.Background(), connect.NewRequest(
+	_, err = client.CreatePhysicalConnection(context.Background(),
 		(&dcimv1.CreatePhysicalConnectionRequest_builder{
 			SourcePlacementId:      otherPlacementA,
 			SourcePortDefinitionId: otherPortA,
 			TargetPlacementId:      otherPlacementB,
 			TargetPortDefinitionId: otherPortB,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	resp, err := client.ListConnectionsBySite(context.Background(), connect.NewRequest(
+	resp, err := client.ListConnectionsBySite(context.Background(),
 		(&dcimv1.ListConnectionsBySiteRequest_builder{SiteId: siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetConnections()))
-	for _, c := range resp.Msg.GetConnections() {
+	got := make([]string, 0, len(resp.GetConnections()))
+	for _, c := range resp.GetConnections() {
 		got = append(got, c.GetId())
 	}
 	assert.Equal(t, []string{wantConnID}, got)

--- a/dcim-api/pkg/dcim/physical_connection_update.go
+++ b/dcim-api/pkg/dcim/physical_connection_update.go
@@ -19,24 +19,24 @@ import (
 
 func (s *Server) UpdatePhysicalConnection(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdatePhysicalConnectionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	connID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdatePhysicalConnectionRequest,
+) (*emptypb.Empty, error) {
+	connID := uuid.MustParse(req.GetId())
 
 	params := db.PhysicalConnectionUpdateParams{
 		ID: connID,
 	}
 
-	if req.Msg.HasCableAssetId() {
-		if v := req.Msg.GetCableAssetId(); v == "" {
+	if req.HasCableAssetId() {
+		if v := req.GetCableAssetId(); v == "" {
 			params.ClearCableAssetID = true
 		} else {
 			params.CableAssetID = pgtype.UUID{Bytes: uuid.MustParse(v), Valid: true}
 		}
 	}
 
-	if req.Msg.HasLogicalConnectionId() {
-		if v := req.Msg.GetLogicalConnectionId(); v == "" {
+	if req.HasLogicalConnectionId() {
+		if v := req.GetLogicalConnectionId(); v == "" {
 			params.ClearLogicalConnectionID = true
 		} else {
 			params.LogicalConnectionID = pgtype.UUID{Bytes: uuid.MustParse(v), Valid: true}
@@ -46,32 +46,32 @@ func (s *Server) UpdatePhysicalConnection(
 	// For the presentation attributes, an explicitly-set field clears the column
 	// when it carries the "empty" sentinel (UNSPECIFIED enum / empty label) and
 	// otherwise overwrites it. Leaving the field unset keeps the current value.
-	if req.Msg.HasCableType() {
-		if t := req.Msg.GetCableType(); t == dcimv1.CableType_CABLE_TYPE_UNSPECIFIED {
+	if req.HasCableType() {
+		if t := req.GetCableType(); t == dcimv1.CableType_CABLE_TYPE_UNSPECIFIED {
 			params.ClearCableType = true
 		} else {
 			params.CableType = cableTypeToDB(t)
 		}
 	}
 
-	if req.Msg.HasStatus() {
-		if st := req.Msg.GetStatus(); st == dcimv1.CableStatus_CABLE_STATUS_UNSPECIFIED {
+	if req.HasStatus() {
+		if st := req.GetStatus(); st == dcimv1.CableStatus_CABLE_STATUS_UNSPECIFIED {
 			params.ClearStatus = true
 		} else {
 			params.Status = cableStatusToDB(st)
 		}
 	}
 
-	if req.Msg.HasColor() {
-		if c := req.Msg.GetColor(); c == dcimv1.CableColor_CABLE_COLOR_UNSPECIFIED {
+	if req.HasColor() {
+		if c := req.GetColor(); c == dcimv1.CableColor_CABLE_COLOR_UNSPECIFIED {
 			params.ClearColor = true
 		} else {
 			params.Color = cableColorToDB(c)
 		}
 	}
 
-	if req.Msg.HasLabel() {
-		if v := req.Msg.GetLabel(); v == "" {
+	if req.HasLabel() {
+		if v := req.GetLabel(); v == "" {
 			params.ClearLabel = true
 		} else {
 			params.Label = pgtype.Text{String: v, Valid: true}
@@ -98,5 +98,5 @@ func (s *Server) UpdatePhysicalConnection(
 
 	s.logger.InfoContext(ctx, "physical connection updated", "connection_id", connID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/placement_create.go
+++ b/dcim-api/pkg/dcim/placement_create.go
@@ -18,20 +18,20 @@ import (
 
 func (s *Server) CreatePlacement(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreatePlacementRequest],
-) (*connect.Response[dcimv1.CreatePlacementResponse], error) {
+	req *dcimv1.CreatePlacementRequest,
+) (*dcimv1.CreatePlacementResponse, error) {
 	params := db.PlacementCreateParams{
-		AssetID: uuid.MustParse(req.Msg.GetAssetId()),
+		AssetID: uuid.MustParse(req.GetAssetId()),
 	}
 
-	switch loc := req.Msg.WhichLocation(); loc {
+	switch loc := req.WhichLocation(); loc {
 	case dcimv1.CreatePlacementRequest_Rack_case:
-		rack := req.Msg.GetRack()
+		rack := req.GetRack()
 		params.RackID = pgtype.UUID{Bytes: uuid.MustParse(rack.GetRackId()), Valid: true}
 		params.StartUnit = pgtype.Int4{Int32: rack.GetRackUnitStart(), Valid: true}
 		params.SlotType = pgtype.Text{String: rackSlotTypeToDB(rack.GetRackSlotType()), Valid: true}
 	case dcimv1.CreatePlacementRequest_SubComponent_case:
-		sub := req.Msg.GetSubComponent()
+		sub := req.GetSubComponent()
 		params.ParentPlacementID = pgtype.UUID{Bytes: uuid.MustParse(sub.GetParentPlacementId()), Valid: true}
 		params.PortDefinitionID = pgtype.UUID{Bytes: uuid.MustParse(sub.GetParentPortDefinitionId()), Valid: true}
 	case dcimv1.CreatePlacementRequest_Location_not_set_case:
@@ -40,12 +40,12 @@ func (s *Server) CreatePlacement(
 		panic("unhandled placement location case")
 	}
 
-	if req.Msg.HasLogicalDeviceId() {
-		params.LogicalDeviceID = pgtype.UUID{Bytes: uuid.MustParse(req.Msg.GetLogicalDeviceId()), Valid: true}
+	if req.HasLogicalDeviceId() {
+		params.LogicalDeviceID = pgtype.UUID{Bytes: uuid.MustParse(req.GetLogicalDeviceId()), Valid: true}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	id, err := s.queries.PlacementCreate(ctx, params)
@@ -70,7 +70,7 @@ func (s *Server) CreatePlacement(
 
 	s.logger.InfoContext(ctx, "placement created", "placement_id", id)
 
-	return connect.NewResponse(dcimv1.CreatePlacementResponse_builder{
+	return dcimv1.CreatePlacementResponse_builder{
 		PlacementId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/placement_create_test.go
+++ b/dcim-api/pkg/dcim/placement_create_test.go
@@ -23,7 +23,7 @@ func TestPlacementService_CreatePlacement_RejectsUnitBelowOne(t *testing.T) {
 	catalogID := createCatalogEntry(t, env, "Unit model")
 	assetID := createAsset(t, env, catalogID)
 
-	_, err := client.CreatePlacement(context.Background(), connect.NewRequest(
+	_, err := client.CreatePlacement(context.Background(),
 		(&dcimv1.CreatePlacementRequest_builder{
 			AssetId: assetID,
 			Rack: (&dcimv1.RackLocation_builder{
@@ -32,6 +32,6 @@ func TestPlacementService_CreatePlacement_RejectsUnitBelowOne(t *testing.T) {
 				RackSlotType:  dcimv1.RackSlotType_RACK_SLOT_TYPE_UNIT,
 			}).Build(),
 		}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeInvalidArgument)
 }

--- a/dcim-api/pkg/dcim/placement_delete.go
+++ b/dcim-api/pkg/dcim/placement_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeletePlacement(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeletePlacementRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	placementID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeletePlacementRequest,
+) (*emptypb.Empty, error) {
+	placementID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.PlacementDelete(ctx, db.PlacementDeleteParams{ID: placementID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeletePlacement(
 
 	s.logger.InfoContext(ctx, "placement deleted", "placement_id", placementID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/placement_get.go
+++ b/dcim-api/pkg/dcim/placement_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetPlacement(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetPlacementRequest],
-) (*connect.Response[dcimv1.GetPlacementResponse], error) {
-	placementID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetPlacementRequest,
+) (*dcimv1.GetPlacementResponse, error) {
+	placementID := uuid.MustParse(req.GetId())
 
 	placement, err := s.queries.PlacementGetByID(ctx, db.PlacementGetByIDParams{ID: placementID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetPlacement(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get placement: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetPlacementResponse_builder{
+	return dcimv1.GetPlacementResponse_builder{
 		Placement: placementFromGetRow(&placement),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/placement_get_by_asset.go
+++ b/dcim-api/pkg/dcim/placement_get_by_asset.go
@@ -17,19 +17,19 @@ import (
 // placement when the asset has not been placed.
 func (s *Server) GetPlacementByAsset(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetPlacementByAssetRequest],
-) (*connect.Response[dcimv1.GetPlacementByAssetResponse], error) {
-	assetID := uuid.MustParse(req.Msg.GetAssetId())
+	req *dcimv1.GetPlacementByAssetRequest,
+) (*dcimv1.GetPlacementByAssetResponse, error) {
+	assetID := uuid.MustParse(req.GetAssetId())
 
 	placement, err := s.queries.PlacementGetByAsset(ctx, db.PlacementGetByAssetParams{AssetID: assetID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return connect.NewResponse(dcimv1.GetPlacementByAssetResponse_builder{}.Build()), nil
+			return dcimv1.GetPlacementByAssetResponse_builder{}.Build(), nil
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get placement by asset: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetPlacementByAssetResponse_builder{
+	return dcimv1.GetPlacementByAssetResponse_builder{
 		Placement: placementFromGetByAssetRow(&placement),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/placement_list_by_rack.go
+++ b/dcim-api/pkg/dcim/placement_list_by_rack.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) ListPlacementsByRack(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListPlacementsByRackRequest],
-) (*connect.Response[dcimv1.ListPlacementsByRackResponse], error) {
-	rackID := uuid.MustParse(req.Msg.GetRackId())
+	req *dcimv1.ListPlacementsByRackRequest,
+) (*dcimv1.ListPlacementsByRackResponse, error) {
+	rackID := uuid.MustParse(req.GetRackId())
 
 	rows, err := s.queries.PlacementListByRack(ctx, db.PlacementListByRackParams{
 		RackID: pgtype.UUID{Bytes: rackID, Valid: true},
@@ -30,7 +30,7 @@ func (s *Server) ListPlacementsByRack(
 		placements = append(placements, placementFromRackListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListPlacementsByRackResponse_builder{
+	return dcimv1.ListPlacementsByRackResponse_builder{
 		Placements: placements,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/placement_list_children.go
+++ b/dcim-api/pkg/dcim/placement_list_children.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) ListChildPlacements(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListChildPlacementsRequest],
-) (*connect.Response[dcimv1.ListChildPlacementsResponse], error) {
-	parentID := uuid.MustParse(req.Msg.GetParentPlacementId())
+	req *dcimv1.ListChildPlacementsRequest,
+) (*dcimv1.ListChildPlacementsResponse, error) {
+	parentID := uuid.MustParse(req.GetParentPlacementId())
 
 	rows, err := s.queries.PlacementListByParent(ctx, db.PlacementListByParentParams{
 		ParentPlacementID: pgtype.UUID{Bytes: parentID, Valid: true},
@@ -30,7 +30,7 @@ func (s *Server) ListChildPlacements(
 		placements = append(placements, placementFromParentListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListChildPlacementsResponse_builder{
+	return dcimv1.ListChildPlacementsResponse_builder{
 		Placements: placements,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/placement_update.go
+++ b/dcim-api/pkg/dcim/placement_update.go
@@ -19,22 +19,22 @@ import (
 
 func (s *Server) UpdatePlacement(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdatePlacementRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	placementID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdatePlacementRequest,
+) (*emptypb.Empty, error) {
+	placementID := uuid.MustParse(req.GetId())
 
 	params := db.PlacementUpdateParams{
 		ID: placementID,
 	}
 
-	switch loc := req.Msg.WhichLocation(); loc {
+	switch loc := req.WhichLocation(); loc {
 	case dcimv1.UpdatePlacementRequest_Rack_case:
-		rack := req.Msg.GetRack()
+		rack := req.GetRack()
 		params.RackID = pgtype.UUID{Bytes: uuid.MustParse(rack.GetRackId()), Valid: true}
 		params.StartUnit = pgtype.Int4{Int32: rack.GetRackUnitStart(), Valid: true}
 		params.SlotType = pgtype.Text{String: rackSlotTypeToDB(rack.GetRackSlotType()), Valid: true}
 	case dcimv1.UpdatePlacementRequest_SubComponent_case:
-		sub := req.Msg.GetSubComponent()
+		sub := req.GetSubComponent()
 		params.ParentPlacementID = pgtype.UUID{Bytes: uuid.MustParse(sub.GetParentPlacementId()), Valid: true}
 		params.PortDefinitionID = pgtype.UUID{Bytes: uuid.MustParse(sub.GetParentPortDefinitionId()), Valid: true}
 	case dcimv1.UpdatePlacementRequest_Location_not_set_case:
@@ -43,16 +43,16 @@ func (s *Server) UpdatePlacement(
 		panic("unhandled placement location case")
 	}
 
-	if req.Msg.HasLogicalDeviceId() {
-		if v := req.Msg.GetLogicalDeviceId(); v == "" {
+	if req.HasLogicalDeviceId() {
+		if v := req.GetLogicalDeviceId(); v == "" {
 			params.ClearLogicalDeviceID = true
 		} else {
 			params.LogicalDeviceID = pgtype.UUID{Bytes: uuid.MustParse(v), Valid: true}
 		}
 	}
 
-	if req.Msg.HasNotes() {
-		params.Notes = pgtype.Text{String: req.Msg.GetNotes(), Valid: true}
+	if req.HasNotes() {
+		params.Notes = pgtype.Text{String: req.GetNotes(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.PlacementUpdate(ctx, params)
@@ -79,5 +79,5 @@ func (s *Server) UpdatePlacement(
 
 	s.logger.InfoContext(ctx, "placement updated", "placement_id", placementID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/port_compatibility_create.go
+++ b/dcim-api/pkg/dcim/port_compatibility_create.go
@@ -18,10 +18,10 @@ import (
 
 func (s *Server) CreatePortCompatibility(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreatePortCompatibilityRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	portDefID := uuid.MustParse(req.Msg.GetPortDefinitionId())
-	compatCatalogID := uuid.MustParse(req.Msg.GetCompatibleCatalogId())
+	req *dcimv1.CreatePortCompatibilityRequest,
+) (*emptypb.Empty, error) {
+	portDefID := uuid.MustParse(req.GetPortDefinitionId())
+	compatCatalogID := uuid.MustParse(req.GetCompatibleCatalogId())
 
 	_, err := s.queries.PortCompatibilityCreate(ctx, db.PortCompatibilityCreateParams{
 		PortDefinitionID:    portDefID,
@@ -45,5 +45,5 @@ func (s *Server) CreatePortCompatibility(
 
 	s.logger.InfoContext(ctx, "port compatibility created", "port_definition_id", portDefID, "compatible_catalog_id", compatCatalogID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/port_compatibility_delete.go
+++ b/dcim-api/pkg/dcim/port_compatibility_delete.go
@@ -15,10 +15,10 @@ import (
 
 func (s *Server) DeletePortCompatibility(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeletePortCompatibilityRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	portDefID := uuid.MustParse(req.Msg.GetPortDefinitionId())
-	compatCatalogID := uuid.MustParse(req.Msg.GetCompatibleCatalogId())
+	req *dcimv1.DeletePortCompatibilityRequest,
+) (*emptypb.Empty, error) {
+	portDefID := uuid.MustParse(req.GetPortDefinitionId())
+	compatCatalogID := uuid.MustParse(req.GetCompatibleCatalogId())
 
 	rowsAffected, err := s.queries.PortCompatibilityDelete(ctx, db.PortCompatibilityDeleteParams{
 		PortDefinitionID: portDefID,
@@ -37,5 +37,5 @@ func (s *Server) DeletePortCompatibility(
 
 	s.logger.InfoContext(ctx, "port compatibility deleted", "port_definition_id", portDefID, "compatible_catalog_id", compatCatalogID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/port_compatibility_list.go
+++ b/dcim-api/pkg/dcim/port_compatibility_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListPortCompatibilities(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListPortCompatibilitiesRequest],
-) (*connect.Response[dcimv1.ListPortCompatibilitiesResponse], error) {
-	portDefID := uuid.MustParse(req.Msg.GetPortDefinitionId())
+	req *dcimv1.ListPortCompatibilitiesRequest,
+) (*dcimv1.ListPortCompatibilitiesResponse, error) {
+	portDefID := uuid.MustParse(req.GetPortDefinitionId())
 
 	rows, err := s.queries.PortCompatibilityList(ctx, db.PortCompatibilityListParams{PortDefinitionID: portDefID})
 	if err != nil {
@@ -36,7 +36,7 @@ func (s *Server) ListPortCompatibilities(
 		compatibilities = append(compatibilities, pc)
 	}
 
-	return connect.NewResponse(dcimv1.ListPortCompatibilitiesResponse_builder{
+	return dcimv1.ListPortCompatibilitiesResponse_builder{
 		Compatibilities: compatibilities,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/port_compatibility_list_test.go
+++ b/dcim-api/pkg/dcim/port_compatibility_list_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -17,19 +16,19 @@ func createPortDefinition(t *testing.T, env *testEnv, catalogID, name string) st
 
 	client := dcimv1connect.NewCatalogServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreatePortDefinition(context.Background(), connect.NewRequest(
+	resp, err := client.CreatePortDefinition(context.Background(),
 		(&dcimv1.CreatePortDefinitionRequest_builder{
 			DeviceCatalogId: catalogID,
 			Name:            name,
 			PortType:        dcimv1.PortType_PORT_TYPE_NETWORK,
 			Direction:       dcimv1.PortDirection_PORT_DIRECTION_BIDIR,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, resp.Msg.GetPortDefinitionId())
+	require.NotEmpty(t, resp.GetPortDefinitionId())
 
-	return resp.Msg.GetPortDefinitionId()
+	return resp.GetPortDefinitionId()
 }
 
 // TestCatalogService_ListPortCompatibilities verifies that both kinds of
@@ -49,12 +48,12 @@ func TestCatalogService_ListPortCompatibilities(t *testing.T) {
 	// Entry-specific compatibility: the API derives the category (SERVER) from
 	// the compatible catalog entry created by the helper.
 	compatID := createCatalogEntry(t, env, "Compatible SFP")
-	_, err := client.CreatePortCompatibility(context.Background(), connect.NewRequest(
+	_, err := client.CreatePortCompatibility(context.Background(),
 		(&dcimv1.CreatePortCompatibilityRequest_builder{
 			PortDefinitionId:    portDefID,
 			CompatibleCatalogId: compatID,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	// Category-wide compatibility (no specific catalog entry). The create API
@@ -65,12 +64,12 @@ func TestCatalogService_ListPortCompatibilities(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	resp, err := client.ListPortCompatibilities(context.Background(), connect.NewRequest(
+	resp, err := client.ListPortCompatibilities(context.Background(),
 		(&dcimv1.ListPortCompatibilitiesRequest_builder{PortDefinitionId: portDefID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	compatibilities := resp.Msg.GetCompatibilities()
+	compatibilities := resp.GetCompatibilities()
 	require.Len(t, compatibilities, 2)
 
 	var entrySpecific, categoryWide *dcimv1.PortCompatibility

--- a/dcim-api/pkg/dcim/port_definition_create.go
+++ b/dcim-api/pkg/dcim/port_definition_create.go
@@ -17,26 +17,26 @@ import (
 
 func (s *Server) CreatePortDefinition(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreatePortDefinitionRequest],
-) (*connect.Response[dcimv1.CreatePortDefinitionResponse], error) {
+	req *dcimv1.CreatePortDefinitionRequest,
+) (*dcimv1.CreatePortDefinitionResponse, error) {
 	params := db.PortDefinitionCreateParams{
-		DeviceCatalogID: uuid.MustParse(req.Msg.GetDeviceCatalogId()),
-		Name:            req.Msg.GetName(),
-		PortType:        portTypeToDB(req.Msg.GetPortType()),
-		Direction:       portDirectionToDB(req.Msg.GetDirection()),
-		Ordinal:         req.Msg.GetOrdinal(),
+		DeviceCatalogID: uuid.MustParse(req.GetDeviceCatalogId()),
+		Name:            req.GetName(),
+		PortType:        portTypeToDB(req.GetPortType()),
+		Direction:       portDirectionToDB(req.GetDirection()),
+		Ordinal:         req.GetOrdinal(),
 	}
 
-	if req.Msg.HasMediaType() {
-		params.MediaType = pgtype.Text{String: req.Msg.GetMediaType(), Valid: true}
+	if req.HasMediaType() {
+		params.MediaType = pgtype.Text{String: req.GetMediaType(), Valid: true}
 	}
 
-	if req.Msg.HasSpeed() {
-		params.Speed = pgtype.Text{String: req.Msg.GetSpeed(), Valid: true}
+	if req.HasSpeed() {
+		params.Speed = pgtype.Text{String: req.GetSpeed(), Valid: true}
 	}
 
-	if req.Msg.HasMaxPowerW() {
-		params.MaxPowerW = float64ToNumeric(req.Msg.GetMaxPowerW())
+	if req.HasMaxPowerW() {
+		params.MaxPowerW = float64ToNumeric(req.GetMaxPowerW())
 	}
 
 	id, err := s.queries.PortDefinitionCreate(ctx, params)
@@ -55,7 +55,7 @@ func (s *Server) CreatePortDefinition(
 
 	s.logger.InfoContext(ctx, "port definition created", "port_definition_id", id)
 
-	return connect.NewResponse(dcimv1.CreatePortDefinitionResponse_builder{
+	return dcimv1.CreatePortDefinitionResponse_builder{
 		PortDefinitionId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/port_definition_delete.go
+++ b/dcim-api/pkg/dcim/port_definition_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeletePortDefinition(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeletePortDefinitionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	portDefID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeletePortDefinitionRequest,
+) (*emptypb.Empty, error) {
+	portDefID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.PortDefinitionDelete(ctx, db.PortDefinitionDeleteParams{ID: portDefID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeletePortDefinition(
 
 	s.logger.InfoContext(ctx, "port definition deleted", "port_definition_id", portDefID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/port_definition_get.go
+++ b/dcim-api/pkg/dcim/port_definition_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetPortDefinition(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetPortDefinitionRequest],
-) (*connect.Response[dcimv1.GetPortDefinitionResponse], error) {
-	portDefID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetPortDefinitionRequest,
+) (*dcimv1.GetPortDefinitionResponse, error) {
+	portDefID := uuid.MustParse(req.GetId())
 
 	row, err := s.queries.PortDefinitionGetByID(ctx, db.PortDefinitionGetByIDParams{ID: portDefID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetPortDefinition(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get port definition: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetPortDefinitionResponse_builder{
+	return dcimv1.GetPortDefinitionResponse_builder{
 		PortDefinition: portDefinitionFromGetRow(&row),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/port_definition_list.go
+++ b/dcim-api/pkg/dcim/port_definition_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListPortDefinitions(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListPortDefinitionsRequest],
-) (*connect.Response[dcimv1.ListPortDefinitionsResponse], error) {
-	catalogID := uuid.MustParse(req.Msg.GetDeviceCatalogId())
+	req *dcimv1.ListPortDefinitionsRequest,
+) (*dcimv1.ListPortDefinitionsResponse, error) {
+	catalogID := uuid.MustParse(req.GetDeviceCatalogId())
 
 	rows, err := s.queries.PortDefinitionList(ctx, db.PortDefinitionListParams{DeviceCatalogID: catalogID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) ListPortDefinitions(
 		portDefs = append(portDefs, portDefinitionFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListPortDefinitionsResponse_builder{
+	return dcimv1.ListPortDefinitionsResponse_builder{
 		PortDefinitions: portDefs,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/port_definition_update.go
+++ b/dcim-api/pkg/dcim/port_definition_update.go
@@ -18,40 +18,40 @@ import (
 
 func (s *Server) UpdatePortDefinition(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdatePortDefinitionRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	portDefID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdatePortDefinitionRequest,
+) (*emptypb.Empty, error) {
+	portDefID := uuid.MustParse(req.GetId())
 
 	params := db.PortDefinitionUpdateParams{
 		ID: portDefID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasPortType() {
-		params.PortType = pgtype.Text{String: portTypeToDB(req.Msg.GetPortType()), Valid: true}
+	if req.HasPortType() {
+		params.PortType = pgtype.Text{String: portTypeToDB(req.GetPortType()), Valid: true}
 	}
 
-	if req.Msg.HasMediaType() {
-		params.MediaType = pgtype.Text{String: req.Msg.GetMediaType(), Valid: true}
+	if req.HasMediaType() {
+		params.MediaType = pgtype.Text{String: req.GetMediaType(), Valid: true}
 	}
 
-	if req.Msg.HasSpeed() {
-		params.Speed = pgtype.Text{String: req.Msg.GetSpeed(), Valid: true}
+	if req.HasSpeed() {
+		params.Speed = pgtype.Text{String: req.GetSpeed(), Valid: true}
 	}
 
-	if req.Msg.HasMaxPowerW() {
-		params.MaxPowerW = float64ToNumeric(req.Msg.GetMaxPowerW())
+	if req.HasMaxPowerW() {
+		params.MaxPowerW = float64ToNumeric(req.GetMaxPowerW())
 	}
 
-	if req.Msg.HasDirection() {
-		params.Direction = pgtype.Text{String: portDirectionToDB(req.Msg.GetDirection()), Valid: true}
+	if req.HasDirection() {
+		params.Direction = pgtype.Text{String: portDirectionToDB(req.GetDirection()), Valid: true}
 	}
 
-	if req.Msg.HasOrdinal() {
-		params.Ordinal = pgtype.Int4{Int32: req.Msg.GetOrdinal(), Valid: true}
+	if req.HasOrdinal() {
+		params.Ordinal = pgtype.Int4{Int32: req.GetOrdinal(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.PortDefinitionUpdate(ctx, params)
@@ -69,5 +69,5 @@ func (s *Server) UpdatePortDefinition(
 
 	s.logger.InfoContext(ctx, "port definition updated", "port_definition_id", portDefID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/rack_create.go
+++ b/dcim-api/pkg/dcim/rack_create.go
@@ -16,13 +16,13 @@ import (
 
 func (s *Server) CreateRack(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateRackRequest],
-) (*connect.Response[dcimv1.CreateRackResponse], error) {
+	req *dcimv1.CreateRackRequest,
+) (*dcimv1.CreateRackResponse, error) {
 	params := db.RackCreateParams{
-		RackRowID:     uuid.MustParse(req.Msg.GetRowId()),
-		Name:          req.Msg.GetName(),
-		TotalUnits:    req.Msg.GetTotalUnits(),
-		PositionInRow: req.Msg.GetPositionInRow(),
+		RackRowID:     uuid.MustParse(req.GetRowId()),
+		Name:          req.GetName(),
+		TotalUnits:    req.GetTotalUnits(),
+		PositionInRow: req.GetPositionInRow(),
 	}
 
 	id, err := s.queries.RackCreate(ctx, params)
@@ -41,7 +41,7 @@ func (s *Server) CreateRack(
 
 	s.logger.InfoContext(ctx, "rack created", "rack_id", id)
 
-	return connect.NewResponse(dcimv1.CreateRackResponse_builder{
+	return dcimv1.CreateRackResponse_builder{
 		RackId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_create_test.go
+++ b/dcim-api/pkg/dcim/rack_create_test.go
@@ -19,16 +19,16 @@ func TestRackService_CreateRack_HappyFlow(t *testing.T) {
 
 	rowID := createRackRowFixture(t, env, "Rack Create")
 
-	resp, err := client.CreateRack(context.Background(), connect.NewRequest(
+	resp, err := client.CreateRack(context.Background(),
 		(&dcimv1.CreateRackRequest_builder{
 			RowId:      rowID,
 			Name:       "Rack A",
 			TotalUnits: 42,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.Msg.GetRackId())
+	assert.NotEmpty(t, resp.GetRackId())
 }
 
 func TestRackService_CreateRack_Errors(t *testing.T) {
@@ -54,13 +54,13 @@ func TestRackService_CreateRack_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.CreateRack(context.Background(), connect.NewRequest(
+			_, err := client.CreateRack(context.Background(),
 				(&dcimv1.CreateRackRequest_builder{
 					RowId:      tc.rowID,
 					Name:       tc.rackName,
 					TotalUnits: tc.totalUnits,
 				}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/rack_delete.go
+++ b/dcim-api/pkg/dcim/rack_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteRack(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteRackRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	rackID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteRackRequest,
+) (*emptypb.Empty, error) {
+	rackID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.RackDelete(ctx, db.RackDeleteParams{ID: rackID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteRack(
 
 	s.logger.InfoContext(ctx, "rack deleted", "rack_id", rackID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/rack_delete_test.go
+++ b/dcim-api/pkg/dcim/rack_delete_test.go
@@ -19,14 +19,14 @@ func TestRackService_DeleteRack_HappyFlow(t *testing.T) {
 	rowID := createRackRowFixture(t, env, "Rack Delete")
 	rackID := createRack(t, env, rowID, "Rack To Delete", 24)
 
-	_, err := client.DeleteRack(context.Background(), connect.NewRequest(
+	_, err := client.DeleteRack(context.Background(),
 		(&dcimv1.DeleteRackRequest_builder{Id: rackID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	_, err = client.GetRack(context.Background(), connect.NewRequest(
+	_, err = client.GetRack(context.Background(),
 		(&dcimv1.GetRackRequest_builder{Id: rackID}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }
 
@@ -48,9 +48,9 @@ func TestRackService_DeleteRack_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.DeleteRack(context.Background(), connect.NewRequest(
+			_, err := client.DeleteRack(context.Background(),
 				(&dcimv1.DeleteRackRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/rack_get.go
+++ b/dcim-api/pkg/dcim/rack_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetRack(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetRackRequest],
-) (*connect.Response[dcimv1.GetRackResponse], error) {
-	rackID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetRackRequest,
+) (*dcimv1.GetRackResponse, error) {
+	rackID := uuid.MustParse(req.GetId())
 
 	row, err := s.queries.RackGetByID(ctx, db.RackGetByIDParams{ID: rackID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetRack(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get rack: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetRackResponse_builder{
+	return dcimv1.GetRackResponse_builder{
 		Rack: rackFromGetRow(&row),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_get_test.go
+++ b/dcim-api/pkg/dcim/rack_get_test.go
@@ -20,12 +20,12 @@ func TestRackService_GetRack_HappyFlow(t *testing.T) {
 	rowID := createRackRowFixture(t, env, "Rack Get")
 	rackID := createRack(t, env, rowID, "Rack Get Target", 24)
 
-	resp, err := client.GetRack(context.Background(), connect.NewRequest(
+	resp, err := client.GetRack(context.Background(),
 		(&dcimv1.GetRackRequest_builder{Id: rackID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	rack := resp.Msg.GetRack()
+	rack := resp.GetRack()
 	require.NotNil(t, rack)
 	assert.Equal(t, rackID, rack.GetId())
 	assert.Equal(t, rowID, rack.GetRowId())
@@ -51,9 +51,9 @@ func TestRackService_GetRack_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.GetRack(context.Background(), connect.NewRequest(
+			_, err := client.GetRack(context.Background(),
 				(&dcimv1.GetRackRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/rack_list.go
+++ b/dcim-api/pkg/dcim/rack_list.go
@@ -14,16 +14,16 @@ import (
 
 func (s *Server) ListRacks(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListRacksRequest],
-) (*connect.Response[dcimv1.ListRacksResponse], error) {
+	req *dcimv1.ListRacksRequest,
+) (*dcimv1.ListRacksResponse, error) {
 	params := db.RackListParams{}
 
-	if req.Msg.HasRowId() {
-		rowID := uuid.MustParse(req.Msg.GetRowId())
+	if req.HasRowId() {
+		rowID := uuid.MustParse(req.GetRowId())
 		params.RackRowID = pgtype.UUID{Bytes: rowID, Valid: true}
 	}
-	if req.Msg.HasSiteId() {
-		siteID := uuid.MustParse(req.Msg.GetSiteId())
+	if req.HasSiteId() {
+		siteID := uuid.MustParse(req.GetSiteId())
 		params.SiteID = pgtype.UUID{Bytes: siteID, Valid: true}
 	}
 
@@ -41,7 +41,7 @@ func (s *Server) ListRacks(
 		}.Build())
 	}
 
-	return connect.NewResponse(dcimv1.ListRacksResponse_builder{
+	return dcimv1.ListRacksResponse_builder{
 		Racks: racks,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_list_test.go
+++ b/dcim-api/pkg/dcim/rack_list_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -24,13 +23,13 @@ func TestRackService_ListRacks_HappyFlow(t *testing.T) {
 		createRack(t, env, rowID, name, 42)
 	}
 
-	resp, err := client.ListRacks(context.Background(), connect.NewRequest(
+	resp, err := client.ListRacks(context.Background(),
 		(&dcimv1.ListRacksRequest_builder{RowId: &rowID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetRacks()))
-	for _, summary := range resp.Msg.GetRacks() {
+	got := make([]string, 0, len(resp.GetRacks()))
+	for _, summary := range resp.GetRacks() {
 		got = append(got, summary.GetRack().GetName())
 	}
 
@@ -58,13 +57,13 @@ func TestRackService_ListRacks_FilterBySite(t *testing.T) {
 	otherRow := createRackRow(t, env, otherRoom, "Other row")
 	createRack(t, env, otherRow, "Other rack", 42)
 
-	resp, err := client.ListRacks(context.Background(), connect.NewRequest(
+	resp, err := client.ListRacks(context.Background(),
 		(&dcimv1.ListRacksRequest_builder{SiteId: &siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetRacks()))
-	for _, summary := range resp.Msg.GetRacks() {
+	got := make([]string, 0, len(resp.GetRacks()))
+	for _, summary := range resp.GetRacks() {
 		got = append(got, summary.GetRack().GetName())
 	}
 

--- a/dcim-api/pkg/dcim/rack_row_create.go
+++ b/dcim-api/pkg/dcim/rack_row_create.go
@@ -17,19 +17,19 @@ import (
 
 func (s *Server) CreateRackRow(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateRackRowRequest],
-) (*connect.Response[dcimv1.CreateRackRowResponse], error) {
+	req *dcimv1.CreateRackRowRequest,
+) (*dcimv1.CreateRackRowResponse, error) {
 	params := db.RackRowCreateParams{
-		RoomID: uuid.MustParse(req.Msg.GetRoomId()),
-		Name:   req.Msg.GetName(),
+		RoomID: uuid.MustParse(req.GetRoomId()),
+		Name:   req.GetName(),
 	}
 
-	if req.Msg.HasPositionX() {
-		params.PositionX = pgtype.Float8{Float64: req.Msg.GetPositionX(), Valid: true}
+	if req.HasPositionX() {
+		params.PositionX = pgtype.Float8{Float64: req.GetPositionX(), Valid: true}
 	}
 
-	if req.Msg.HasPositionY() {
-		params.PositionY = pgtype.Float8{Float64: req.Msg.GetPositionY(), Valid: true}
+	if req.HasPositionY() {
+		params.PositionY = pgtype.Float8{Float64: req.GetPositionY(), Valid: true}
 	}
 
 	id, err := s.queries.RackRowCreate(ctx, params)
@@ -48,7 +48,7 @@ func (s *Server) CreateRackRow(
 
 	s.logger.InfoContext(ctx, "rack row created", "rack_row_id", id)
 
-	return connect.NewResponse(dcimv1.CreateRackRowResponse_builder{
+	return dcimv1.CreateRackRowResponse_builder{
 		RackRowId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_row_delete.go
+++ b/dcim-api/pkg/dcim/rack_row_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteRackRow(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteRackRowRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	rackRowID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteRackRowRequest,
+) (*emptypb.Empty, error) {
+	rackRowID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.RackRowDelete(ctx, db.RackRowDeleteParams{ID: rackRowID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteRackRow(
 
 	s.logger.InfoContext(ctx, "rack row deleted", "rack_row_id", rackRowID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/rack_row_get.go
+++ b/dcim-api/pkg/dcim/rack_row_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetRackRow(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetRackRowRequest],
-) (*connect.Response[dcimv1.GetRackRowResponse], error) {
-	rackRowID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetRackRowRequest,
+) (*dcimv1.GetRackRowResponse, error) {
+	rackRowID := uuid.MustParse(req.GetId())
 
 	rackRow, err := s.queries.RackRowGetByID(ctx, db.RackRowGetByIDParams{ID: rackRowID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetRackRow(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get rack row: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetRackRowResponse_builder{
+	return dcimv1.GetRackRowResponse_builder{
 		RackRow: rackRowFromRow(&rackRow),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_row_list.go
+++ b/dcim-api/pkg/dcim/rack_row_list.go
@@ -14,16 +14,16 @@ import (
 
 func (s *Server) ListRackRows(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListRackRowsRequest],
-) (*connect.Response[dcimv1.ListRackRowsResponse], error) {
+	req *dcimv1.ListRackRowsRequest,
+) (*dcimv1.ListRackRowsResponse, error) {
 	params := db.RackRowListParams{}
 
-	if req.Msg.HasRoomId() {
-		roomID := uuid.MustParse(req.Msg.GetRoomId())
+	if req.HasRoomId() {
+		roomID := uuid.MustParse(req.GetRoomId())
 		params.RoomID = pgtype.UUID{Bytes: roomID, Valid: true}
 	}
-	if req.Msg.HasSiteId() {
-		siteID := uuid.MustParse(req.Msg.GetSiteId())
+	if req.HasSiteId() {
+		siteID := uuid.MustParse(req.GetSiteId())
 		params.SiteID = pgtype.UUID{Bytes: siteID, Valid: true}
 	}
 
@@ -37,7 +37,7 @@ func (s *Server) ListRackRows(
 		rackRows = append(rackRows, rackRowFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListRackRowsResponse_builder{
+	return dcimv1.ListRackRowsResponse_builder{
 		RackRows: rackRows,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/rack_row_list_test.go
+++ b/dcim-api/pkg/dcim/rack_row_list_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -29,13 +28,13 @@ func TestRackRowService_ListRackRows_FilterBySite(t *testing.T) {
 	otherRoom := createRoom(t, env, otherSite, "Other room")
 	createRackRow(t, env, otherRoom, "Other row")
 
-	resp, err := client.ListRackRows(context.Background(), connect.NewRequest(
+	resp, err := client.ListRackRows(context.Background(),
 		(&dcimv1.ListRackRowsRequest_builder{SiteId: &siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetRackRows()))
-	for _, row := range resp.Msg.GetRackRows() {
+	got := make([]string, 0, len(resp.GetRackRows()))
+	for _, row := range resp.GetRackRows() {
 		got = append(got, row.GetName())
 	}
 

--- a/dcim-api/pkg/dcim/rack_row_update.go
+++ b/dcim-api/pkg/dcim/rack_row_update.go
@@ -18,24 +18,24 @@ import (
 
 func (s *Server) UpdateRackRow(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateRackRowRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	rackRowID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateRackRowRequest,
+) (*emptypb.Empty, error) {
+	rackRowID := uuid.MustParse(req.GetId())
 
 	params := db.RackRowUpdateParams{
 		ID: rackRowID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasPositionX() {
-		params.PositionX = pgtype.Float8{Float64: req.Msg.GetPositionX(), Valid: true}
+	if req.HasPositionX() {
+		params.PositionX = pgtype.Float8{Float64: req.GetPositionX(), Valid: true}
 	}
 
-	if req.Msg.HasPositionY() {
-		params.PositionY = pgtype.Float8{Float64: req.Msg.GetPositionY(), Valid: true}
+	if req.HasPositionY() {
+		params.PositionY = pgtype.Float8{Float64: req.GetPositionY(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.RackRowUpdate(ctx, params)
@@ -53,5 +53,5 @@ func (s *Server) UpdateRackRow(
 
 	s.logger.InfoContext(ctx, "rack row updated", "rack_row_id", rackRowID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/rack_update.go
+++ b/dcim-api/pkg/dcim/rack_update.go
@@ -18,24 +18,24 @@ import (
 
 func (s *Server) UpdateRack(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateRackRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	rackID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateRackRequest,
+) (*emptypb.Empty, error) {
+	rackID := uuid.MustParse(req.GetId())
 
 	params := db.RackUpdateParams{
 		ID: rackID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasTotalUnits() {
-		params.TotalUnits = pgtype.Int4{Int32: req.Msg.GetTotalUnits(), Valid: true}
+	if req.HasTotalUnits() {
+		params.TotalUnits = pgtype.Int4{Int32: req.GetTotalUnits(), Valid: true}
 	}
 
-	if req.Msg.HasPositionInRow() {
-		params.PositionInRow = pgtype.Int4{Int32: req.Msg.GetPositionInRow(), Valid: true}
+	if req.HasPositionInRow() {
+		params.PositionInRow = pgtype.Int4{Int32: req.GetPositionInRow(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.RackUpdate(ctx, params)
@@ -53,5 +53,5 @@ func (s *Server) UpdateRack(
 
 	s.logger.InfoContext(ctx, "rack updated", "rack_id", rackID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/rack_update_test.go
+++ b/dcim-api/pkg/dcim/rack_update_test.go
@@ -22,21 +22,21 @@ func TestRackService_UpdateRack_HappyFlow(t *testing.T) {
 
 	newName := "Rack After Update"
 	newUnits := int32(48)
-	_, err := client.UpdateRack(context.Background(), connect.NewRequest(
+	_, err := client.UpdateRack(context.Background(),
 		(&dcimv1.UpdateRackRequest_builder{
 			Id:         rackID,
 			Name:       &newName,
 			TotalUnits: &newUnits,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	getResp, err := client.GetRack(context.Background(), connect.NewRequest(
+	getResp, err := client.GetRack(context.Background(),
 		(&dcimv1.GetRackRequest_builder{Id: rackID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	rack := getResp.Msg.GetRack()
+	rack := getResp.GetRack()
 	require.NotNil(t, rack)
 
 	assert.Equal(t, newName, rack.GetName())
@@ -61,9 +61,9 @@ func TestRackService_UpdateRack_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.UpdateRack(context.Background(), connect.NewRequest(
+			_, err := client.UpdateRack(context.Background(),
 				(&dcimv1.UpdateRackRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/room_create.go
+++ b/dcim-api/pkg/dcim/room_create.go
@@ -17,15 +17,15 @@ import (
 
 func (s *Server) CreateRoom(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateRoomRequest],
-) (*connect.Response[dcimv1.CreateRoomResponse], error) {
+	req *dcimv1.CreateRoomRequest,
+) (*dcimv1.CreateRoomResponse, error) {
 	params := db.RoomCreateParams{
-		SiteID: uuid.MustParse(req.Msg.GetSiteId()),
-		Name:   req.Msg.GetName(),
+		SiteID: uuid.MustParse(req.GetSiteId()),
+		Name:   req.GetName(),
 	}
 
-	if req.Msg.HasFloor() {
-		params.Floor = pgtype.Text{String: req.Msg.GetFloor(), Valid: true}
+	if req.HasFloor() {
+		params.Floor = pgtype.Text{String: req.GetFloor(), Valid: true}
 	}
 
 	id, err := s.queries.RoomCreate(ctx, params)
@@ -44,7 +44,7 @@ func (s *Server) CreateRoom(
 
 	s.logger.InfoContext(ctx, "room created", "room_id", id)
 
-	return connect.NewResponse(dcimv1.CreateRoomResponse_builder{
+	return dcimv1.CreateRoomResponse_builder{
 		RoomId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/room_delete.go
+++ b/dcim-api/pkg/dcim/room_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteRoom(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteRoomRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	roomID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteRoomRequest,
+) (*emptypb.Empty, error) {
+	roomID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.RoomDelete(ctx, db.RoomDeleteParams{ID: roomID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteRoom(
 
 	s.logger.InfoContext(ctx, "room deleted", "room_id", roomID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/room_get.go
+++ b/dcim-api/pkg/dcim/room_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetRoom(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetRoomRequest],
-) (*connect.Response[dcimv1.GetRoomResponse], error) {
-	roomID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetRoomRequest,
+) (*dcimv1.GetRoomResponse, error) {
+	roomID := uuid.MustParse(req.GetId())
 
 	room, err := s.queries.RoomGetByID(ctx, db.RoomGetByIDParams{ID: roomID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetRoom(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get room: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetRoomResponse_builder{
+	return dcimv1.GetRoomResponse_builder{
 		Room: roomFromRow(&room),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/room_list.go
+++ b/dcim-api/pkg/dcim/room_list.go
@@ -14,12 +14,12 @@ import (
 
 func (s *Server) ListRooms(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListRoomsRequest],
-) (*connect.Response[dcimv1.ListRoomsResponse], error) {
+	req *dcimv1.ListRoomsRequest,
+) (*dcimv1.ListRoomsResponse, error) {
 	params := db.RoomListParams{}
 
-	if req.Msg.HasSiteId() {
-		siteID := uuid.MustParse(req.Msg.GetSiteId())
+	if req.HasSiteId() {
+		siteID := uuid.MustParse(req.GetSiteId())
 		params.SiteID = pgtype.UUID{Bytes: siteID, Valid: true}
 	}
 
@@ -33,7 +33,7 @@ func (s *Server) ListRooms(
 		rooms = append(rooms, roomFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListRoomsResponse_builder{
+	return dcimv1.ListRoomsResponse_builder{
 		Rooms: rooms,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/room_update.go
+++ b/dcim-api/pkg/dcim/room_update.go
@@ -18,20 +18,20 @@ import (
 
 func (s *Server) UpdateRoom(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateRoomRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	roomID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateRoomRequest,
+) (*emptypb.Empty, error) {
+	roomID := uuid.MustParse(req.GetId())
 
 	params := db.RoomUpdateParams{
 		ID: roomID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasFloor() {
-		params.Floor = pgtype.Text{String: req.Msg.GetFloor(), Valid: true}
+	if req.HasFloor() {
+		params.Floor = pgtype.Text{String: req.GetFloor(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.RoomUpdate(ctx, params)
@@ -49,5 +49,5 @@ func (s *Server) UpdateRoom(
 
 	s.logger.InfoContext(ctx, "room updated", "room_id", roomID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/site_create.go
+++ b/dcim-api/pkg/dcim/site_create.go
@@ -17,14 +17,14 @@ import (
 
 func (s *Server) CreateSite(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateSiteRequest],
-) (*connect.Response[dcimv1.CreateSiteResponse], error) {
+	req *dcimv1.CreateSiteRequest,
+) (*dcimv1.CreateSiteResponse, error) {
 	params := db.SiteCreateParams{
-		Name: req.Msg.GetName(),
+		Name: req.GetName(),
 	}
 
-	if req.Msg.HasAddress() {
-		params.Address = pgtype.Text{String: req.Msg.GetAddress(), Valid: true}
+	if req.HasAddress() {
+		params.Address = pgtype.Text{String: req.GetAddress(), Valid: true}
 	}
 
 	id, err := s.queries.SiteCreate(ctx, params)
@@ -38,7 +38,7 @@ func (s *Server) CreateSite(
 
 	s.logger.InfoContext(ctx, "site created", "site_id", id)
 
-	return connect.NewResponse(dcimv1.CreateSiteResponse_builder{
+	return dcimv1.CreateSiteResponse_builder{
 		SiteId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/site_create_test.go
+++ b/dcim-api/pkg/dcim/site_create_test.go
@@ -17,9 +17,9 @@ func TestSiteService_CreateSite_InvalidInput(t *testing.T) {
 	env := newTestAPI(t)
 	client := dcimv1connect.NewSiteServiceClient(env.client(), env.server.URL)
 
-	_, err := client.CreateSite(context.Background(), connect.NewRequest(
+	_, err := client.CreateSite(context.Background(),
 		(&dcimv1.CreateSiteRequest_builder{Name: ""}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeInvalidArgument)
 }
 
@@ -29,9 +29,9 @@ func TestSiteService_CreateSite(t *testing.T) {
 	env := newTestAPI(t)
 	client := dcimv1connect.NewSiteServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.CreateSite(context.Background(), connect.NewRequest(
+	resp, err := client.CreateSite(context.Background(),
 		(&dcimv1.CreateSiteRequest_builder{Name: "Site A"}).Build(),
-	))
+	)
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.Msg.GetSiteId())
+	assert.NotEmpty(t, resp.GetSiteId())
 }

--- a/dcim-api/pkg/dcim/site_delete.go
+++ b/dcim-api/pkg/dcim/site_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteSite(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteSiteRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	siteID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteSiteRequest,
+) (*emptypb.Empty, error) {
+	siteID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.SiteDelete(ctx, db.SiteDeleteParams{ID: siteID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteSite(
 
 	s.logger.InfoContext(ctx, "site deleted", "site_id", siteID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/site_delete_test.go
+++ b/dcim-api/pkg/dcim/site_delete_test.go
@@ -18,14 +18,14 @@ func TestSiteService_DeleteSite_HappyFlow(t *testing.T) {
 
 	siteID := createSite(t, env, "Site To Delete")
 
-	_, err := client.DeleteSite(context.Background(), connect.NewRequest(
+	_, err := client.DeleteSite(context.Background(),
 		(&dcimv1.DeleteSiteRequest_builder{Id: siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	_, err = client.GetSite(context.Background(), connect.NewRequest(
+	_, err = client.GetSite(context.Background(),
 		(&dcimv1.GetSiteRequest_builder{Id: siteID}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }
 
@@ -47,9 +47,9 @@ func TestSiteService_DeleteSite(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.DeleteSite(context.Background(), connect.NewRequest(
+			_, err := client.DeleteSite(context.Background(),
 				(&dcimv1.DeleteSiteRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/site_get.go
+++ b/dcim-api/pkg/dcim/site_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetSite(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetSiteRequest],
-) (*connect.Response[dcimv1.GetSiteResponse], error) {
-	siteID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetSiteRequest,
+) (*dcimv1.GetSiteResponse, error) {
+	siteID := uuid.MustParse(req.GetId())
 
 	site, err := s.queries.SiteGetByID(ctx, db.SiteGetByIDParams{ID: siteID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetSite(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get site: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetSiteResponse_builder{
+	return dcimv1.GetSiteResponse_builder{
 		Site: siteFromRow(&site),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/site_get_test.go
+++ b/dcim-api/pkg/dcim/site_get_test.go
@@ -19,12 +19,12 @@ func TestSiteService_GetSite_HappyFlow(t *testing.T) {
 
 	siteID := createSite(t, env, "Site Get Success")
 
-	resp, err := client.GetSite(context.Background(), connect.NewRequest(
+	resp, err := client.GetSite(context.Background(),
 		(&dcimv1.GetSiteRequest_builder{Id: siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	site := resp.Msg.GetSite()
+	site := resp.GetSite()
 	require.NotNil(t, site)
 	assert.Equal(t, siteID, site.GetId())
 	assert.Equal(t, "Site Get Success", site.GetName())
@@ -48,9 +48,9 @@ func TestSiteService_GetSite(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.GetSite(context.Background(), connect.NewRequest(
+			_, err := client.GetSite(context.Background(),
 				(&dcimv1.GetSiteRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/site_list.go
+++ b/dcim-api/pkg/dcim/site_list.go
@@ -10,8 +10,8 @@ import (
 
 func (s *Server) ListSites(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListSitesRequest],
-) (*connect.Response[dcimv1.ListSitesResponse], error) {
+	req *dcimv1.ListSitesRequest,
+) (*dcimv1.ListSitesResponse, error) {
 	rows, err := s.queries.SiteList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list sites: %w", err))
@@ -22,7 +22,7 @@ func (s *Server) ListSites(
 		sites = append(sites, siteFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListSitesResponse_builder{
+	return dcimv1.ListSitesResponse_builder{
 		Sites: sites,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/site_list_test.go
+++ b/dcim-api/pkg/dcim/site_list_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	dcimv1 "github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/dcim-api/pkg/proto/gen/v1/dcimv1connect"
 	"github.com/stretchr/testify/assert"
@@ -22,11 +21,11 @@ func TestSiteService_ListSites_Populated(t *testing.T) {
 		createSite(t, env, name)
 	}
 
-	resp, err := client.ListSites(context.Background(), connect.NewRequest(&dcimv1.ListSitesRequest{}))
+	resp, err := client.ListSites(context.Background(), &dcimv1.ListSitesRequest{})
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetSites()))
-	for _, s := range resp.Msg.GetSites() {
+	got := make([]string, 0, len(resp.GetSites()))
+	for _, s := range resp.GetSites() {
 		got = append(got, s.GetName())
 	}
 	// ListSites is unfiltered, so the response also includes seeded sites

--- a/dcim-api/pkg/dcim/site_update.go
+++ b/dcim-api/pkg/dcim/site_update.go
@@ -19,20 +19,20 @@ import (
 
 func (s *Server) UpdateSite(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateSiteRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	siteID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateSiteRequest,
+) (*emptypb.Empty, error) {
+	siteID := uuid.MustParse(req.GetId())
 
 	params := db.SiteUpdateParams{
 		ID: siteID,
 	}
 
-	if req.Msg.HasName() {
-		params.Name = pgtype.Text{String: req.Msg.GetName(), Valid: true}
+	if req.HasName() {
+		params.Name = pgtype.Text{String: req.GetName(), Valid: true}
 	}
 
-	if req.Msg.HasAddress() {
-		params.Address = pgtype.Text{String: req.Msg.GetAddress(), Valid: true}
+	if req.HasAddress() {
+		params.Address = pgtype.Text{String: req.GetAddress(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.SiteUpdate(ctx, params)
@@ -50,5 +50,5 @@ func (s *Server) UpdateSite(
 
 	s.logger.InfoContext(ctx, "site updated", "site_id", siteID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/site_update_test.go
+++ b/dcim-api/pkg/dcim/site_update_test.go
@@ -21,20 +21,20 @@ func TestSiteService_UpdateSite_HappyFlow(t *testing.T) {
 
 	newName := "Site After Update"
 	newAddress := "Updated street 1"
-	_, err := client.UpdateSite(context.Background(), connect.NewRequest(
+	_, err := client.UpdateSite(context.Background(),
 		(&dcimv1.UpdateSiteRequest_builder{
 			Id:      siteID,
 			Name:    &newName,
 			Address: &newAddress,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	getResp, err := client.GetSite(context.Background(), connect.NewRequest(
+	getResp, err := client.GetSite(context.Background(),
 		(&dcimv1.GetSiteRequest_builder{Id: siteID}).Build(),
-	))
+	)
 	require.NoError(t, err)
-	site := getResp.Msg.GetSite()
+	site := getResp.GetSite()
 	require.NotNil(t, site)
 	assert.Equal(t, newName, site.GetName())
 	assert.Equal(t, newAddress, site.GetAddress())
@@ -58,9 +58,9 @@ func TestSiteService_UpdateSite(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.UpdateSite(context.Background(), connect.NewRequest(
+			_, err := client.UpdateSite(context.Background(),
 				(&dcimv1.UpdateSiteRequest_builder{Id: tc.id}).Build(),
-			))
+			)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/task_create.go
+++ b/dcim-api/pkg/dcim/task_create.go
@@ -17,21 +17,21 @@ import (
 
 func (s *Server) CreateTask(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateTaskRequest],
-) (*connect.Response[dcimv1.CreateTaskResponse], error) {
+	req *dcimv1.CreateTaskRequest,
+) (*dcimv1.CreateTaskResponse, error) {
 	params := db.TaskCreateParams{
-		Title:    req.Msg.GetTitle(),
-		Status:   taskStatusFromProto(req.Msg.GetStatus()),
-		Priority: taskPriorityFromProto(req.Msg.GetPriority()),
-		Category: taskCategoryFromProto(req.Msg.GetCategory()),
+		Title:    req.GetTitle(),
+		Status:   taskStatusFromProto(req.GetStatus()),
+		Priority: taskPriorityFromProto(req.GetPriority()),
+		Category: taskCategoryFromProto(req.GetCategory()),
 	}
 
-	if req.Msg.HasDescription() {
-		params.Description = pgtype.Text{String: req.Msg.GetDescription(), Valid: true}
+	if req.HasDescription() {
+		params.Description = pgtype.Text{String: req.GetDescription(), Valid: true}
 	}
 
-	if req.Msg.HasAssigneeId() {
-		assigneeID, err := uuid.Parse(req.Msg.GetAssigneeId())
+	if req.HasAssigneeId() {
+		assigneeID, err := uuid.Parse(req.GetAssigneeId())
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid assignee_id: %w", err))
 		}
@@ -39,12 +39,12 @@ func (s *Server) CreateTask(
 		params.AssigneeID = pgtype.UUID{Bytes: assigneeID, Valid: true}
 	}
 
-	if req.Msg.HasDueDate() {
-		params.DueDate = pgtype.Timestamptz{Time: req.Msg.GetDueDate().AsTime(), Valid: true}
+	if req.HasDueDate() {
+		params.DueDate = pgtype.Timestamptz{Time: req.GetDueDate().AsTime(), Valid: true}
 	}
 
-	if req.Msg.HasLocation() {
-		params.Location = pgtype.Text{String: req.Msg.GetLocation(), Valid: true}
+	if req.HasLocation() {
+		params.Location = pgtype.Text{String: req.GetLocation(), Valid: true}
 	}
 
 	id, err := s.queries.TaskCreate(ctx, params)
@@ -58,7 +58,7 @@ func (s *Server) CreateTask(
 
 	s.logger.InfoContext(ctx, "task created", "task_id", id)
 
-	return connect.NewResponse(dcimv1.CreateTaskResponse_builder{
+	return dcimv1.CreateTaskResponse_builder{
 		TaskId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/task_delete.go
+++ b/dcim-api/pkg/dcim/task_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteTask(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteTaskRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	taskID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteTaskRequest,
+) (*emptypb.Empty, error) {
+	taskID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.TaskDelete(ctx, db.TaskDeleteParams{ID: taskID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteTask(
 
 	s.logger.InfoContext(ctx, "task deleted", "task_id", taskID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/task_get.go
+++ b/dcim-api/pkg/dcim/task_get.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) GetTask(
 	ctx context.Context,
-	req *connect.Request[dcimv1.GetTaskRequest],
-) (*connect.Response[dcimv1.GetTaskResponse], error) {
-	taskID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.GetTaskRequest,
+) (*dcimv1.GetTaskResponse, error) {
+	taskID := uuid.MustParse(req.GetId())
 
 	task, err := s.queries.TaskGetByID(ctx, db.TaskGetByIDParams{ID: taskID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) GetTask(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get task: %w", err))
 	}
 
-	return connect.NewResponse(dcimv1.GetTaskResponse_builder{
+	return dcimv1.GetTaskResponse_builder{
 		Task: taskFromRow(&task),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/task_list.go
+++ b/dcim-api/pkg/dcim/task_list.go
@@ -14,24 +14,24 @@ import (
 
 func (s *Server) ListTasks(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListTasksRequest],
-) (*connect.Response[dcimv1.ListTasksResponse], error) {
+	req *dcimv1.ListTasksRequest,
+) (*dcimv1.ListTasksResponse, error) {
 	params := db.TaskListParams{}
 
-	if req.Msg.HasStatus() {
-		params.Status = pgtype.Text{String: taskStatusFromProto(req.Msg.GetStatus()), Valid: true}
+	if req.HasStatus() {
+		params.Status = pgtype.Text{String: taskStatusFromProto(req.GetStatus()), Valid: true}
 	}
 
-	if req.Msg.HasPriority() {
-		params.Priority = pgtype.Text{String: taskPriorityFromProto(req.Msg.GetPriority()), Valid: true}
+	if req.HasPriority() {
+		params.Priority = pgtype.Text{String: taskPriorityFromProto(req.GetPriority()), Valid: true}
 	}
 
-	if req.Msg.HasCategory() {
-		params.Category = pgtype.Text{String: taskCategoryFromProto(req.Msg.GetCategory()), Valid: true}
+	if req.HasCategory() {
+		params.Category = pgtype.Text{String: taskCategoryFromProto(req.GetCategory()), Valid: true}
 	}
 
-	if req.Msg.HasAssigneeId() {
-		assigneeID, err := uuid.Parse(req.Msg.GetAssigneeId())
+	if req.HasAssigneeId() {
+		assigneeID, err := uuid.Parse(req.GetAssigneeId())
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid assignee_id: %w", err))
 		}
@@ -49,7 +49,7 @@ func (s *Server) ListTasks(
 		tasks = append(tasks, taskFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListTasksResponse_builder{
+	return dcimv1.ListTasksResponse_builder{
 		Tasks: tasks,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/task_step_create.go
+++ b/dcim-api/pkg/dcim/task_step_create.go
@@ -17,16 +17,16 @@ import (
 
 func (s *Server) CreateTaskStep(
 	ctx context.Context,
-	req *connect.Request[dcimv1.CreateTaskStepRequest],
-) (*connect.Response[dcimv1.CreateTaskStepResponse], error) {
+	req *dcimv1.CreateTaskStepRequest,
+) (*dcimv1.CreateTaskStepResponse, error) {
 	params := db.TaskStepCreateParams{
-		TaskID:  uuid.MustParse(req.Msg.GetTaskId()),
-		Title:   req.Msg.GetTitle(),
-		Ordinal: req.Msg.GetOrdinal(),
+		TaskID:  uuid.MustParse(req.GetTaskId()),
+		Title:   req.GetTitle(),
+		Ordinal: req.GetOrdinal(),
 	}
 
-	if req.Msg.HasDescription() {
-		params.Description = pgtype.Text{String: req.Msg.GetDescription(), Valid: true}
+	if req.HasDescription() {
+		params.Description = pgtype.Text{String: req.GetDescription(), Valid: true}
 	}
 
 	id, err := s.queries.TaskStepCreate(ctx, params)
@@ -40,7 +40,7 @@ func (s *Server) CreateTaskStep(
 
 	s.logger.InfoContext(ctx, "task step created", "task_step_id", id)
 
-	return connect.NewResponse(dcimv1.CreateTaskStepResponse_builder{
+	return dcimv1.CreateTaskStepResponse_builder{
 		TaskStepId: id.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/task_step_delete.go
+++ b/dcim-api/pkg/dcim/task_step_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteTaskStep(
 	ctx context.Context,
-	req *connect.Request[dcimv1.DeleteTaskStepRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	taskStepID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.DeleteTaskStepRequest,
+) (*emptypb.Empty, error) {
+	taskStepID := uuid.MustParse(req.GetId())
 
 	rowsAffected, err := s.queries.TaskStepDelete(ctx, db.TaskStepDeleteParams{ID: taskStepID})
 	if err != nil {
@@ -29,5 +29,5 @@ func (s *Server) DeleteTaskStep(
 
 	s.logger.InfoContext(ctx, "task step deleted", "task_step_id", taskStepID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/task_step_list.go
+++ b/dcim-api/pkg/dcim/task_step_list.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) ListTaskSteps(
 	ctx context.Context,
-	req *connect.Request[dcimv1.ListTaskStepsRequest],
-) (*connect.Response[dcimv1.ListTaskStepsResponse], error) {
-	taskID := uuid.MustParse(req.Msg.GetTaskId())
+	req *dcimv1.ListTaskStepsRequest,
+) (*dcimv1.ListTaskStepsResponse, error) {
+	taskID := uuid.MustParse(req.GetTaskId())
 
 	rows, err := s.queries.TaskStepList(ctx, db.TaskStepListParams{TaskID: taskID})
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *Server) ListTaskSteps(
 		steps = append(steps, taskStepFromListRow(&row))
 	}
 
-	return connect.NewResponse(dcimv1.ListTaskStepsResponse_builder{
+	return dcimv1.ListTaskStepsResponse_builder{
 		Steps: steps,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/task_step_update.go
+++ b/dcim-api/pkg/dcim/task_step_update.go
@@ -15,28 +15,28 @@ import (
 
 func (s *Server) UpdateTaskStep(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateTaskStepRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	taskStepID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateTaskStepRequest,
+) (*emptypb.Empty, error) {
+	taskStepID := uuid.MustParse(req.GetId())
 
 	params := db.TaskStepUpdateParams{
 		ID: taskStepID,
 	}
 
-	if req.Msg.HasTitle() {
-		params.Title = pgtype.Text{String: req.Msg.GetTitle(), Valid: true}
+	if req.HasTitle() {
+		params.Title = pgtype.Text{String: req.GetTitle(), Valid: true}
 	}
 
-	if req.Msg.HasDescription() {
-		params.Description = pgtype.Text{String: req.Msg.GetDescription(), Valid: true}
+	if req.HasDescription() {
+		params.Description = pgtype.Text{String: req.GetDescription(), Valid: true}
 	}
 
-	if req.Msg.HasOrdinal() {
-		params.Ordinal = pgtype.Int4{Int32: req.Msg.GetOrdinal(), Valid: true}
+	if req.HasOrdinal() {
+		params.Ordinal = pgtype.Int4{Int32: req.GetOrdinal(), Valid: true}
 	}
 
-	if req.Msg.HasCompleted() {
-		params.Completed = pgtype.Bool{Bool: req.Msg.GetCompleted(), Valid: true}
+	if req.HasCompleted() {
+		params.Completed = pgtype.Bool{Bool: req.GetCompleted(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.TaskStepUpdate(ctx, params)
@@ -50,5 +50,5 @@ func (s *Server) UpdateTaskStep(
 
 	s.logger.InfoContext(ctx, "task step updated", "task_step_id", taskStepID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/task_update.go
+++ b/dcim-api/pkg/dcim/task_update.go
@@ -19,28 +19,28 @@ import (
 
 func (s *Server) UpdateTask(
 	ctx context.Context,
-	req *connect.Request[dcimv1.UpdateTaskRequest],
-) (*connect.Response[emptypb.Empty], error) {
-	taskID := uuid.MustParse(req.Msg.GetId())
+	req *dcimv1.UpdateTaskRequest,
+) (*emptypb.Empty, error) {
+	taskID := uuid.MustParse(req.GetId())
 
 	params := db.TaskUpdateParams{
 		ID: taskID,
 	}
 
-	if req.Msg.HasTitle() {
-		params.Title = pgtype.Text{String: req.Msg.GetTitle(), Valid: true}
+	if req.HasTitle() {
+		params.Title = pgtype.Text{String: req.GetTitle(), Valid: true}
 	}
 
-	if req.Msg.HasStatus() {
-		params.Status = pgtype.Text{String: taskStatusFromProto(req.Msg.GetStatus()), Valid: true}
+	if req.HasStatus() {
+		params.Status = pgtype.Text{String: taskStatusFromProto(req.GetStatus()), Valid: true}
 	}
 
-	if req.Msg.HasPriority() {
-		params.Priority = pgtype.Text{String: taskPriorityFromProto(req.Msg.GetPriority()), Valid: true}
+	if req.HasPriority() {
+		params.Priority = pgtype.Text{String: taskPriorityFromProto(req.GetPriority()), Valid: true}
 	}
 
-	if req.Msg.HasCategory() {
-		params.Category = pgtype.Text{String: taskCategoryFromProto(req.Msg.GetCategory()), Valid: true}
+	if req.HasCategory() {
+		params.Category = pgtype.Text{String: taskCategoryFromProto(req.GetCategory()), Valid: true}
 	}
 
 	// For the nullable columns, an explicitly-set field clears the column when it
@@ -51,16 +51,16 @@ func (s *Server) UpdateTask(
 	// starts NULL, so an edit that empties it has to write NULL as well —
 	// otherwise the table ends up with two spellings of "no description", '' on
 	// rows that were edited and NULL on rows that never had one.
-	if req.Msg.HasDescription() {
-		if v := req.Msg.GetDescription(); v == "" {
+	if req.HasDescription() {
+		if v := req.GetDescription(); v == "" {
 			params.ClearDescription = true
 		} else {
 			params.Description = pgtype.Text{String: v, Valid: true}
 		}
 	}
 
-	if req.Msg.HasAssigneeId() {
-		if v := req.Msg.GetAssigneeId(); v == "" {
+	if req.HasAssigneeId() {
+		if v := req.GetAssigneeId(); v == "" {
 			params.ClearAssignee = true
 		} else {
 			assigneeID, err := uuid.Parse(v)
@@ -72,16 +72,16 @@ func (s *Server) UpdateTask(
 		}
 	}
 
-	if req.Msg.HasDueDate() {
-		if t := req.Msg.GetDueDate().AsTime(); t.Equal(time.Unix(0, 0).UTC()) {
+	if req.HasDueDate() {
+		if t := req.GetDueDate().AsTime(); t.Equal(time.Unix(0, 0).UTC()) {
 			params.ClearDueDate = true
 		} else {
 			params.DueDate = pgtype.Timestamptz{Time: t, Valid: true}
 		}
 	}
 
-	if req.Msg.HasLocation() {
-		if v := req.Msg.GetLocation(); v == "" {
+	if req.HasLocation() {
+		if v := req.GetLocation(); v == "" {
 			params.ClearLocation = true
 		} else {
 			params.Location = pgtype.Text{String: v, Valid: true}
@@ -103,5 +103,5 @@ func (s *Server) UpdateTask(
 
 	s.logger.InfoContext(ctx, "task updated", "task_id", taskID)
 
-	return connect.NewResponse(&emptypb.Empty{}), nil
+	return &emptypb.Empty{}, nil
 }

--- a/dcim-api/pkg/dcim/task_update_test.go
+++ b/dcim-api/pkg/dcim/task_update_test.go
@@ -44,12 +44,12 @@ func getTask(t *testing.T, env *testEnv, taskID string) *dcimv1.Task {
 
 	client := dcimv1connect.NewTaskServiceClient(env.client(), env.server.URL)
 
-	resp, err := client.GetTask(context.Background(), connect.NewRequest(
+	resp, err := client.GetTask(context.Background(),
 		(&dcimv1.GetTaskRequest_builder{Id: taskID}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
-	task := resp.Msg.GetTask()
+	task := resp.GetTask()
 	require.NotNil(t, task)
 
 	return task
@@ -73,7 +73,7 @@ func TestTaskService_UpdateTask_HappyFlow(t *testing.T) {
 	newLocation := "Room B"
 	newDueDate := dueDate.Add(48 * time.Hour)
 
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:          taskID,
 			Title:       &newTitle,
@@ -85,7 +85,7 @@ func TestTaskService_UpdateTask_HappyFlow(t *testing.T) {
 			DueDate:     timestamppb.New(newDueDate),
 			Location:    &newLocation,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	task := getTask(t, env, taskID)
@@ -114,12 +114,12 @@ func TestTaskService_UpdateTask_UnsetFieldsAreKept(t *testing.T) {
 
 	// Patch only the title; everything else must survive untouched.
 	newTitle := "Only The Title Changed"
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:    taskID,
 			Title: &newTitle,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	task := getTask(t, env, taskID)
@@ -149,7 +149,7 @@ func TestTaskService_UpdateTask_ClearsNullableFields(t *testing.T) {
 	emptyAssignee := ""
 	emptyLocation := ""
 	emptyDescription := ""
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:          taskID,
 			Description: &emptyDescription,
@@ -157,7 +157,7 @@ func TestTaskService_UpdateTask_ClearsNullableFields(t *testing.T) {
 			DueDate:     timestamppb.New(time.Unix(0, 0).UTC()),
 			Location:    &emptyLocation,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	task := getTask(t, env, taskID)
@@ -186,12 +186,12 @@ func TestTaskService_UpdateTask_ClearedDescriptionIsNull(t *testing.T) {
 	taskID := createTaskFixture(t, env, "Task Clearing Description", assigneeID)
 
 	emptyDescription := ""
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:          taskID,
 			Description: &emptyDescription,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	var description *string
@@ -215,13 +215,13 @@ func TestTaskService_UpdateTask_ClearIsIndependentPerField(t *testing.T) {
 	// Clear the assignee while overwriting the location in the same request.
 	emptyAssignee := ""
 	newLocation := "Room C"
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:         taskID,
 			AssigneeId: &emptyAssignee,
 			Location:   &newLocation,
 		}).Build(),
-	))
+	)
 	require.NoError(t, err)
 
 	task := getTask(t, env, taskID)
@@ -244,12 +244,12 @@ func TestTaskService_UpdateTask_UnknownAssignee(t *testing.T) {
 	assigneeID := createUser(t, env, "Real Assignee", "real@example.com", "")
 	taskID := createTaskFixture(t, env, "Task With Unknown Assignee", assigneeID)
 
-	_, err := client.UpdateTask(context.Background(), connect.NewRequest(
+	_, err := client.UpdateTask(context.Background(),
 		(&dcimv1.UpdateTaskRequest_builder{
 			Id:         taskID,
 			AssigneeId: ptr(validUUID),
 		}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }
 
@@ -259,7 +259,7 @@ func TestTaskService_CreateTask_UnknownAssignee(t *testing.T) {
 	env := newTestAPI(t)
 	client := dcimv1connect.NewTaskServiceClient(env.client(), env.server.URL)
 
-	_, err := client.CreateTask(context.Background(), connect.NewRequest(
+	_, err := client.CreateTask(context.Background(),
 		(&dcimv1.CreateTaskRequest_builder{
 			Title:      "Task For A Ghost",
 			Status:     dcimv1.TaskStatus_TASK_STATUS_READY,
@@ -267,7 +267,7 @@ func TestTaskService_CreateTask_UnknownAssignee(t *testing.T) {
 			Category:   dcimv1.TaskCategory_TASK_CATEGORY_HARDWARE,
 			AssigneeId: ptr(validUUID),
 		}).Build(),
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }
 
@@ -309,7 +309,7 @@ func TestTaskService_UpdateTask_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.UpdateTask(context.Background(), connect.NewRequest(tc.req))
+			_, err := client.UpdateTask(context.Background(), tc.req)
 			requireCode(t, err, tc.want)
 		})
 	}

--- a/dcim-api/pkg/dcim/user_get_current.go
+++ b/dcim-api/pkg/dcim/user_get_current.go
@@ -76,14 +76,14 @@ func (s *Server) currentUser(ctx context.Context) (db.UserGetByExternalRefRow, e
 
 func (s *Server) GetCurrentUser(
 	ctx context.Context,
-	_ *connect.Request[dcimv1.GetCurrentUserRequest],
-) (*connect.Response[dcimv1.GetCurrentUserResponse], error) {
+	_ *dcimv1.GetCurrentUserRequest,
+) (*dcimv1.GetCurrentUserResponse, error) {
 	row, err := s.currentUser(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return connect.NewResponse(dcimv1.GetCurrentUserResponse_builder{
+	return dcimv1.GetCurrentUserResponse_builder{
 		User: userToProtoWithEmail(row.ID, row.Name, row.Email),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/user_get_current_test.go
+++ b/dcim-api/pkg/dcim/user_get_current_test.go
@@ -26,12 +26,12 @@ func TestUserService_GetCurrentUser_Found(t *testing.T) {
 	createUser(t, env, "Someone Else", "someone@example.com", "00000000-0000-0000-0000-0000000000ff")
 	userID := createUser(t, env, "Current User", "current@example.com", env.subject)
 
-	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(
+	resp, err := client.GetCurrentUser(context.Background(),
 		&dcimv1.GetCurrentUserRequest{},
-	))
+	)
 	require.NoError(t, err)
 
-	user := resp.Msg.GetUser()
+	user := resp.GetUser()
 	require.NotNil(t, user)
 
 	assert.Equal(t, userID, user.GetId())
@@ -53,12 +53,12 @@ func TestUserService_GetCurrentUser_NullEmail(t *testing.T) {
 		`UPDATE dcim.users SET email = NULL WHERE id = $1`, userID)
 	require.NoError(t, err)
 
-	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(
+	resp, err := client.GetCurrentUser(context.Background(),
 		&dcimv1.GetCurrentUserRequest{},
-	))
+	)
 	require.NoError(t, err)
 
-	user := resp.Msg.GetUser()
+	user := resp.GetUser()
 	require.NotNil(t, user)
 
 	assert.Equal(t, userID, user.GetId())
@@ -73,9 +73,9 @@ func TestUserService_GetCurrentUser_NotFound(t *testing.T) {
 	env := newTestAPI(t)
 	client := dcimv1connect.NewUserServiceClient(env.client(), env.server.URL)
 
-	_, err := client.GetCurrentUser(context.Background(), connect.NewRequest(
+	_, err := client.GetCurrentUser(context.Background(),
 		&dcimv1.GetCurrentUserRequest{},
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }
 
@@ -93,8 +93,8 @@ func TestUserService_GetCurrentUser_SoftDeleted(t *testing.T) {
 		`UPDATE dcim.users SET deleted = now() WHERE id = $1`, userID)
 	require.NoError(t, err)
 
-	_, err = client.GetCurrentUser(context.Background(), connect.NewRequest(
+	_, err = client.GetCurrentUser(context.Background(),
 		&dcimv1.GetCurrentUserRequest{},
-	))
+	)
 	requireCode(t, err, connect.CodeNotFound)
 }

--- a/dcim-api/pkg/dcim/user_list.go
+++ b/dcim-api/pkg/dcim/user_list.go
@@ -11,8 +11,8 @@ import (
 
 func (s *Server) ListUsers(
 	ctx context.Context,
-	_ *connect.Request[dcimv1.ListUsersRequest],
-) (*connect.Response[dcimv1.ListUsersResponse], error) {
+	_ *dcimv1.ListUsersRequest,
+) (*dcimv1.ListUsersResponse, error) {
 	rows, err := s.queries.UserList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list users: %w", err))
@@ -23,7 +23,7 @@ func (s *Server) ListUsers(
 		users = append(users, userToProto(row.ID, row.Name))
 	}
 
-	return connect.NewResponse(dcimv1.ListUsersResponse_builder{
+	return dcimv1.ListUsersResponse_builder{
 		Users: users,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/dcim-api/pkg/dcim/user_list_test.go
+++ b/dcim-api/pkg/dcim/user_list_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,11 +22,11 @@ func TestUserService_ListUsers_Populated(t *testing.T) {
 		createUser(t, env, name, name+"@example.com", "")
 	}
 
-	resp, err := client.ListUsers(context.Background(), connect.NewRequest(&dcimv1.ListUsersRequest{}))
+	resp, err := client.ListUsers(context.Background(), &dcimv1.ListUsersRequest{})
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(resp.Msg.GetUsers()))
-	for _, u := range resp.Msg.GetUsers() {
+	got := make([]string, 0, len(resp.GetUsers()))
+	for _, u := range resp.GetUsers() {
 		got = append(got, u.GetName())
 	}
 	// ListUsers is unfiltered, so the response also includes seeded users (the
@@ -47,11 +46,11 @@ func TestUserService_ListUsers_OmitsEmail(t *testing.T) {
 
 	userID := createUser(t, env, "Emailed User", "listed@example.com", "")
 
-	resp, err := client.ListUsers(context.Background(), connect.NewRequest(&dcimv1.ListUsersRequest{}))
+	resp, err := client.ListUsers(context.Background(), &dcimv1.ListUsersRequest{})
 	require.NoError(t, err)
 
 	var found *dcimv1.User
-	for _, u := range resp.Msg.GetUsers() {
+	for _, u := range resp.GetUsers() {
 		if u.GetId() == userID {
 			found = u
 			break
@@ -62,7 +61,7 @@ func TestUserService_ListUsers_OmitsEmail(t *testing.T) {
 	assert.Equal(t, "Emailed User", found.GetName())
 	assert.False(t, found.HasEmail(), "the roster listing must not expose email addresses")
 
-	for _, u := range resp.Msg.GetUsers() {
+	for _, u := range resp.GetUsers() {
 		assert.False(t, u.HasEmail(), "no roster entry may carry an email")
 	}
 }
@@ -80,10 +79,10 @@ func TestUserService_ListUsers_ExcludesSoftDeleted(t *testing.T) {
 		`UPDATE dcim.users SET deleted = now() WHERE id = $1`, userID)
 	require.NoError(t, err)
 
-	resp, err := client.ListUsers(context.Background(), connect.NewRequest(&dcimv1.ListUsersRequest{}))
+	resp, err := client.ListUsers(context.Background(), &dcimv1.ListUsersRequest{})
 	require.NoError(t, err)
 
-	for _, u := range resp.Msg.GetUsers() {
+	for _, u := range resp.GetUsers() {
 		assert.NotEqual(t, userID, u.GetId())
 	}
 }

--- a/dcim-api/pkg/proto/buf.gen.yaml
+++ b/dcim-api/pkg/proto/buf.gen.yaml
@@ -5,4 +5,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/asset.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/asset.connect.go
@@ -60,14 +60,14 @@ const (
 
 // AssetServiceClient is a client for the dcim.v1.AssetService service.
 type AssetServiceClient interface {
-	ListAssets(context.Context, *connect.Request[v1.ListAssetsRequest]) (*connect.Response[v1.ListAssetsResponse], error)
-	GetAsset(context.Context, *connect.Request[v1.GetAssetRequest]) (*connect.Response[v1.GetAssetResponse], error)
-	CreateAsset(context.Context, *connect.Request[v1.CreateAssetRequest]) (*connect.Response[v1.CreateAssetResponse], error)
-	UpdateAsset(context.Context, *connect.Request[v1.UpdateAssetRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteAsset(context.Context, *connect.Request[v1.DeleteAssetRequest]) (*connect.Response[emptypb.Empty], error)
-	GetAssetEvents(context.Context, *connect.Request[v1.GetAssetEventsRequest]) (*connect.Response[v1.GetAssetEventsResponse], error)
-	GetAssetLocation(context.Context, *connect.Request[v1.GetAssetLocationRequest]) (*connect.Response[v1.GetAssetLocationResponse], error)
-	GetAssetStats(context.Context, *connect.Request[v1.GetAssetStatsRequest]) (*connect.Response[v1.GetAssetStatsResponse], error)
+	ListAssets(context.Context, *v1.ListAssetsRequest) (*v1.ListAssetsResponse, error)
+	GetAsset(context.Context, *v1.GetAssetRequest) (*v1.GetAssetResponse, error)
+	CreateAsset(context.Context, *v1.CreateAssetRequest) (*v1.CreateAssetResponse, error)
+	UpdateAsset(context.Context, *v1.UpdateAssetRequest) (*emptypb.Empty, error)
+	DeleteAsset(context.Context, *v1.DeleteAssetRequest) (*emptypb.Empty, error)
+	GetAssetEvents(context.Context, *v1.GetAssetEventsRequest) (*v1.GetAssetEventsResponse, error)
+	GetAssetLocation(context.Context, *v1.GetAssetLocationRequest) (*v1.GetAssetLocationResponse, error)
+	GetAssetStats(context.Context, *v1.GetAssetStatsRequest) (*v1.GetAssetStatsResponse, error)
 }
 
 // NewAssetServiceClient constructs a client for the dcim.v1.AssetService service. By default, it
@@ -145,55 +145,87 @@ type assetServiceClient struct {
 }
 
 // ListAssets calls dcim.v1.AssetService.ListAssets.
-func (c *assetServiceClient) ListAssets(ctx context.Context, req *connect.Request[v1.ListAssetsRequest]) (*connect.Response[v1.ListAssetsResponse], error) {
-	return c.listAssets.CallUnary(ctx, req)
+func (c *assetServiceClient) ListAssets(ctx context.Context, req *v1.ListAssetsRequest) (*v1.ListAssetsResponse, error) {
+	response, err := c.listAssets.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetAsset calls dcim.v1.AssetService.GetAsset.
-func (c *assetServiceClient) GetAsset(ctx context.Context, req *connect.Request[v1.GetAssetRequest]) (*connect.Response[v1.GetAssetResponse], error) {
-	return c.getAsset.CallUnary(ctx, req)
+func (c *assetServiceClient) GetAsset(ctx context.Context, req *v1.GetAssetRequest) (*v1.GetAssetResponse, error) {
+	response, err := c.getAsset.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateAsset calls dcim.v1.AssetService.CreateAsset.
-func (c *assetServiceClient) CreateAsset(ctx context.Context, req *connect.Request[v1.CreateAssetRequest]) (*connect.Response[v1.CreateAssetResponse], error) {
-	return c.createAsset.CallUnary(ctx, req)
+func (c *assetServiceClient) CreateAsset(ctx context.Context, req *v1.CreateAssetRequest) (*v1.CreateAssetResponse, error) {
+	response, err := c.createAsset.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateAsset calls dcim.v1.AssetService.UpdateAsset.
-func (c *assetServiceClient) UpdateAsset(ctx context.Context, req *connect.Request[v1.UpdateAssetRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateAsset.CallUnary(ctx, req)
+func (c *assetServiceClient) UpdateAsset(ctx context.Context, req *v1.UpdateAssetRequest) (*emptypb.Empty, error) {
+	response, err := c.updateAsset.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteAsset calls dcim.v1.AssetService.DeleteAsset.
-func (c *assetServiceClient) DeleteAsset(ctx context.Context, req *connect.Request[v1.DeleteAssetRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteAsset.CallUnary(ctx, req)
+func (c *assetServiceClient) DeleteAsset(ctx context.Context, req *v1.DeleteAssetRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteAsset.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetAssetEvents calls dcim.v1.AssetService.GetAssetEvents.
-func (c *assetServiceClient) GetAssetEvents(ctx context.Context, req *connect.Request[v1.GetAssetEventsRequest]) (*connect.Response[v1.GetAssetEventsResponse], error) {
-	return c.getAssetEvents.CallUnary(ctx, req)
+func (c *assetServiceClient) GetAssetEvents(ctx context.Context, req *v1.GetAssetEventsRequest) (*v1.GetAssetEventsResponse, error) {
+	response, err := c.getAssetEvents.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetAssetLocation calls dcim.v1.AssetService.GetAssetLocation.
-func (c *assetServiceClient) GetAssetLocation(ctx context.Context, req *connect.Request[v1.GetAssetLocationRequest]) (*connect.Response[v1.GetAssetLocationResponse], error) {
-	return c.getAssetLocation.CallUnary(ctx, req)
+func (c *assetServiceClient) GetAssetLocation(ctx context.Context, req *v1.GetAssetLocationRequest) (*v1.GetAssetLocationResponse, error) {
+	response, err := c.getAssetLocation.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetAssetStats calls dcim.v1.AssetService.GetAssetStats.
-func (c *assetServiceClient) GetAssetStats(ctx context.Context, req *connect.Request[v1.GetAssetStatsRequest]) (*connect.Response[v1.GetAssetStatsResponse], error) {
-	return c.getAssetStats.CallUnary(ctx, req)
+func (c *assetServiceClient) GetAssetStats(ctx context.Context, req *v1.GetAssetStatsRequest) (*v1.GetAssetStatsResponse, error) {
+	response, err := c.getAssetStats.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // AssetServiceHandler is an implementation of the dcim.v1.AssetService service.
 type AssetServiceHandler interface {
-	ListAssets(context.Context, *connect.Request[v1.ListAssetsRequest]) (*connect.Response[v1.ListAssetsResponse], error)
-	GetAsset(context.Context, *connect.Request[v1.GetAssetRequest]) (*connect.Response[v1.GetAssetResponse], error)
-	CreateAsset(context.Context, *connect.Request[v1.CreateAssetRequest]) (*connect.Response[v1.CreateAssetResponse], error)
-	UpdateAsset(context.Context, *connect.Request[v1.UpdateAssetRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteAsset(context.Context, *connect.Request[v1.DeleteAssetRequest]) (*connect.Response[emptypb.Empty], error)
-	GetAssetEvents(context.Context, *connect.Request[v1.GetAssetEventsRequest]) (*connect.Response[v1.GetAssetEventsResponse], error)
-	GetAssetLocation(context.Context, *connect.Request[v1.GetAssetLocationRequest]) (*connect.Response[v1.GetAssetLocationResponse], error)
-	GetAssetStats(context.Context, *connect.Request[v1.GetAssetStatsRequest]) (*connect.Response[v1.GetAssetStatsResponse], error)
+	ListAssets(context.Context, *v1.ListAssetsRequest) (*v1.ListAssetsResponse, error)
+	GetAsset(context.Context, *v1.GetAssetRequest) (*v1.GetAssetResponse, error)
+	CreateAsset(context.Context, *v1.CreateAssetRequest) (*v1.CreateAssetResponse, error)
+	UpdateAsset(context.Context, *v1.UpdateAssetRequest) (*emptypb.Empty, error)
+	DeleteAsset(context.Context, *v1.DeleteAssetRequest) (*emptypb.Empty, error)
+	GetAssetEvents(context.Context, *v1.GetAssetEventsRequest) (*v1.GetAssetEventsResponse, error)
+	GetAssetLocation(context.Context, *v1.GetAssetLocationRequest) (*v1.GetAssetLocationResponse, error)
+	GetAssetStats(context.Context, *v1.GetAssetStatsRequest) (*v1.GetAssetStatsResponse, error)
 }
 
 // NewAssetServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -203,49 +235,49 @@ type AssetServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewAssetServiceHandler(svc AssetServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	assetServiceMethods := v1.File_v1_asset_proto.Services().ByName("AssetService").Methods()
-	assetServiceListAssetsHandler := connect.NewUnaryHandler(
+	assetServiceListAssetsHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceListAssetsProcedure,
 		svc.ListAssets,
 		connect.WithSchema(assetServiceMethods.ByName("ListAssets")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceGetAssetHandler := connect.NewUnaryHandler(
+	assetServiceGetAssetHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceGetAssetProcedure,
 		svc.GetAsset,
 		connect.WithSchema(assetServiceMethods.ByName("GetAsset")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceCreateAssetHandler := connect.NewUnaryHandler(
+	assetServiceCreateAssetHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceCreateAssetProcedure,
 		svc.CreateAsset,
 		connect.WithSchema(assetServiceMethods.ByName("CreateAsset")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceUpdateAssetHandler := connect.NewUnaryHandler(
+	assetServiceUpdateAssetHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceUpdateAssetProcedure,
 		svc.UpdateAsset,
 		connect.WithSchema(assetServiceMethods.ByName("UpdateAsset")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceDeleteAssetHandler := connect.NewUnaryHandler(
+	assetServiceDeleteAssetHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceDeleteAssetProcedure,
 		svc.DeleteAsset,
 		connect.WithSchema(assetServiceMethods.ByName("DeleteAsset")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceGetAssetEventsHandler := connect.NewUnaryHandler(
+	assetServiceGetAssetEventsHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceGetAssetEventsProcedure,
 		svc.GetAssetEvents,
 		connect.WithSchema(assetServiceMethods.ByName("GetAssetEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceGetAssetLocationHandler := connect.NewUnaryHandler(
+	assetServiceGetAssetLocationHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceGetAssetLocationProcedure,
 		svc.GetAssetLocation,
 		connect.WithSchema(assetServiceMethods.ByName("GetAssetLocation")),
 		connect.WithHandlerOptions(opts...),
 	)
-	assetServiceGetAssetStatsHandler := connect.NewUnaryHandler(
+	assetServiceGetAssetStatsHandler := connect.NewUnaryHandlerSimple(
 		AssetServiceGetAssetStatsProcedure,
 		svc.GetAssetStats,
 		connect.WithSchema(assetServiceMethods.ByName("GetAssetStats")),
@@ -278,34 +310,34 @@ func NewAssetServiceHandler(svc AssetServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedAssetServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedAssetServiceHandler struct{}
 
-func (UnimplementedAssetServiceHandler) ListAssets(context.Context, *connect.Request[v1.ListAssetsRequest]) (*connect.Response[v1.ListAssetsResponse], error) {
+func (UnimplementedAssetServiceHandler) ListAssets(context.Context, *v1.ListAssetsRequest) (*v1.ListAssetsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.ListAssets is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) GetAsset(context.Context, *connect.Request[v1.GetAssetRequest]) (*connect.Response[v1.GetAssetResponse], error) {
+func (UnimplementedAssetServiceHandler) GetAsset(context.Context, *v1.GetAssetRequest) (*v1.GetAssetResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.GetAsset is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) CreateAsset(context.Context, *connect.Request[v1.CreateAssetRequest]) (*connect.Response[v1.CreateAssetResponse], error) {
+func (UnimplementedAssetServiceHandler) CreateAsset(context.Context, *v1.CreateAssetRequest) (*v1.CreateAssetResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.CreateAsset is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) UpdateAsset(context.Context, *connect.Request[v1.UpdateAssetRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedAssetServiceHandler) UpdateAsset(context.Context, *v1.UpdateAssetRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.UpdateAsset is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) DeleteAsset(context.Context, *connect.Request[v1.DeleteAssetRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedAssetServiceHandler) DeleteAsset(context.Context, *v1.DeleteAssetRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.DeleteAsset is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) GetAssetEvents(context.Context, *connect.Request[v1.GetAssetEventsRequest]) (*connect.Response[v1.GetAssetEventsResponse], error) {
+func (UnimplementedAssetServiceHandler) GetAssetEvents(context.Context, *v1.GetAssetEventsRequest) (*v1.GetAssetEventsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.GetAssetEvents is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) GetAssetLocation(context.Context, *connect.Request[v1.GetAssetLocationRequest]) (*connect.Response[v1.GetAssetLocationResponse], error) {
+func (UnimplementedAssetServiceHandler) GetAssetLocation(context.Context, *v1.GetAssetLocationRequest) (*v1.GetAssetLocationResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.GetAssetLocation is not implemented"))
 }
 
-func (UnimplementedAssetServiceHandler) GetAssetStats(context.Context, *connect.Request[v1.GetAssetStatsRequest]) (*connect.Response[v1.GetAssetStatsResponse], error) {
+func (UnimplementedAssetServiceHandler) GetAssetStats(context.Context, *v1.GetAssetStatsRequest) (*v1.GetAssetStatsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.AssetService.GetAssetStats is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/catalog.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/catalog.connect.go
@@ -81,22 +81,22 @@ const (
 // CatalogServiceClient is a client for the dcim.v1.CatalogService service.
 type CatalogServiceClient interface {
 	// Device catalog entries
-	ListCatalog(context.Context, *connect.Request[v1.ListCatalogRequest]) (*connect.Response[v1.ListCatalogResponse], error)
-	GetCatalogEntry(context.Context, *connect.Request[v1.GetCatalogEntryRequest]) (*connect.Response[v1.GetCatalogEntryResponse], error)
-	CreateCatalogEntry(context.Context, *connect.Request[v1.CreateCatalogEntryRequest]) (*connect.Response[v1.CreateCatalogEntryResponse], error)
-	UpdateCatalogEntry(context.Context, *connect.Request[v1.UpdateCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteCatalogEntry(context.Context, *connect.Request[v1.DeleteCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error)
-	ListAssetsByCatalogEntry(context.Context, *connect.Request[v1.ListAssetsByCatalogEntryRequest]) (*connect.Response[v1.ListAssetsByCatalogEntryResponse], error)
+	ListCatalog(context.Context, *v1.ListCatalogRequest) (*v1.ListCatalogResponse, error)
+	GetCatalogEntry(context.Context, *v1.GetCatalogEntryRequest) (*v1.GetCatalogEntryResponse, error)
+	CreateCatalogEntry(context.Context, *v1.CreateCatalogEntryRequest) (*v1.CreateCatalogEntryResponse, error)
+	UpdateCatalogEntry(context.Context, *v1.UpdateCatalogEntryRequest) (*emptypb.Empty, error)
+	DeleteCatalogEntry(context.Context, *v1.DeleteCatalogEntryRequest) (*emptypb.Empty, error)
+	ListAssetsByCatalogEntry(context.Context, *v1.ListAssetsByCatalogEntryRequest) (*v1.ListAssetsByCatalogEntryResponse, error)
 	// Port definitions
-	ListPortDefinitions(context.Context, *connect.Request[v1.ListPortDefinitionsRequest]) (*connect.Response[v1.ListPortDefinitionsResponse], error)
-	GetPortDefinition(context.Context, *connect.Request[v1.GetPortDefinitionRequest]) (*connect.Response[v1.GetPortDefinitionResponse], error)
-	CreatePortDefinition(context.Context, *connect.Request[v1.CreatePortDefinitionRequest]) (*connect.Response[v1.CreatePortDefinitionResponse], error)
-	UpdatePortDefinition(context.Context, *connect.Request[v1.UpdatePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePortDefinition(context.Context, *connect.Request[v1.DeletePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error)
+	ListPortDefinitions(context.Context, *v1.ListPortDefinitionsRequest) (*v1.ListPortDefinitionsResponse, error)
+	GetPortDefinition(context.Context, *v1.GetPortDefinitionRequest) (*v1.GetPortDefinitionResponse, error)
+	CreatePortDefinition(context.Context, *v1.CreatePortDefinitionRequest) (*v1.CreatePortDefinitionResponse, error)
+	UpdatePortDefinition(context.Context, *v1.UpdatePortDefinitionRequest) (*emptypb.Empty, error)
+	DeletePortDefinition(context.Context, *v1.DeletePortDefinitionRequest) (*emptypb.Empty, error)
 	// Port compatibilities
-	ListPortCompatibilities(context.Context, *connect.Request[v1.ListPortCompatibilitiesRequest]) (*connect.Response[v1.ListPortCompatibilitiesResponse], error)
-	CreatePortCompatibility(context.Context, *connect.Request[v1.CreatePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePortCompatibility(context.Context, *connect.Request[v1.DeletePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error)
+	ListPortCompatibilities(context.Context, *v1.ListPortCompatibilitiesRequest) (*v1.ListPortCompatibilitiesResponse, error)
+	CreatePortCompatibility(context.Context, *v1.CreatePortCompatibilityRequest) (*emptypb.Empty, error)
+	DeletePortCompatibility(context.Context, *v1.DeletePortCompatibilityRequest) (*emptypb.Empty, error)
 }
 
 // NewCatalogServiceClient constructs a client for the dcim.v1.CatalogService service. By default,
@@ -216,94 +216,150 @@ type catalogServiceClient struct {
 }
 
 // ListCatalog calls dcim.v1.CatalogService.ListCatalog.
-func (c *catalogServiceClient) ListCatalog(ctx context.Context, req *connect.Request[v1.ListCatalogRequest]) (*connect.Response[v1.ListCatalogResponse], error) {
-	return c.listCatalog.CallUnary(ctx, req)
+func (c *catalogServiceClient) ListCatalog(ctx context.Context, req *v1.ListCatalogRequest) (*v1.ListCatalogResponse, error) {
+	response, err := c.listCatalog.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetCatalogEntry calls dcim.v1.CatalogService.GetCatalogEntry.
-func (c *catalogServiceClient) GetCatalogEntry(ctx context.Context, req *connect.Request[v1.GetCatalogEntryRequest]) (*connect.Response[v1.GetCatalogEntryResponse], error) {
-	return c.getCatalogEntry.CallUnary(ctx, req)
+func (c *catalogServiceClient) GetCatalogEntry(ctx context.Context, req *v1.GetCatalogEntryRequest) (*v1.GetCatalogEntryResponse, error) {
+	response, err := c.getCatalogEntry.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateCatalogEntry calls dcim.v1.CatalogService.CreateCatalogEntry.
-func (c *catalogServiceClient) CreateCatalogEntry(ctx context.Context, req *connect.Request[v1.CreateCatalogEntryRequest]) (*connect.Response[v1.CreateCatalogEntryResponse], error) {
-	return c.createCatalogEntry.CallUnary(ctx, req)
+func (c *catalogServiceClient) CreateCatalogEntry(ctx context.Context, req *v1.CreateCatalogEntryRequest) (*v1.CreateCatalogEntryResponse, error) {
+	response, err := c.createCatalogEntry.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateCatalogEntry calls dcim.v1.CatalogService.UpdateCatalogEntry.
-func (c *catalogServiceClient) UpdateCatalogEntry(ctx context.Context, req *connect.Request[v1.UpdateCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateCatalogEntry.CallUnary(ctx, req)
+func (c *catalogServiceClient) UpdateCatalogEntry(ctx context.Context, req *v1.UpdateCatalogEntryRequest) (*emptypb.Empty, error) {
+	response, err := c.updateCatalogEntry.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteCatalogEntry calls dcim.v1.CatalogService.DeleteCatalogEntry.
-func (c *catalogServiceClient) DeleteCatalogEntry(ctx context.Context, req *connect.Request[v1.DeleteCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteCatalogEntry.CallUnary(ctx, req)
+func (c *catalogServiceClient) DeleteCatalogEntry(ctx context.Context, req *v1.DeleteCatalogEntryRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteCatalogEntry.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListAssetsByCatalogEntry calls dcim.v1.CatalogService.ListAssetsByCatalogEntry.
-func (c *catalogServiceClient) ListAssetsByCatalogEntry(ctx context.Context, req *connect.Request[v1.ListAssetsByCatalogEntryRequest]) (*connect.Response[v1.ListAssetsByCatalogEntryResponse], error) {
-	return c.listAssetsByCatalogEntry.CallUnary(ctx, req)
+func (c *catalogServiceClient) ListAssetsByCatalogEntry(ctx context.Context, req *v1.ListAssetsByCatalogEntryRequest) (*v1.ListAssetsByCatalogEntryResponse, error) {
+	response, err := c.listAssetsByCatalogEntry.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListPortDefinitions calls dcim.v1.CatalogService.ListPortDefinitions.
-func (c *catalogServiceClient) ListPortDefinitions(ctx context.Context, req *connect.Request[v1.ListPortDefinitionsRequest]) (*connect.Response[v1.ListPortDefinitionsResponse], error) {
-	return c.listPortDefinitions.CallUnary(ctx, req)
+func (c *catalogServiceClient) ListPortDefinitions(ctx context.Context, req *v1.ListPortDefinitionsRequest) (*v1.ListPortDefinitionsResponse, error) {
+	response, err := c.listPortDefinitions.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPortDefinition calls dcim.v1.CatalogService.GetPortDefinition.
-func (c *catalogServiceClient) GetPortDefinition(ctx context.Context, req *connect.Request[v1.GetPortDefinitionRequest]) (*connect.Response[v1.GetPortDefinitionResponse], error) {
-	return c.getPortDefinition.CallUnary(ctx, req)
+func (c *catalogServiceClient) GetPortDefinition(ctx context.Context, req *v1.GetPortDefinitionRequest) (*v1.GetPortDefinitionResponse, error) {
+	response, err := c.getPortDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreatePortDefinition calls dcim.v1.CatalogService.CreatePortDefinition.
-func (c *catalogServiceClient) CreatePortDefinition(ctx context.Context, req *connect.Request[v1.CreatePortDefinitionRequest]) (*connect.Response[v1.CreatePortDefinitionResponse], error) {
-	return c.createPortDefinition.CallUnary(ctx, req)
+func (c *catalogServiceClient) CreatePortDefinition(ctx context.Context, req *v1.CreatePortDefinitionRequest) (*v1.CreatePortDefinitionResponse, error) {
+	response, err := c.createPortDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdatePortDefinition calls dcim.v1.CatalogService.UpdatePortDefinition.
-func (c *catalogServiceClient) UpdatePortDefinition(ctx context.Context, req *connect.Request[v1.UpdatePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updatePortDefinition.CallUnary(ctx, req)
+func (c *catalogServiceClient) UpdatePortDefinition(ctx context.Context, req *v1.UpdatePortDefinitionRequest) (*emptypb.Empty, error) {
+	response, err := c.updatePortDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeletePortDefinition calls dcim.v1.CatalogService.DeletePortDefinition.
-func (c *catalogServiceClient) DeletePortDefinition(ctx context.Context, req *connect.Request[v1.DeletePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deletePortDefinition.CallUnary(ctx, req)
+func (c *catalogServiceClient) DeletePortDefinition(ctx context.Context, req *v1.DeletePortDefinitionRequest) (*emptypb.Empty, error) {
+	response, err := c.deletePortDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListPortCompatibilities calls dcim.v1.CatalogService.ListPortCompatibilities.
-func (c *catalogServiceClient) ListPortCompatibilities(ctx context.Context, req *connect.Request[v1.ListPortCompatibilitiesRequest]) (*connect.Response[v1.ListPortCompatibilitiesResponse], error) {
-	return c.listPortCompatibilities.CallUnary(ctx, req)
+func (c *catalogServiceClient) ListPortCompatibilities(ctx context.Context, req *v1.ListPortCompatibilitiesRequest) (*v1.ListPortCompatibilitiesResponse, error) {
+	response, err := c.listPortCompatibilities.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreatePortCompatibility calls dcim.v1.CatalogService.CreatePortCompatibility.
-func (c *catalogServiceClient) CreatePortCompatibility(ctx context.Context, req *connect.Request[v1.CreatePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.createPortCompatibility.CallUnary(ctx, req)
+func (c *catalogServiceClient) CreatePortCompatibility(ctx context.Context, req *v1.CreatePortCompatibilityRequest) (*emptypb.Empty, error) {
+	response, err := c.createPortCompatibility.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeletePortCompatibility calls dcim.v1.CatalogService.DeletePortCompatibility.
-func (c *catalogServiceClient) DeletePortCompatibility(ctx context.Context, req *connect.Request[v1.DeletePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deletePortCompatibility.CallUnary(ctx, req)
+func (c *catalogServiceClient) DeletePortCompatibility(ctx context.Context, req *v1.DeletePortCompatibilityRequest) (*emptypb.Empty, error) {
+	response, err := c.deletePortCompatibility.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CatalogServiceHandler is an implementation of the dcim.v1.CatalogService service.
 type CatalogServiceHandler interface {
 	// Device catalog entries
-	ListCatalog(context.Context, *connect.Request[v1.ListCatalogRequest]) (*connect.Response[v1.ListCatalogResponse], error)
-	GetCatalogEntry(context.Context, *connect.Request[v1.GetCatalogEntryRequest]) (*connect.Response[v1.GetCatalogEntryResponse], error)
-	CreateCatalogEntry(context.Context, *connect.Request[v1.CreateCatalogEntryRequest]) (*connect.Response[v1.CreateCatalogEntryResponse], error)
-	UpdateCatalogEntry(context.Context, *connect.Request[v1.UpdateCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteCatalogEntry(context.Context, *connect.Request[v1.DeleteCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error)
-	ListAssetsByCatalogEntry(context.Context, *connect.Request[v1.ListAssetsByCatalogEntryRequest]) (*connect.Response[v1.ListAssetsByCatalogEntryResponse], error)
+	ListCatalog(context.Context, *v1.ListCatalogRequest) (*v1.ListCatalogResponse, error)
+	GetCatalogEntry(context.Context, *v1.GetCatalogEntryRequest) (*v1.GetCatalogEntryResponse, error)
+	CreateCatalogEntry(context.Context, *v1.CreateCatalogEntryRequest) (*v1.CreateCatalogEntryResponse, error)
+	UpdateCatalogEntry(context.Context, *v1.UpdateCatalogEntryRequest) (*emptypb.Empty, error)
+	DeleteCatalogEntry(context.Context, *v1.DeleteCatalogEntryRequest) (*emptypb.Empty, error)
+	ListAssetsByCatalogEntry(context.Context, *v1.ListAssetsByCatalogEntryRequest) (*v1.ListAssetsByCatalogEntryResponse, error)
 	// Port definitions
-	ListPortDefinitions(context.Context, *connect.Request[v1.ListPortDefinitionsRequest]) (*connect.Response[v1.ListPortDefinitionsResponse], error)
-	GetPortDefinition(context.Context, *connect.Request[v1.GetPortDefinitionRequest]) (*connect.Response[v1.GetPortDefinitionResponse], error)
-	CreatePortDefinition(context.Context, *connect.Request[v1.CreatePortDefinitionRequest]) (*connect.Response[v1.CreatePortDefinitionResponse], error)
-	UpdatePortDefinition(context.Context, *connect.Request[v1.UpdatePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePortDefinition(context.Context, *connect.Request[v1.DeletePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error)
+	ListPortDefinitions(context.Context, *v1.ListPortDefinitionsRequest) (*v1.ListPortDefinitionsResponse, error)
+	GetPortDefinition(context.Context, *v1.GetPortDefinitionRequest) (*v1.GetPortDefinitionResponse, error)
+	CreatePortDefinition(context.Context, *v1.CreatePortDefinitionRequest) (*v1.CreatePortDefinitionResponse, error)
+	UpdatePortDefinition(context.Context, *v1.UpdatePortDefinitionRequest) (*emptypb.Empty, error)
+	DeletePortDefinition(context.Context, *v1.DeletePortDefinitionRequest) (*emptypb.Empty, error)
 	// Port compatibilities
-	ListPortCompatibilities(context.Context, *connect.Request[v1.ListPortCompatibilitiesRequest]) (*connect.Response[v1.ListPortCompatibilitiesResponse], error)
-	CreatePortCompatibility(context.Context, *connect.Request[v1.CreatePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePortCompatibility(context.Context, *connect.Request[v1.DeletePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error)
+	ListPortCompatibilities(context.Context, *v1.ListPortCompatibilitiesRequest) (*v1.ListPortCompatibilitiesResponse, error)
+	CreatePortCompatibility(context.Context, *v1.CreatePortCompatibilityRequest) (*emptypb.Empty, error)
+	DeletePortCompatibility(context.Context, *v1.DeletePortCompatibilityRequest) (*emptypb.Empty, error)
 }
 
 // NewCatalogServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -313,85 +369,85 @@ type CatalogServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewCatalogServiceHandler(svc CatalogServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	catalogServiceMethods := v1.File_v1_catalog_proto.Services().ByName("CatalogService").Methods()
-	catalogServiceListCatalogHandler := connect.NewUnaryHandler(
+	catalogServiceListCatalogHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceListCatalogProcedure,
 		svc.ListCatalog,
 		connect.WithSchema(catalogServiceMethods.ByName("ListCatalog")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceGetCatalogEntryHandler := connect.NewUnaryHandler(
+	catalogServiceGetCatalogEntryHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceGetCatalogEntryProcedure,
 		svc.GetCatalogEntry,
 		connect.WithSchema(catalogServiceMethods.ByName("GetCatalogEntry")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceCreateCatalogEntryHandler := connect.NewUnaryHandler(
+	catalogServiceCreateCatalogEntryHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceCreateCatalogEntryProcedure,
 		svc.CreateCatalogEntry,
 		connect.WithSchema(catalogServiceMethods.ByName("CreateCatalogEntry")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceUpdateCatalogEntryHandler := connect.NewUnaryHandler(
+	catalogServiceUpdateCatalogEntryHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceUpdateCatalogEntryProcedure,
 		svc.UpdateCatalogEntry,
 		connect.WithSchema(catalogServiceMethods.ByName("UpdateCatalogEntry")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceDeleteCatalogEntryHandler := connect.NewUnaryHandler(
+	catalogServiceDeleteCatalogEntryHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceDeleteCatalogEntryProcedure,
 		svc.DeleteCatalogEntry,
 		connect.WithSchema(catalogServiceMethods.ByName("DeleteCatalogEntry")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceListAssetsByCatalogEntryHandler := connect.NewUnaryHandler(
+	catalogServiceListAssetsByCatalogEntryHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceListAssetsByCatalogEntryProcedure,
 		svc.ListAssetsByCatalogEntry,
 		connect.WithSchema(catalogServiceMethods.ByName("ListAssetsByCatalogEntry")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceListPortDefinitionsHandler := connect.NewUnaryHandler(
+	catalogServiceListPortDefinitionsHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceListPortDefinitionsProcedure,
 		svc.ListPortDefinitions,
 		connect.WithSchema(catalogServiceMethods.ByName("ListPortDefinitions")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceGetPortDefinitionHandler := connect.NewUnaryHandler(
+	catalogServiceGetPortDefinitionHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceGetPortDefinitionProcedure,
 		svc.GetPortDefinition,
 		connect.WithSchema(catalogServiceMethods.ByName("GetPortDefinition")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceCreatePortDefinitionHandler := connect.NewUnaryHandler(
+	catalogServiceCreatePortDefinitionHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceCreatePortDefinitionProcedure,
 		svc.CreatePortDefinition,
 		connect.WithSchema(catalogServiceMethods.ByName("CreatePortDefinition")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceUpdatePortDefinitionHandler := connect.NewUnaryHandler(
+	catalogServiceUpdatePortDefinitionHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceUpdatePortDefinitionProcedure,
 		svc.UpdatePortDefinition,
 		connect.WithSchema(catalogServiceMethods.ByName("UpdatePortDefinition")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceDeletePortDefinitionHandler := connect.NewUnaryHandler(
+	catalogServiceDeletePortDefinitionHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceDeletePortDefinitionProcedure,
 		svc.DeletePortDefinition,
 		connect.WithSchema(catalogServiceMethods.ByName("DeletePortDefinition")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceListPortCompatibilitiesHandler := connect.NewUnaryHandler(
+	catalogServiceListPortCompatibilitiesHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceListPortCompatibilitiesProcedure,
 		svc.ListPortCompatibilities,
 		connect.WithSchema(catalogServiceMethods.ByName("ListPortCompatibilities")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceCreatePortCompatibilityHandler := connect.NewUnaryHandler(
+	catalogServiceCreatePortCompatibilityHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceCreatePortCompatibilityProcedure,
 		svc.CreatePortCompatibility,
 		connect.WithSchema(catalogServiceMethods.ByName("CreatePortCompatibility")),
 		connect.WithHandlerOptions(opts...),
 	)
-	catalogServiceDeletePortCompatibilityHandler := connect.NewUnaryHandler(
+	catalogServiceDeletePortCompatibilityHandler := connect.NewUnaryHandlerSimple(
 		CatalogServiceDeletePortCompatibilityProcedure,
 		svc.DeletePortCompatibility,
 		connect.WithSchema(catalogServiceMethods.ByName("DeletePortCompatibility")),
@@ -436,58 +492,58 @@ func NewCatalogServiceHandler(svc CatalogServiceHandler, opts ...connect.Handler
 // UnimplementedCatalogServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedCatalogServiceHandler struct{}
 
-func (UnimplementedCatalogServiceHandler) ListCatalog(context.Context, *connect.Request[v1.ListCatalogRequest]) (*connect.Response[v1.ListCatalogResponse], error) {
+func (UnimplementedCatalogServiceHandler) ListCatalog(context.Context, *v1.ListCatalogRequest) (*v1.ListCatalogResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.ListCatalog is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) GetCatalogEntry(context.Context, *connect.Request[v1.GetCatalogEntryRequest]) (*connect.Response[v1.GetCatalogEntryResponse], error) {
+func (UnimplementedCatalogServiceHandler) GetCatalogEntry(context.Context, *v1.GetCatalogEntryRequest) (*v1.GetCatalogEntryResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.GetCatalogEntry is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) CreateCatalogEntry(context.Context, *connect.Request[v1.CreateCatalogEntryRequest]) (*connect.Response[v1.CreateCatalogEntryResponse], error) {
+func (UnimplementedCatalogServiceHandler) CreateCatalogEntry(context.Context, *v1.CreateCatalogEntryRequest) (*v1.CreateCatalogEntryResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.CreateCatalogEntry is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) UpdateCatalogEntry(context.Context, *connect.Request[v1.UpdateCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) UpdateCatalogEntry(context.Context, *v1.UpdateCatalogEntryRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.UpdateCatalogEntry is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) DeleteCatalogEntry(context.Context, *connect.Request[v1.DeleteCatalogEntryRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) DeleteCatalogEntry(context.Context, *v1.DeleteCatalogEntryRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.DeleteCatalogEntry is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) ListAssetsByCatalogEntry(context.Context, *connect.Request[v1.ListAssetsByCatalogEntryRequest]) (*connect.Response[v1.ListAssetsByCatalogEntryResponse], error) {
+func (UnimplementedCatalogServiceHandler) ListAssetsByCatalogEntry(context.Context, *v1.ListAssetsByCatalogEntryRequest) (*v1.ListAssetsByCatalogEntryResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.ListAssetsByCatalogEntry is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) ListPortDefinitions(context.Context, *connect.Request[v1.ListPortDefinitionsRequest]) (*connect.Response[v1.ListPortDefinitionsResponse], error) {
+func (UnimplementedCatalogServiceHandler) ListPortDefinitions(context.Context, *v1.ListPortDefinitionsRequest) (*v1.ListPortDefinitionsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.ListPortDefinitions is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) GetPortDefinition(context.Context, *connect.Request[v1.GetPortDefinitionRequest]) (*connect.Response[v1.GetPortDefinitionResponse], error) {
+func (UnimplementedCatalogServiceHandler) GetPortDefinition(context.Context, *v1.GetPortDefinitionRequest) (*v1.GetPortDefinitionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.GetPortDefinition is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) CreatePortDefinition(context.Context, *connect.Request[v1.CreatePortDefinitionRequest]) (*connect.Response[v1.CreatePortDefinitionResponse], error) {
+func (UnimplementedCatalogServiceHandler) CreatePortDefinition(context.Context, *v1.CreatePortDefinitionRequest) (*v1.CreatePortDefinitionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.CreatePortDefinition is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) UpdatePortDefinition(context.Context, *connect.Request[v1.UpdatePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) UpdatePortDefinition(context.Context, *v1.UpdatePortDefinitionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.UpdatePortDefinition is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) DeletePortDefinition(context.Context, *connect.Request[v1.DeletePortDefinitionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) DeletePortDefinition(context.Context, *v1.DeletePortDefinitionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.DeletePortDefinition is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) ListPortCompatibilities(context.Context, *connect.Request[v1.ListPortCompatibilitiesRequest]) (*connect.Response[v1.ListPortCompatibilitiesResponse], error) {
+func (UnimplementedCatalogServiceHandler) ListPortCompatibilities(context.Context, *v1.ListPortCompatibilitiesRequest) (*v1.ListPortCompatibilitiesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.ListPortCompatibilities is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) CreatePortCompatibility(context.Context, *connect.Request[v1.CreatePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) CreatePortCompatibility(context.Context, *v1.CreatePortCompatibilityRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.CreatePortCompatibility is not implemented"))
 }
 
-func (UnimplementedCatalogServiceHandler) DeletePortCompatibility(context.Context, *connect.Request[v1.DeletePortCompatibilityRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedCatalogServiceHandler) DeletePortCompatibility(context.Context, *v1.DeletePortCompatibilityRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.CatalogService.DeletePortCompatibility is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/connection.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/connection.connect.go
@@ -57,12 +57,12 @@ const (
 
 // PhysicalConnectionServiceClient is a client for the dcim.v1.PhysicalConnectionService service.
 type PhysicalConnectionServiceClient interface {
-	CreatePhysicalConnection(context.Context, *connect.Request[v1.CreatePhysicalConnectionRequest]) (*connect.Response[v1.CreatePhysicalConnectionResponse], error)
-	GetPhysicalConnection(context.Context, *connect.Request[v1.GetPhysicalConnectionRequest]) (*connect.Response[v1.GetPhysicalConnectionResponse], error)
-	UpdatePhysicalConnection(context.Context, *connect.Request[v1.UpdatePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePhysicalConnection(context.Context, *connect.Request[v1.DeletePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	ListConnectionsByPlacement(context.Context, *connect.Request[v1.ListConnectionsByPlacementRequest]) (*connect.Response[v1.ListConnectionsByPlacementResponse], error)
-	ListConnectionsBySite(context.Context, *connect.Request[v1.ListConnectionsBySiteRequest]) (*connect.Response[v1.ListConnectionsBySiteResponse], error)
+	CreatePhysicalConnection(context.Context, *v1.CreatePhysicalConnectionRequest) (*v1.CreatePhysicalConnectionResponse, error)
+	GetPhysicalConnection(context.Context, *v1.GetPhysicalConnectionRequest) (*v1.GetPhysicalConnectionResponse, error)
+	UpdatePhysicalConnection(context.Context, *v1.UpdatePhysicalConnectionRequest) (*emptypb.Empty, error)
+	DeletePhysicalConnection(context.Context, *v1.DeletePhysicalConnectionRequest) (*emptypb.Empty, error)
+	ListConnectionsByPlacement(context.Context, *v1.ListConnectionsByPlacementRequest) (*v1.ListConnectionsByPlacementResponse, error)
+	ListConnectionsBySite(context.Context, *v1.ListConnectionsBySiteRequest) (*v1.ListConnectionsBySiteResponse, error)
 }
 
 // NewPhysicalConnectionServiceClient constructs a client for the dcim.v1.PhysicalConnectionService
@@ -126,44 +126,68 @@ type physicalConnectionServiceClient struct {
 }
 
 // CreatePhysicalConnection calls dcim.v1.PhysicalConnectionService.CreatePhysicalConnection.
-func (c *physicalConnectionServiceClient) CreatePhysicalConnection(ctx context.Context, req *connect.Request[v1.CreatePhysicalConnectionRequest]) (*connect.Response[v1.CreatePhysicalConnectionResponse], error) {
-	return c.createPhysicalConnection.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) CreatePhysicalConnection(ctx context.Context, req *v1.CreatePhysicalConnectionRequest) (*v1.CreatePhysicalConnectionResponse, error) {
+	response, err := c.createPhysicalConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPhysicalConnection calls dcim.v1.PhysicalConnectionService.GetPhysicalConnection.
-func (c *physicalConnectionServiceClient) GetPhysicalConnection(ctx context.Context, req *connect.Request[v1.GetPhysicalConnectionRequest]) (*connect.Response[v1.GetPhysicalConnectionResponse], error) {
-	return c.getPhysicalConnection.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) GetPhysicalConnection(ctx context.Context, req *v1.GetPhysicalConnectionRequest) (*v1.GetPhysicalConnectionResponse, error) {
+	response, err := c.getPhysicalConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdatePhysicalConnection calls dcim.v1.PhysicalConnectionService.UpdatePhysicalConnection.
-func (c *physicalConnectionServiceClient) UpdatePhysicalConnection(ctx context.Context, req *connect.Request[v1.UpdatePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updatePhysicalConnection.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) UpdatePhysicalConnection(ctx context.Context, req *v1.UpdatePhysicalConnectionRequest) (*emptypb.Empty, error) {
+	response, err := c.updatePhysicalConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeletePhysicalConnection calls dcim.v1.PhysicalConnectionService.DeletePhysicalConnection.
-func (c *physicalConnectionServiceClient) DeletePhysicalConnection(ctx context.Context, req *connect.Request[v1.DeletePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deletePhysicalConnection.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) DeletePhysicalConnection(ctx context.Context, req *v1.DeletePhysicalConnectionRequest) (*emptypb.Empty, error) {
+	response, err := c.deletePhysicalConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListConnectionsByPlacement calls dcim.v1.PhysicalConnectionService.ListConnectionsByPlacement.
-func (c *physicalConnectionServiceClient) ListConnectionsByPlacement(ctx context.Context, req *connect.Request[v1.ListConnectionsByPlacementRequest]) (*connect.Response[v1.ListConnectionsByPlacementResponse], error) {
-	return c.listConnectionsByPlacement.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) ListConnectionsByPlacement(ctx context.Context, req *v1.ListConnectionsByPlacementRequest) (*v1.ListConnectionsByPlacementResponse, error) {
+	response, err := c.listConnectionsByPlacement.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListConnectionsBySite calls dcim.v1.PhysicalConnectionService.ListConnectionsBySite.
-func (c *physicalConnectionServiceClient) ListConnectionsBySite(ctx context.Context, req *connect.Request[v1.ListConnectionsBySiteRequest]) (*connect.Response[v1.ListConnectionsBySiteResponse], error) {
-	return c.listConnectionsBySite.CallUnary(ctx, req)
+func (c *physicalConnectionServiceClient) ListConnectionsBySite(ctx context.Context, req *v1.ListConnectionsBySiteRequest) (*v1.ListConnectionsBySiteResponse, error) {
+	response, err := c.listConnectionsBySite.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PhysicalConnectionServiceHandler is an implementation of the dcim.v1.PhysicalConnectionService
 // service.
 type PhysicalConnectionServiceHandler interface {
-	CreatePhysicalConnection(context.Context, *connect.Request[v1.CreatePhysicalConnectionRequest]) (*connect.Response[v1.CreatePhysicalConnectionResponse], error)
-	GetPhysicalConnection(context.Context, *connect.Request[v1.GetPhysicalConnectionRequest]) (*connect.Response[v1.GetPhysicalConnectionResponse], error)
-	UpdatePhysicalConnection(context.Context, *connect.Request[v1.UpdatePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePhysicalConnection(context.Context, *connect.Request[v1.DeletePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	ListConnectionsByPlacement(context.Context, *connect.Request[v1.ListConnectionsByPlacementRequest]) (*connect.Response[v1.ListConnectionsByPlacementResponse], error)
-	ListConnectionsBySite(context.Context, *connect.Request[v1.ListConnectionsBySiteRequest]) (*connect.Response[v1.ListConnectionsBySiteResponse], error)
+	CreatePhysicalConnection(context.Context, *v1.CreatePhysicalConnectionRequest) (*v1.CreatePhysicalConnectionResponse, error)
+	GetPhysicalConnection(context.Context, *v1.GetPhysicalConnectionRequest) (*v1.GetPhysicalConnectionResponse, error)
+	UpdatePhysicalConnection(context.Context, *v1.UpdatePhysicalConnectionRequest) (*emptypb.Empty, error)
+	DeletePhysicalConnection(context.Context, *v1.DeletePhysicalConnectionRequest) (*emptypb.Empty, error)
+	ListConnectionsByPlacement(context.Context, *v1.ListConnectionsByPlacementRequest) (*v1.ListConnectionsByPlacementResponse, error)
+	ListConnectionsBySite(context.Context, *v1.ListConnectionsBySiteRequest) (*v1.ListConnectionsBySiteResponse, error)
 }
 
 // NewPhysicalConnectionServiceHandler builds an HTTP handler from the service implementation. It
@@ -173,37 +197,37 @@ type PhysicalConnectionServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPhysicalConnectionServiceHandler(svc PhysicalConnectionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	physicalConnectionServiceMethods := v1.File_v1_connection_proto.Services().ByName("PhysicalConnectionService").Methods()
-	physicalConnectionServiceCreatePhysicalConnectionHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceCreatePhysicalConnectionHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceCreatePhysicalConnectionProcedure,
 		svc.CreatePhysicalConnection,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("CreatePhysicalConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	physicalConnectionServiceGetPhysicalConnectionHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceGetPhysicalConnectionHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceGetPhysicalConnectionProcedure,
 		svc.GetPhysicalConnection,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("GetPhysicalConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	physicalConnectionServiceUpdatePhysicalConnectionHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceUpdatePhysicalConnectionHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceUpdatePhysicalConnectionProcedure,
 		svc.UpdatePhysicalConnection,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("UpdatePhysicalConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	physicalConnectionServiceDeletePhysicalConnectionHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceDeletePhysicalConnectionHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceDeletePhysicalConnectionProcedure,
 		svc.DeletePhysicalConnection,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("DeletePhysicalConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	physicalConnectionServiceListConnectionsByPlacementHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceListConnectionsByPlacementHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceListConnectionsByPlacementProcedure,
 		svc.ListConnectionsByPlacement,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("ListConnectionsByPlacement")),
 		connect.WithHandlerOptions(opts...),
 	)
-	physicalConnectionServiceListConnectionsBySiteHandler := connect.NewUnaryHandler(
+	physicalConnectionServiceListConnectionsBySiteHandler := connect.NewUnaryHandlerSimple(
 		PhysicalConnectionServiceListConnectionsBySiteProcedure,
 		svc.ListConnectionsBySite,
 		connect.WithSchema(physicalConnectionServiceMethods.ByName("ListConnectionsBySite")),
@@ -232,26 +256,26 @@ func NewPhysicalConnectionServiceHandler(svc PhysicalConnectionServiceHandler, o
 // UnimplementedPhysicalConnectionServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPhysicalConnectionServiceHandler struct{}
 
-func (UnimplementedPhysicalConnectionServiceHandler) CreatePhysicalConnection(context.Context, *connect.Request[v1.CreatePhysicalConnectionRequest]) (*connect.Response[v1.CreatePhysicalConnectionResponse], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) CreatePhysicalConnection(context.Context, *v1.CreatePhysicalConnectionRequest) (*v1.CreatePhysicalConnectionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.CreatePhysicalConnection is not implemented"))
 }
 
-func (UnimplementedPhysicalConnectionServiceHandler) GetPhysicalConnection(context.Context, *connect.Request[v1.GetPhysicalConnectionRequest]) (*connect.Response[v1.GetPhysicalConnectionResponse], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) GetPhysicalConnection(context.Context, *v1.GetPhysicalConnectionRequest) (*v1.GetPhysicalConnectionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.GetPhysicalConnection is not implemented"))
 }
 
-func (UnimplementedPhysicalConnectionServiceHandler) UpdatePhysicalConnection(context.Context, *connect.Request[v1.UpdatePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) UpdatePhysicalConnection(context.Context, *v1.UpdatePhysicalConnectionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.UpdatePhysicalConnection is not implemented"))
 }
 
-func (UnimplementedPhysicalConnectionServiceHandler) DeletePhysicalConnection(context.Context, *connect.Request[v1.DeletePhysicalConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) DeletePhysicalConnection(context.Context, *v1.DeletePhysicalConnectionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.DeletePhysicalConnection is not implemented"))
 }
 
-func (UnimplementedPhysicalConnectionServiceHandler) ListConnectionsByPlacement(context.Context, *connect.Request[v1.ListConnectionsByPlacementRequest]) (*connect.Response[v1.ListConnectionsByPlacementResponse], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) ListConnectionsByPlacement(context.Context, *v1.ListConnectionsByPlacementRequest) (*v1.ListConnectionsByPlacementResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.ListConnectionsByPlacement is not implemented"))
 }
 
-func (UnimplementedPhysicalConnectionServiceHandler) ListConnectionsBySite(context.Context, *connect.Request[v1.ListConnectionsBySiteRequest]) (*connect.Response[v1.ListConnectionsBySiteResponse], error) {
+func (UnimplementedPhysicalConnectionServiceHandler) ListConnectionsBySite(context.Context, *v1.ListConnectionsBySiteRequest) (*v1.ListConnectionsBySiteResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PhysicalConnectionService.ListConnectionsBySite is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/design.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/design.connect.go
@@ -99,11 +99,11 @@ const (
 
 // LogicalDesignServiceClient is a client for the dcim.v1.LogicalDesignService service.
 type LogicalDesignServiceClient interface {
-	ListDesigns(context.Context, *connect.Request[v1.ListDesignsRequest]) (*connect.Response[v1.ListDesignsResponse], error)
-	GetDesign(context.Context, *connect.Request[v1.GetDesignRequest]) (*connect.Response[v1.GetDesignResponse], error)
-	CreateDesign(context.Context, *connect.Request[v1.CreateDesignRequest]) (*connect.Response[v1.CreateDesignResponse], error)
-	UpdateDesign(context.Context, *connect.Request[v1.UpdateDesignRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteDesign(context.Context, *connect.Request[v1.DeleteDesignRequest]) (*connect.Response[emptypb.Empty], error)
+	ListDesigns(context.Context, *v1.ListDesignsRequest) (*v1.ListDesignsResponse, error)
+	GetDesign(context.Context, *v1.GetDesignRequest) (*v1.GetDesignResponse, error)
+	CreateDesign(context.Context, *v1.CreateDesignRequest) (*v1.CreateDesignResponse, error)
+	UpdateDesign(context.Context, *v1.UpdateDesignRequest) (*emptypb.Empty, error)
+	DeleteDesign(context.Context, *v1.DeleteDesignRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDesignServiceClient constructs a client for the dcim.v1.LogicalDesignService service.
@@ -160,37 +160,57 @@ type logicalDesignServiceClient struct {
 }
 
 // ListDesigns calls dcim.v1.LogicalDesignService.ListDesigns.
-func (c *logicalDesignServiceClient) ListDesigns(ctx context.Context, req *connect.Request[v1.ListDesignsRequest]) (*connect.Response[v1.ListDesignsResponse], error) {
-	return c.listDesigns.CallUnary(ctx, req)
+func (c *logicalDesignServiceClient) ListDesigns(ctx context.Context, req *v1.ListDesignsRequest) (*v1.ListDesignsResponse, error) {
+	response, err := c.listDesigns.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetDesign calls dcim.v1.LogicalDesignService.GetDesign.
-func (c *logicalDesignServiceClient) GetDesign(ctx context.Context, req *connect.Request[v1.GetDesignRequest]) (*connect.Response[v1.GetDesignResponse], error) {
-	return c.getDesign.CallUnary(ctx, req)
+func (c *logicalDesignServiceClient) GetDesign(ctx context.Context, req *v1.GetDesignRequest) (*v1.GetDesignResponse, error) {
+	response, err := c.getDesign.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateDesign calls dcim.v1.LogicalDesignService.CreateDesign.
-func (c *logicalDesignServiceClient) CreateDesign(ctx context.Context, req *connect.Request[v1.CreateDesignRequest]) (*connect.Response[v1.CreateDesignResponse], error) {
-	return c.createDesign.CallUnary(ctx, req)
+func (c *logicalDesignServiceClient) CreateDesign(ctx context.Context, req *v1.CreateDesignRequest) (*v1.CreateDesignResponse, error) {
+	response, err := c.createDesign.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateDesign calls dcim.v1.LogicalDesignService.UpdateDesign.
-func (c *logicalDesignServiceClient) UpdateDesign(ctx context.Context, req *connect.Request[v1.UpdateDesignRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateDesign.CallUnary(ctx, req)
+func (c *logicalDesignServiceClient) UpdateDesign(ctx context.Context, req *v1.UpdateDesignRequest) (*emptypb.Empty, error) {
+	response, err := c.updateDesign.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteDesign calls dcim.v1.LogicalDesignService.DeleteDesign.
-func (c *logicalDesignServiceClient) DeleteDesign(ctx context.Context, req *connect.Request[v1.DeleteDesignRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteDesign.CallUnary(ctx, req)
+func (c *logicalDesignServiceClient) DeleteDesign(ctx context.Context, req *v1.DeleteDesignRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteDesign.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // LogicalDesignServiceHandler is an implementation of the dcim.v1.LogicalDesignService service.
 type LogicalDesignServiceHandler interface {
-	ListDesigns(context.Context, *connect.Request[v1.ListDesignsRequest]) (*connect.Response[v1.ListDesignsResponse], error)
-	GetDesign(context.Context, *connect.Request[v1.GetDesignRequest]) (*connect.Response[v1.GetDesignResponse], error)
-	CreateDesign(context.Context, *connect.Request[v1.CreateDesignRequest]) (*connect.Response[v1.CreateDesignResponse], error)
-	UpdateDesign(context.Context, *connect.Request[v1.UpdateDesignRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteDesign(context.Context, *connect.Request[v1.DeleteDesignRequest]) (*connect.Response[emptypb.Empty], error)
+	ListDesigns(context.Context, *v1.ListDesignsRequest) (*v1.ListDesignsResponse, error)
+	GetDesign(context.Context, *v1.GetDesignRequest) (*v1.GetDesignResponse, error)
+	CreateDesign(context.Context, *v1.CreateDesignRequest) (*v1.CreateDesignResponse, error)
+	UpdateDesign(context.Context, *v1.UpdateDesignRequest) (*emptypb.Empty, error)
+	DeleteDesign(context.Context, *v1.DeleteDesignRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDesignServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -200,31 +220,31 @@ type LogicalDesignServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewLogicalDesignServiceHandler(svc LogicalDesignServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	logicalDesignServiceMethods := v1.File_v1_design_proto.Services().ByName("LogicalDesignService").Methods()
-	logicalDesignServiceListDesignsHandler := connect.NewUnaryHandler(
+	logicalDesignServiceListDesignsHandler := connect.NewUnaryHandlerSimple(
 		LogicalDesignServiceListDesignsProcedure,
 		svc.ListDesigns,
 		connect.WithSchema(logicalDesignServiceMethods.ByName("ListDesigns")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDesignServiceGetDesignHandler := connect.NewUnaryHandler(
+	logicalDesignServiceGetDesignHandler := connect.NewUnaryHandlerSimple(
 		LogicalDesignServiceGetDesignProcedure,
 		svc.GetDesign,
 		connect.WithSchema(logicalDesignServiceMethods.ByName("GetDesign")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDesignServiceCreateDesignHandler := connect.NewUnaryHandler(
+	logicalDesignServiceCreateDesignHandler := connect.NewUnaryHandlerSimple(
 		LogicalDesignServiceCreateDesignProcedure,
 		svc.CreateDesign,
 		connect.WithSchema(logicalDesignServiceMethods.ByName("CreateDesign")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDesignServiceUpdateDesignHandler := connect.NewUnaryHandler(
+	logicalDesignServiceUpdateDesignHandler := connect.NewUnaryHandlerSimple(
 		LogicalDesignServiceUpdateDesignProcedure,
 		svc.UpdateDesign,
 		connect.WithSchema(logicalDesignServiceMethods.ByName("UpdateDesign")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDesignServiceDeleteDesignHandler := connect.NewUnaryHandler(
+	logicalDesignServiceDeleteDesignHandler := connect.NewUnaryHandlerSimple(
 		LogicalDesignServiceDeleteDesignProcedure,
 		svc.DeleteDesign,
 		connect.WithSchema(logicalDesignServiceMethods.ByName("DeleteDesign")),
@@ -251,33 +271,33 @@ func NewLogicalDesignServiceHandler(svc LogicalDesignServiceHandler, opts ...con
 // UnimplementedLogicalDesignServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedLogicalDesignServiceHandler struct{}
 
-func (UnimplementedLogicalDesignServiceHandler) ListDesigns(context.Context, *connect.Request[v1.ListDesignsRequest]) (*connect.Response[v1.ListDesignsResponse], error) {
+func (UnimplementedLogicalDesignServiceHandler) ListDesigns(context.Context, *v1.ListDesignsRequest) (*v1.ListDesignsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDesignService.ListDesigns is not implemented"))
 }
 
-func (UnimplementedLogicalDesignServiceHandler) GetDesign(context.Context, *connect.Request[v1.GetDesignRequest]) (*connect.Response[v1.GetDesignResponse], error) {
+func (UnimplementedLogicalDesignServiceHandler) GetDesign(context.Context, *v1.GetDesignRequest) (*v1.GetDesignResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDesignService.GetDesign is not implemented"))
 }
 
-func (UnimplementedLogicalDesignServiceHandler) CreateDesign(context.Context, *connect.Request[v1.CreateDesignRequest]) (*connect.Response[v1.CreateDesignResponse], error) {
+func (UnimplementedLogicalDesignServiceHandler) CreateDesign(context.Context, *v1.CreateDesignRequest) (*v1.CreateDesignResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDesignService.CreateDesign is not implemented"))
 }
 
-func (UnimplementedLogicalDesignServiceHandler) UpdateDesign(context.Context, *connect.Request[v1.UpdateDesignRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalDesignServiceHandler) UpdateDesign(context.Context, *v1.UpdateDesignRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDesignService.UpdateDesign is not implemented"))
 }
 
-func (UnimplementedLogicalDesignServiceHandler) DeleteDesign(context.Context, *connect.Request[v1.DeleteDesignRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalDesignServiceHandler) DeleteDesign(context.Context, *v1.DeleteDesignRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDesignService.DeleteDesign is not implemented"))
 }
 
 // LogicalDeviceServiceClient is a client for the dcim.v1.LogicalDeviceService service.
 type LogicalDeviceServiceClient interface {
-	ListDevices(context.Context, *connect.Request[v1.ListDevicesRequest]) (*connect.Response[v1.ListDevicesResponse], error)
-	GetDevice(context.Context, *connect.Request[v1.GetDeviceRequest]) (*connect.Response[v1.GetDeviceResponse], error)
-	CreateDevice(context.Context, *connect.Request[v1.CreateDeviceRequest]) (*connect.Response[v1.CreateDeviceResponse], error)
-	UpdateDevice(context.Context, *connect.Request[v1.UpdateDeviceRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteDevice(context.Context, *connect.Request[v1.DeleteDeviceRequest]) (*connect.Response[emptypb.Empty], error)
+	ListDevices(context.Context, *v1.ListDevicesRequest) (*v1.ListDevicesResponse, error)
+	GetDevice(context.Context, *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error)
+	CreateDevice(context.Context, *v1.CreateDeviceRequest) (*v1.CreateDeviceResponse, error)
+	UpdateDevice(context.Context, *v1.UpdateDeviceRequest) (*emptypb.Empty, error)
+	DeleteDevice(context.Context, *v1.DeleteDeviceRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDeviceServiceClient constructs a client for the dcim.v1.LogicalDeviceService service.
@@ -334,37 +354,57 @@ type logicalDeviceServiceClient struct {
 }
 
 // ListDevices calls dcim.v1.LogicalDeviceService.ListDevices.
-func (c *logicalDeviceServiceClient) ListDevices(ctx context.Context, req *connect.Request[v1.ListDevicesRequest]) (*connect.Response[v1.ListDevicesResponse], error) {
-	return c.listDevices.CallUnary(ctx, req)
+func (c *logicalDeviceServiceClient) ListDevices(ctx context.Context, req *v1.ListDevicesRequest) (*v1.ListDevicesResponse, error) {
+	response, err := c.listDevices.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetDevice calls dcim.v1.LogicalDeviceService.GetDevice.
-func (c *logicalDeviceServiceClient) GetDevice(ctx context.Context, req *connect.Request[v1.GetDeviceRequest]) (*connect.Response[v1.GetDeviceResponse], error) {
-	return c.getDevice.CallUnary(ctx, req)
+func (c *logicalDeviceServiceClient) GetDevice(ctx context.Context, req *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error) {
+	response, err := c.getDevice.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateDevice calls dcim.v1.LogicalDeviceService.CreateDevice.
-func (c *logicalDeviceServiceClient) CreateDevice(ctx context.Context, req *connect.Request[v1.CreateDeviceRequest]) (*connect.Response[v1.CreateDeviceResponse], error) {
-	return c.createDevice.CallUnary(ctx, req)
+func (c *logicalDeviceServiceClient) CreateDevice(ctx context.Context, req *v1.CreateDeviceRequest) (*v1.CreateDeviceResponse, error) {
+	response, err := c.createDevice.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateDevice calls dcim.v1.LogicalDeviceService.UpdateDevice.
-func (c *logicalDeviceServiceClient) UpdateDevice(ctx context.Context, req *connect.Request[v1.UpdateDeviceRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateDevice.CallUnary(ctx, req)
+func (c *logicalDeviceServiceClient) UpdateDevice(ctx context.Context, req *v1.UpdateDeviceRequest) (*emptypb.Empty, error) {
+	response, err := c.updateDevice.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteDevice calls dcim.v1.LogicalDeviceService.DeleteDevice.
-func (c *logicalDeviceServiceClient) DeleteDevice(ctx context.Context, req *connect.Request[v1.DeleteDeviceRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteDevice.CallUnary(ctx, req)
+func (c *logicalDeviceServiceClient) DeleteDevice(ctx context.Context, req *v1.DeleteDeviceRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteDevice.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // LogicalDeviceServiceHandler is an implementation of the dcim.v1.LogicalDeviceService service.
 type LogicalDeviceServiceHandler interface {
-	ListDevices(context.Context, *connect.Request[v1.ListDevicesRequest]) (*connect.Response[v1.ListDevicesResponse], error)
-	GetDevice(context.Context, *connect.Request[v1.GetDeviceRequest]) (*connect.Response[v1.GetDeviceResponse], error)
-	CreateDevice(context.Context, *connect.Request[v1.CreateDeviceRequest]) (*connect.Response[v1.CreateDeviceResponse], error)
-	UpdateDevice(context.Context, *connect.Request[v1.UpdateDeviceRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteDevice(context.Context, *connect.Request[v1.DeleteDeviceRequest]) (*connect.Response[emptypb.Empty], error)
+	ListDevices(context.Context, *v1.ListDevicesRequest) (*v1.ListDevicesResponse, error)
+	GetDevice(context.Context, *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error)
+	CreateDevice(context.Context, *v1.CreateDeviceRequest) (*v1.CreateDeviceResponse, error)
+	UpdateDevice(context.Context, *v1.UpdateDeviceRequest) (*emptypb.Empty, error)
+	DeleteDevice(context.Context, *v1.DeleteDeviceRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDeviceServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -374,31 +414,31 @@ type LogicalDeviceServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewLogicalDeviceServiceHandler(svc LogicalDeviceServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	logicalDeviceServiceMethods := v1.File_v1_design_proto.Services().ByName("LogicalDeviceService").Methods()
-	logicalDeviceServiceListDevicesHandler := connect.NewUnaryHandler(
+	logicalDeviceServiceListDevicesHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceServiceListDevicesProcedure,
 		svc.ListDevices,
 		connect.WithSchema(logicalDeviceServiceMethods.ByName("ListDevices")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceServiceGetDeviceHandler := connect.NewUnaryHandler(
+	logicalDeviceServiceGetDeviceHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceServiceGetDeviceProcedure,
 		svc.GetDevice,
 		connect.WithSchema(logicalDeviceServiceMethods.ByName("GetDevice")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceServiceCreateDeviceHandler := connect.NewUnaryHandler(
+	logicalDeviceServiceCreateDeviceHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceServiceCreateDeviceProcedure,
 		svc.CreateDevice,
 		connect.WithSchema(logicalDeviceServiceMethods.ByName("CreateDevice")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceServiceUpdateDeviceHandler := connect.NewUnaryHandler(
+	logicalDeviceServiceUpdateDeviceHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceServiceUpdateDeviceProcedure,
 		svc.UpdateDevice,
 		connect.WithSchema(logicalDeviceServiceMethods.ByName("UpdateDevice")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceServiceDeleteDeviceHandler := connect.NewUnaryHandler(
+	logicalDeviceServiceDeleteDeviceHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceServiceDeleteDeviceProcedure,
 		svc.DeleteDevice,
 		connect.WithSchema(logicalDeviceServiceMethods.ByName("DeleteDevice")),
@@ -425,33 +465,33 @@ func NewLogicalDeviceServiceHandler(svc LogicalDeviceServiceHandler, opts ...con
 // UnimplementedLogicalDeviceServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedLogicalDeviceServiceHandler struct{}
 
-func (UnimplementedLogicalDeviceServiceHandler) ListDevices(context.Context, *connect.Request[v1.ListDevicesRequest]) (*connect.Response[v1.ListDevicesResponse], error) {
+func (UnimplementedLogicalDeviceServiceHandler) ListDevices(context.Context, *v1.ListDevicesRequest) (*v1.ListDevicesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceService.ListDevices is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceServiceHandler) GetDevice(context.Context, *connect.Request[v1.GetDeviceRequest]) (*connect.Response[v1.GetDeviceResponse], error) {
+func (UnimplementedLogicalDeviceServiceHandler) GetDevice(context.Context, *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceService.GetDevice is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceServiceHandler) CreateDevice(context.Context, *connect.Request[v1.CreateDeviceRequest]) (*connect.Response[v1.CreateDeviceResponse], error) {
+func (UnimplementedLogicalDeviceServiceHandler) CreateDevice(context.Context, *v1.CreateDeviceRequest) (*v1.CreateDeviceResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceService.CreateDevice is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceServiceHandler) UpdateDevice(context.Context, *connect.Request[v1.UpdateDeviceRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalDeviceServiceHandler) UpdateDevice(context.Context, *v1.UpdateDeviceRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceService.UpdateDevice is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceServiceHandler) DeleteDevice(context.Context, *connect.Request[v1.DeleteDeviceRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalDeviceServiceHandler) DeleteDevice(context.Context, *v1.DeleteDeviceRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceService.DeleteDevice is not implemented"))
 }
 
 // LogicalConnectionServiceClient is a client for the dcim.v1.LogicalConnectionService service.
 type LogicalConnectionServiceClient interface {
-	ListConnections(context.Context, *connect.Request[v1.ListConnectionsRequest]) (*connect.Response[v1.ListConnectionsResponse], error)
-	GetConnection(context.Context, *connect.Request[v1.GetConnectionRequest]) (*connect.Response[v1.GetConnectionResponse], error)
-	CreateConnection(context.Context, *connect.Request[v1.CreateConnectionRequest]) (*connect.Response[v1.CreateConnectionResponse], error)
-	UpdateConnection(context.Context, *connect.Request[v1.UpdateConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteConnection(context.Context, *connect.Request[v1.DeleteConnectionRequest]) (*connect.Response[emptypb.Empty], error)
+	ListConnections(context.Context, *v1.ListConnectionsRequest) (*v1.ListConnectionsResponse, error)
+	GetConnection(context.Context, *v1.GetConnectionRequest) (*v1.GetConnectionResponse, error)
+	CreateConnection(context.Context, *v1.CreateConnectionRequest) (*v1.CreateConnectionResponse, error)
+	UpdateConnection(context.Context, *v1.UpdateConnectionRequest) (*emptypb.Empty, error)
+	DeleteConnection(context.Context, *v1.DeleteConnectionRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalConnectionServiceClient constructs a client for the dcim.v1.LogicalConnectionService
@@ -508,38 +548,58 @@ type logicalConnectionServiceClient struct {
 }
 
 // ListConnections calls dcim.v1.LogicalConnectionService.ListConnections.
-func (c *logicalConnectionServiceClient) ListConnections(ctx context.Context, req *connect.Request[v1.ListConnectionsRequest]) (*connect.Response[v1.ListConnectionsResponse], error) {
-	return c.listConnections.CallUnary(ctx, req)
+func (c *logicalConnectionServiceClient) ListConnections(ctx context.Context, req *v1.ListConnectionsRequest) (*v1.ListConnectionsResponse, error) {
+	response, err := c.listConnections.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetConnection calls dcim.v1.LogicalConnectionService.GetConnection.
-func (c *logicalConnectionServiceClient) GetConnection(ctx context.Context, req *connect.Request[v1.GetConnectionRequest]) (*connect.Response[v1.GetConnectionResponse], error) {
-	return c.getConnection.CallUnary(ctx, req)
+func (c *logicalConnectionServiceClient) GetConnection(ctx context.Context, req *v1.GetConnectionRequest) (*v1.GetConnectionResponse, error) {
+	response, err := c.getConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateConnection calls dcim.v1.LogicalConnectionService.CreateConnection.
-func (c *logicalConnectionServiceClient) CreateConnection(ctx context.Context, req *connect.Request[v1.CreateConnectionRequest]) (*connect.Response[v1.CreateConnectionResponse], error) {
-	return c.createConnection.CallUnary(ctx, req)
+func (c *logicalConnectionServiceClient) CreateConnection(ctx context.Context, req *v1.CreateConnectionRequest) (*v1.CreateConnectionResponse, error) {
+	response, err := c.createConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateConnection calls dcim.v1.LogicalConnectionService.UpdateConnection.
-func (c *logicalConnectionServiceClient) UpdateConnection(ctx context.Context, req *connect.Request[v1.UpdateConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateConnection.CallUnary(ctx, req)
+func (c *logicalConnectionServiceClient) UpdateConnection(ctx context.Context, req *v1.UpdateConnectionRequest) (*emptypb.Empty, error) {
+	response, err := c.updateConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteConnection calls dcim.v1.LogicalConnectionService.DeleteConnection.
-func (c *logicalConnectionServiceClient) DeleteConnection(ctx context.Context, req *connect.Request[v1.DeleteConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteConnection.CallUnary(ctx, req)
+func (c *logicalConnectionServiceClient) DeleteConnection(ctx context.Context, req *v1.DeleteConnectionRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteConnection.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // LogicalConnectionServiceHandler is an implementation of the dcim.v1.LogicalConnectionService
 // service.
 type LogicalConnectionServiceHandler interface {
-	ListConnections(context.Context, *connect.Request[v1.ListConnectionsRequest]) (*connect.Response[v1.ListConnectionsResponse], error)
-	GetConnection(context.Context, *connect.Request[v1.GetConnectionRequest]) (*connect.Response[v1.GetConnectionResponse], error)
-	CreateConnection(context.Context, *connect.Request[v1.CreateConnectionRequest]) (*connect.Response[v1.CreateConnectionResponse], error)
-	UpdateConnection(context.Context, *connect.Request[v1.UpdateConnectionRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteConnection(context.Context, *connect.Request[v1.DeleteConnectionRequest]) (*connect.Response[emptypb.Empty], error)
+	ListConnections(context.Context, *v1.ListConnectionsRequest) (*v1.ListConnectionsResponse, error)
+	GetConnection(context.Context, *v1.GetConnectionRequest) (*v1.GetConnectionResponse, error)
+	CreateConnection(context.Context, *v1.CreateConnectionRequest) (*v1.CreateConnectionResponse, error)
+	UpdateConnection(context.Context, *v1.UpdateConnectionRequest) (*emptypb.Empty, error)
+	DeleteConnection(context.Context, *v1.DeleteConnectionRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalConnectionServiceHandler builds an HTTP handler from the service implementation. It
@@ -549,31 +609,31 @@ type LogicalConnectionServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewLogicalConnectionServiceHandler(svc LogicalConnectionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	logicalConnectionServiceMethods := v1.File_v1_design_proto.Services().ByName("LogicalConnectionService").Methods()
-	logicalConnectionServiceListConnectionsHandler := connect.NewUnaryHandler(
+	logicalConnectionServiceListConnectionsHandler := connect.NewUnaryHandlerSimple(
 		LogicalConnectionServiceListConnectionsProcedure,
 		svc.ListConnections,
 		connect.WithSchema(logicalConnectionServiceMethods.ByName("ListConnections")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalConnectionServiceGetConnectionHandler := connect.NewUnaryHandler(
+	logicalConnectionServiceGetConnectionHandler := connect.NewUnaryHandlerSimple(
 		LogicalConnectionServiceGetConnectionProcedure,
 		svc.GetConnection,
 		connect.WithSchema(logicalConnectionServiceMethods.ByName("GetConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalConnectionServiceCreateConnectionHandler := connect.NewUnaryHandler(
+	logicalConnectionServiceCreateConnectionHandler := connect.NewUnaryHandlerSimple(
 		LogicalConnectionServiceCreateConnectionProcedure,
 		svc.CreateConnection,
 		connect.WithSchema(logicalConnectionServiceMethods.ByName("CreateConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalConnectionServiceUpdateConnectionHandler := connect.NewUnaryHandler(
+	logicalConnectionServiceUpdateConnectionHandler := connect.NewUnaryHandlerSimple(
 		LogicalConnectionServiceUpdateConnectionProcedure,
 		svc.UpdateConnection,
 		connect.WithSchema(logicalConnectionServiceMethods.ByName("UpdateConnection")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalConnectionServiceDeleteConnectionHandler := connect.NewUnaryHandler(
+	logicalConnectionServiceDeleteConnectionHandler := connect.NewUnaryHandlerSimple(
 		LogicalConnectionServiceDeleteConnectionProcedure,
 		svc.DeleteConnection,
 		connect.WithSchema(logicalConnectionServiceMethods.ByName("DeleteConnection")),
@@ -600,31 +660,31 @@ func NewLogicalConnectionServiceHandler(svc LogicalConnectionServiceHandler, opt
 // UnimplementedLogicalConnectionServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedLogicalConnectionServiceHandler struct{}
 
-func (UnimplementedLogicalConnectionServiceHandler) ListConnections(context.Context, *connect.Request[v1.ListConnectionsRequest]) (*connect.Response[v1.ListConnectionsResponse], error) {
+func (UnimplementedLogicalConnectionServiceHandler) ListConnections(context.Context, *v1.ListConnectionsRequest) (*v1.ListConnectionsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalConnectionService.ListConnections is not implemented"))
 }
 
-func (UnimplementedLogicalConnectionServiceHandler) GetConnection(context.Context, *connect.Request[v1.GetConnectionRequest]) (*connect.Response[v1.GetConnectionResponse], error) {
+func (UnimplementedLogicalConnectionServiceHandler) GetConnection(context.Context, *v1.GetConnectionRequest) (*v1.GetConnectionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalConnectionService.GetConnection is not implemented"))
 }
 
-func (UnimplementedLogicalConnectionServiceHandler) CreateConnection(context.Context, *connect.Request[v1.CreateConnectionRequest]) (*connect.Response[v1.CreateConnectionResponse], error) {
+func (UnimplementedLogicalConnectionServiceHandler) CreateConnection(context.Context, *v1.CreateConnectionRequest) (*v1.CreateConnectionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalConnectionService.CreateConnection is not implemented"))
 }
 
-func (UnimplementedLogicalConnectionServiceHandler) UpdateConnection(context.Context, *connect.Request[v1.UpdateConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalConnectionServiceHandler) UpdateConnection(context.Context, *v1.UpdateConnectionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalConnectionService.UpdateConnection is not implemented"))
 }
 
-func (UnimplementedLogicalConnectionServiceHandler) DeleteConnection(context.Context, *connect.Request[v1.DeleteConnectionRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalConnectionServiceHandler) DeleteConnection(context.Context, *v1.DeleteConnectionRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalConnectionService.DeleteConnection is not implemented"))
 }
 
 // LogicalDeviceLayoutServiceClient is a client for the dcim.v1.LogicalDeviceLayoutService service.
 type LogicalDeviceLayoutServiceClient interface {
-	GetLayout(context.Context, *connect.Request[v1.GetLayoutRequest]) (*connect.Response[v1.GetLayoutResponse], error)
-	SaveLayout(context.Context, *connect.Request[v1.SaveLayoutRequest]) (*connect.Response[v1.SaveLayoutResponse], error)
-	DeleteLayout(context.Context, *connect.Request[v1.DeleteLayoutRequest]) (*connect.Response[emptypb.Empty], error)
+	GetLayout(context.Context, *v1.GetLayoutRequest) (*v1.GetLayoutResponse, error)
+	SaveLayout(context.Context, *v1.SaveLayoutRequest) (*v1.SaveLayoutResponse, error)
+	DeleteLayout(context.Context, *v1.DeleteLayoutRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDeviceLayoutServiceClient constructs a client for the
@@ -667,26 +727,38 @@ type logicalDeviceLayoutServiceClient struct {
 }
 
 // GetLayout calls dcim.v1.LogicalDeviceLayoutService.GetLayout.
-func (c *logicalDeviceLayoutServiceClient) GetLayout(ctx context.Context, req *connect.Request[v1.GetLayoutRequest]) (*connect.Response[v1.GetLayoutResponse], error) {
-	return c.getLayout.CallUnary(ctx, req)
+func (c *logicalDeviceLayoutServiceClient) GetLayout(ctx context.Context, req *v1.GetLayoutRequest) (*v1.GetLayoutResponse, error) {
+	response, err := c.getLayout.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // SaveLayout calls dcim.v1.LogicalDeviceLayoutService.SaveLayout.
-func (c *logicalDeviceLayoutServiceClient) SaveLayout(ctx context.Context, req *connect.Request[v1.SaveLayoutRequest]) (*connect.Response[v1.SaveLayoutResponse], error) {
-	return c.saveLayout.CallUnary(ctx, req)
+func (c *logicalDeviceLayoutServiceClient) SaveLayout(ctx context.Context, req *v1.SaveLayoutRequest) (*v1.SaveLayoutResponse, error) {
+	response, err := c.saveLayout.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteLayout calls dcim.v1.LogicalDeviceLayoutService.DeleteLayout.
-func (c *logicalDeviceLayoutServiceClient) DeleteLayout(ctx context.Context, req *connect.Request[v1.DeleteLayoutRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteLayout.CallUnary(ctx, req)
+func (c *logicalDeviceLayoutServiceClient) DeleteLayout(ctx context.Context, req *v1.DeleteLayoutRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteLayout.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // LogicalDeviceLayoutServiceHandler is an implementation of the dcim.v1.LogicalDeviceLayoutService
 // service.
 type LogicalDeviceLayoutServiceHandler interface {
-	GetLayout(context.Context, *connect.Request[v1.GetLayoutRequest]) (*connect.Response[v1.GetLayoutResponse], error)
-	SaveLayout(context.Context, *connect.Request[v1.SaveLayoutRequest]) (*connect.Response[v1.SaveLayoutResponse], error)
-	DeleteLayout(context.Context, *connect.Request[v1.DeleteLayoutRequest]) (*connect.Response[emptypb.Empty], error)
+	GetLayout(context.Context, *v1.GetLayoutRequest) (*v1.GetLayoutResponse, error)
+	SaveLayout(context.Context, *v1.SaveLayoutRequest) (*v1.SaveLayoutResponse, error)
+	DeleteLayout(context.Context, *v1.DeleteLayoutRequest) (*emptypb.Empty, error)
 }
 
 // NewLogicalDeviceLayoutServiceHandler builds an HTTP handler from the service implementation. It
@@ -696,19 +768,19 @@ type LogicalDeviceLayoutServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewLogicalDeviceLayoutServiceHandler(svc LogicalDeviceLayoutServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	logicalDeviceLayoutServiceMethods := v1.File_v1_design_proto.Services().ByName("LogicalDeviceLayoutService").Methods()
-	logicalDeviceLayoutServiceGetLayoutHandler := connect.NewUnaryHandler(
+	logicalDeviceLayoutServiceGetLayoutHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceLayoutServiceGetLayoutProcedure,
 		svc.GetLayout,
 		connect.WithSchema(logicalDeviceLayoutServiceMethods.ByName("GetLayout")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceLayoutServiceSaveLayoutHandler := connect.NewUnaryHandler(
+	logicalDeviceLayoutServiceSaveLayoutHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceLayoutServiceSaveLayoutProcedure,
 		svc.SaveLayout,
 		connect.WithSchema(logicalDeviceLayoutServiceMethods.ByName("SaveLayout")),
 		connect.WithHandlerOptions(opts...),
 	)
-	logicalDeviceLayoutServiceDeleteLayoutHandler := connect.NewUnaryHandler(
+	logicalDeviceLayoutServiceDeleteLayoutHandler := connect.NewUnaryHandlerSimple(
 		LogicalDeviceLayoutServiceDeleteLayoutProcedure,
 		svc.DeleteLayout,
 		connect.WithSchema(logicalDeviceLayoutServiceMethods.ByName("DeleteLayout")),
@@ -731,14 +803,14 @@ func NewLogicalDeviceLayoutServiceHandler(svc LogicalDeviceLayoutServiceHandler,
 // UnimplementedLogicalDeviceLayoutServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedLogicalDeviceLayoutServiceHandler struct{}
 
-func (UnimplementedLogicalDeviceLayoutServiceHandler) GetLayout(context.Context, *connect.Request[v1.GetLayoutRequest]) (*connect.Response[v1.GetLayoutResponse], error) {
+func (UnimplementedLogicalDeviceLayoutServiceHandler) GetLayout(context.Context, *v1.GetLayoutRequest) (*v1.GetLayoutResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceLayoutService.GetLayout is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceLayoutServiceHandler) SaveLayout(context.Context, *connect.Request[v1.SaveLayoutRequest]) (*connect.Response[v1.SaveLayoutResponse], error) {
+func (UnimplementedLogicalDeviceLayoutServiceHandler) SaveLayout(context.Context, *v1.SaveLayoutRequest) (*v1.SaveLayoutResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceLayoutService.SaveLayout is not implemented"))
 }
 
-func (UnimplementedLogicalDeviceLayoutServiceHandler) DeleteLayout(context.Context, *connect.Request[v1.DeleteLayoutRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedLogicalDeviceLayoutServiceHandler) DeleteLayout(context.Context, *v1.DeleteLayoutRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.LogicalDeviceLayoutService.DeleteLayout is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/note.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/note.connect.go
@@ -44,9 +44,9 @@ const (
 
 // NoteServiceClient is a client for the dcim.v1.NoteService service.
 type NoteServiceClient interface {
-	ListNotes(context.Context, *connect.Request[v1.ListNotesRequest]) (*connect.Response[v1.ListNotesResponse], error)
-	CreateNote(context.Context, *connect.Request[v1.CreateNoteRequest]) (*connect.Response[v1.CreateNoteResponse], error)
-	DeleteNote(context.Context, *connect.Request[v1.DeleteNoteRequest]) (*connect.Response[emptypb.Empty], error)
+	ListNotes(context.Context, *v1.ListNotesRequest) (*v1.ListNotesResponse, error)
+	CreateNote(context.Context, *v1.CreateNoteRequest) (*v1.CreateNoteResponse, error)
+	DeleteNote(context.Context, *v1.DeleteNoteRequest) (*emptypb.Empty, error)
 }
 
 // NewNoteServiceClient constructs a client for the dcim.v1.NoteService service. By default, it uses
@@ -89,25 +89,37 @@ type noteServiceClient struct {
 }
 
 // ListNotes calls dcim.v1.NoteService.ListNotes.
-func (c *noteServiceClient) ListNotes(ctx context.Context, req *connect.Request[v1.ListNotesRequest]) (*connect.Response[v1.ListNotesResponse], error) {
-	return c.listNotes.CallUnary(ctx, req)
+func (c *noteServiceClient) ListNotes(ctx context.Context, req *v1.ListNotesRequest) (*v1.ListNotesResponse, error) {
+	response, err := c.listNotes.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateNote calls dcim.v1.NoteService.CreateNote.
-func (c *noteServiceClient) CreateNote(ctx context.Context, req *connect.Request[v1.CreateNoteRequest]) (*connect.Response[v1.CreateNoteResponse], error) {
-	return c.createNote.CallUnary(ctx, req)
+func (c *noteServiceClient) CreateNote(ctx context.Context, req *v1.CreateNoteRequest) (*v1.CreateNoteResponse, error) {
+	response, err := c.createNote.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteNote calls dcim.v1.NoteService.DeleteNote.
-func (c *noteServiceClient) DeleteNote(ctx context.Context, req *connect.Request[v1.DeleteNoteRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteNote.CallUnary(ctx, req)
+func (c *noteServiceClient) DeleteNote(ctx context.Context, req *v1.DeleteNoteRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteNote.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // NoteServiceHandler is an implementation of the dcim.v1.NoteService service.
 type NoteServiceHandler interface {
-	ListNotes(context.Context, *connect.Request[v1.ListNotesRequest]) (*connect.Response[v1.ListNotesResponse], error)
-	CreateNote(context.Context, *connect.Request[v1.CreateNoteRequest]) (*connect.Response[v1.CreateNoteResponse], error)
-	DeleteNote(context.Context, *connect.Request[v1.DeleteNoteRequest]) (*connect.Response[emptypb.Empty], error)
+	ListNotes(context.Context, *v1.ListNotesRequest) (*v1.ListNotesResponse, error)
+	CreateNote(context.Context, *v1.CreateNoteRequest) (*v1.CreateNoteResponse, error)
+	DeleteNote(context.Context, *v1.DeleteNoteRequest) (*emptypb.Empty, error)
 }
 
 // NewNoteServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -117,19 +129,19 @@ type NoteServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewNoteServiceHandler(svc NoteServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	noteServiceMethods := v1.File_v1_note_proto.Services().ByName("NoteService").Methods()
-	noteServiceListNotesHandler := connect.NewUnaryHandler(
+	noteServiceListNotesHandler := connect.NewUnaryHandlerSimple(
 		NoteServiceListNotesProcedure,
 		svc.ListNotes,
 		connect.WithSchema(noteServiceMethods.ByName("ListNotes")),
 		connect.WithHandlerOptions(opts...),
 	)
-	noteServiceCreateNoteHandler := connect.NewUnaryHandler(
+	noteServiceCreateNoteHandler := connect.NewUnaryHandlerSimple(
 		NoteServiceCreateNoteProcedure,
 		svc.CreateNote,
 		connect.WithSchema(noteServiceMethods.ByName("CreateNote")),
 		connect.WithHandlerOptions(opts...),
 	)
-	noteServiceDeleteNoteHandler := connect.NewUnaryHandler(
+	noteServiceDeleteNoteHandler := connect.NewUnaryHandlerSimple(
 		NoteServiceDeleteNoteProcedure,
 		svc.DeleteNote,
 		connect.WithSchema(noteServiceMethods.ByName("DeleteNote")),
@@ -152,14 +164,14 @@ func NewNoteServiceHandler(svc NoteServiceHandler, opts ...connect.HandlerOption
 // UnimplementedNoteServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedNoteServiceHandler struct{}
 
-func (UnimplementedNoteServiceHandler) ListNotes(context.Context, *connect.Request[v1.ListNotesRequest]) (*connect.Response[v1.ListNotesResponse], error) {
+func (UnimplementedNoteServiceHandler) ListNotes(context.Context, *v1.ListNotesRequest) (*v1.ListNotesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.NoteService.ListNotes is not implemented"))
 }
 
-func (UnimplementedNoteServiceHandler) CreateNote(context.Context, *connect.Request[v1.CreateNoteRequest]) (*connect.Response[v1.CreateNoteResponse], error) {
+func (UnimplementedNoteServiceHandler) CreateNote(context.Context, *v1.CreateNoteRequest) (*v1.CreateNoteResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.NoteService.CreateNote is not implemented"))
 }
 
-func (UnimplementedNoteServiceHandler) DeleteNote(context.Context, *connect.Request[v1.DeleteNoteRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedNoteServiceHandler) DeleteNote(context.Context, *v1.DeleteNoteRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.NoteService.DeleteNote is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/placement.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/placement.connect.go
@@ -59,13 +59,13 @@ const (
 
 // PlacementServiceClient is a client for the dcim.v1.PlacementService service.
 type PlacementServiceClient interface {
-	CreatePlacement(context.Context, *connect.Request[v1.CreatePlacementRequest]) (*connect.Response[v1.CreatePlacementResponse], error)
-	GetPlacement(context.Context, *connect.Request[v1.GetPlacementRequest]) (*connect.Response[v1.GetPlacementResponse], error)
-	GetPlacementByAsset(context.Context, *connect.Request[v1.GetPlacementByAssetRequest]) (*connect.Response[v1.GetPlacementByAssetResponse], error)
-	UpdatePlacement(context.Context, *connect.Request[v1.UpdatePlacementRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePlacement(context.Context, *connect.Request[v1.DeletePlacementRequest]) (*connect.Response[emptypb.Empty], error)
-	ListPlacementsByRack(context.Context, *connect.Request[v1.ListPlacementsByRackRequest]) (*connect.Response[v1.ListPlacementsByRackResponse], error)
-	ListChildPlacements(context.Context, *connect.Request[v1.ListChildPlacementsRequest]) (*connect.Response[v1.ListChildPlacementsResponse], error)
+	CreatePlacement(context.Context, *v1.CreatePlacementRequest) (*v1.CreatePlacementResponse, error)
+	GetPlacement(context.Context, *v1.GetPlacementRequest) (*v1.GetPlacementResponse, error)
+	GetPlacementByAsset(context.Context, *v1.GetPlacementByAssetRequest) (*v1.GetPlacementByAssetResponse, error)
+	UpdatePlacement(context.Context, *v1.UpdatePlacementRequest) (*emptypb.Empty, error)
+	DeletePlacement(context.Context, *v1.DeletePlacementRequest) (*emptypb.Empty, error)
+	ListPlacementsByRack(context.Context, *v1.ListPlacementsByRackRequest) (*v1.ListPlacementsByRackResponse, error)
+	ListChildPlacements(context.Context, *v1.ListChildPlacementsRequest) (*v1.ListChildPlacementsResponse, error)
 }
 
 // NewPlacementServiceClient constructs a client for the dcim.v1.PlacementService service. By
@@ -136,49 +136,77 @@ type placementServiceClient struct {
 }
 
 // CreatePlacement calls dcim.v1.PlacementService.CreatePlacement.
-func (c *placementServiceClient) CreatePlacement(ctx context.Context, req *connect.Request[v1.CreatePlacementRequest]) (*connect.Response[v1.CreatePlacementResponse], error) {
-	return c.createPlacement.CallUnary(ctx, req)
+func (c *placementServiceClient) CreatePlacement(ctx context.Context, req *v1.CreatePlacementRequest) (*v1.CreatePlacementResponse, error) {
+	response, err := c.createPlacement.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPlacement calls dcim.v1.PlacementService.GetPlacement.
-func (c *placementServiceClient) GetPlacement(ctx context.Context, req *connect.Request[v1.GetPlacementRequest]) (*connect.Response[v1.GetPlacementResponse], error) {
-	return c.getPlacement.CallUnary(ctx, req)
+func (c *placementServiceClient) GetPlacement(ctx context.Context, req *v1.GetPlacementRequest) (*v1.GetPlacementResponse, error) {
+	response, err := c.getPlacement.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPlacementByAsset calls dcim.v1.PlacementService.GetPlacementByAsset.
-func (c *placementServiceClient) GetPlacementByAsset(ctx context.Context, req *connect.Request[v1.GetPlacementByAssetRequest]) (*connect.Response[v1.GetPlacementByAssetResponse], error) {
-	return c.getPlacementByAsset.CallUnary(ctx, req)
+func (c *placementServiceClient) GetPlacementByAsset(ctx context.Context, req *v1.GetPlacementByAssetRequest) (*v1.GetPlacementByAssetResponse, error) {
+	response, err := c.getPlacementByAsset.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdatePlacement calls dcim.v1.PlacementService.UpdatePlacement.
-func (c *placementServiceClient) UpdatePlacement(ctx context.Context, req *connect.Request[v1.UpdatePlacementRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updatePlacement.CallUnary(ctx, req)
+func (c *placementServiceClient) UpdatePlacement(ctx context.Context, req *v1.UpdatePlacementRequest) (*emptypb.Empty, error) {
+	response, err := c.updatePlacement.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeletePlacement calls dcim.v1.PlacementService.DeletePlacement.
-func (c *placementServiceClient) DeletePlacement(ctx context.Context, req *connect.Request[v1.DeletePlacementRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deletePlacement.CallUnary(ctx, req)
+func (c *placementServiceClient) DeletePlacement(ctx context.Context, req *v1.DeletePlacementRequest) (*emptypb.Empty, error) {
+	response, err := c.deletePlacement.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListPlacementsByRack calls dcim.v1.PlacementService.ListPlacementsByRack.
-func (c *placementServiceClient) ListPlacementsByRack(ctx context.Context, req *connect.Request[v1.ListPlacementsByRackRequest]) (*connect.Response[v1.ListPlacementsByRackResponse], error) {
-	return c.listPlacementsByRack.CallUnary(ctx, req)
+func (c *placementServiceClient) ListPlacementsByRack(ctx context.Context, req *v1.ListPlacementsByRackRequest) (*v1.ListPlacementsByRackResponse, error) {
+	response, err := c.listPlacementsByRack.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListChildPlacements calls dcim.v1.PlacementService.ListChildPlacements.
-func (c *placementServiceClient) ListChildPlacements(ctx context.Context, req *connect.Request[v1.ListChildPlacementsRequest]) (*connect.Response[v1.ListChildPlacementsResponse], error) {
-	return c.listChildPlacements.CallUnary(ctx, req)
+func (c *placementServiceClient) ListChildPlacements(ctx context.Context, req *v1.ListChildPlacementsRequest) (*v1.ListChildPlacementsResponse, error) {
+	response, err := c.listChildPlacements.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PlacementServiceHandler is an implementation of the dcim.v1.PlacementService service.
 type PlacementServiceHandler interface {
-	CreatePlacement(context.Context, *connect.Request[v1.CreatePlacementRequest]) (*connect.Response[v1.CreatePlacementResponse], error)
-	GetPlacement(context.Context, *connect.Request[v1.GetPlacementRequest]) (*connect.Response[v1.GetPlacementResponse], error)
-	GetPlacementByAsset(context.Context, *connect.Request[v1.GetPlacementByAssetRequest]) (*connect.Response[v1.GetPlacementByAssetResponse], error)
-	UpdatePlacement(context.Context, *connect.Request[v1.UpdatePlacementRequest]) (*connect.Response[emptypb.Empty], error)
-	DeletePlacement(context.Context, *connect.Request[v1.DeletePlacementRequest]) (*connect.Response[emptypb.Empty], error)
-	ListPlacementsByRack(context.Context, *connect.Request[v1.ListPlacementsByRackRequest]) (*connect.Response[v1.ListPlacementsByRackResponse], error)
-	ListChildPlacements(context.Context, *connect.Request[v1.ListChildPlacementsRequest]) (*connect.Response[v1.ListChildPlacementsResponse], error)
+	CreatePlacement(context.Context, *v1.CreatePlacementRequest) (*v1.CreatePlacementResponse, error)
+	GetPlacement(context.Context, *v1.GetPlacementRequest) (*v1.GetPlacementResponse, error)
+	GetPlacementByAsset(context.Context, *v1.GetPlacementByAssetRequest) (*v1.GetPlacementByAssetResponse, error)
+	UpdatePlacement(context.Context, *v1.UpdatePlacementRequest) (*emptypb.Empty, error)
+	DeletePlacement(context.Context, *v1.DeletePlacementRequest) (*emptypb.Empty, error)
+	ListPlacementsByRack(context.Context, *v1.ListPlacementsByRackRequest) (*v1.ListPlacementsByRackResponse, error)
+	ListChildPlacements(context.Context, *v1.ListChildPlacementsRequest) (*v1.ListChildPlacementsResponse, error)
 }
 
 // NewPlacementServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -188,43 +216,43 @@ type PlacementServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPlacementServiceHandler(svc PlacementServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	placementServiceMethods := v1.File_v1_placement_proto.Services().ByName("PlacementService").Methods()
-	placementServiceCreatePlacementHandler := connect.NewUnaryHandler(
+	placementServiceCreatePlacementHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceCreatePlacementProcedure,
 		svc.CreatePlacement,
 		connect.WithSchema(placementServiceMethods.ByName("CreatePlacement")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceGetPlacementHandler := connect.NewUnaryHandler(
+	placementServiceGetPlacementHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceGetPlacementProcedure,
 		svc.GetPlacement,
 		connect.WithSchema(placementServiceMethods.ByName("GetPlacement")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceGetPlacementByAssetHandler := connect.NewUnaryHandler(
+	placementServiceGetPlacementByAssetHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceGetPlacementByAssetProcedure,
 		svc.GetPlacementByAsset,
 		connect.WithSchema(placementServiceMethods.ByName("GetPlacementByAsset")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceUpdatePlacementHandler := connect.NewUnaryHandler(
+	placementServiceUpdatePlacementHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceUpdatePlacementProcedure,
 		svc.UpdatePlacement,
 		connect.WithSchema(placementServiceMethods.ByName("UpdatePlacement")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceDeletePlacementHandler := connect.NewUnaryHandler(
+	placementServiceDeletePlacementHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceDeletePlacementProcedure,
 		svc.DeletePlacement,
 		connect.WithSchema(placementServiceMethods.ByName("DeletePlacement")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceListPlacementsByRackHandler := connect.NewUnaryHandler(
+	placementServiceListPlacementsByRackHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceListPlacementsByRackProcedure,
 		svc.ListPlacementsByRack,
 		connect.WithSchema(placementServiceMethods.ByName("ListPlacementsByRack")),
 		connect.WithHandlerOptions(opts...),
 	)
-	placementServiceListChildPlacementsHandler := connect.NewUnaryHandler(
+	placementServiceListChildPlacementsHandler := connect.NewUnaryHandlerSimple(
 		PlacementServiceListChildPlacementsProcedure,
 		svc.ListChildPlacements,
 		connect.WithSchema(placementServiceMethods.ByName("ListChildPlacements")),
@@ -255,30 +283,30 @@ func NewPlacementServiceHandler(svc PlacementServiceHandler, opts ...connect.Han
 // UnimplementedPlacementServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPlacementServiceHandler struct{}
 
-func (UnimplementedPlacementServiceHandler) CreatePlacement(context.Context, *connect.Request[v1.CreatePlacementRequest]) (*connect.Response[v1.CreatePlacementResponse], error) {
+func (UnimplementedPlacementServiceHandler) CreatePlacement(context.Context, *v1.CreatePlacementRequest) (*v1.CreatePlacementResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.CreatePlacement is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) GetPlacement(context.Context, *connect.Request[v1.GetPlacementRequest]) (*connect.Response[v1.GetPlacementResponse], error) {
+func (UnimplementedPlacementServiceHandler) GetPlacement(context.Context, *v1.GetPlacementRequest) (*v1.GetPlacementResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.GetPlacement is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) GetPlacementByAsset(context.Context, *connect.Request[v1.GetPlacementByAssetRequest]) (*connect.Response[v1.GetPlacementByAssetResponse], error) {
+func (UnimplementedPlacementServiceHandler) GetPlacementByAsset(context.Context, *v1.GetPlacementByAssetRequest) (*v1.GetPlacementByAssetResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.GetPlacementByAsset is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) UpdatePlacement(context.Context, *connect.Request[v1.UpdatePlacementRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedPlacementServiceHandler) UpdatePlacement(context.Context, *v1.UpdatePlacementRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.UpdatePlacement is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) DeletePlacement(context.Context, *connect.Request[v1.DeletePlacementRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedPlacementServiceHandler) DeletePlacement(context.Context, *v1.DeletePlacementRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.DeletePlacement is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) ListPlacementsByRack(context.Context, *connect.Request[v1.ListPlacementsByRackRequest]) (*connect.Response[v1.ListPlacementsByRackResponse], error) {
+func (UnimplementedPlacementServiceHandler) ListPlacementsByRack(context.Context, *v1.ListPlacementsByRackRequest) (*v1.ListPlacementsByRackResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.ListPlacementsByRack is not implemented"))
 }
 
-func (UnimplementedPlacementServiceHandler) ListChildPlacements(context.Context, *connect.Request[v1.ListChildPlacementsRequest]) (*connect.Response[v1.ListChildPlacementsResponse], error) {
+func (UnimplementedPlacementServiceHandler) ListChildPlacements(context.Context, *v1.ListChildPlacementsRequest) (*v1.ListChildPlacementsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.PlacementService.ListChildPlacements is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/rack.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/rack.connect.go
@@ -48,11 +48,11 @@ const (
 
 // RackServiceClient is a client for the dcim.v1.RackService service.
 type RackServiceClient interface {
-	ListRacks(context.Context, *connect.Request[v1.ListRacksRequest]) (*connect.Response[v1.ListRacksResponse], error)
-	GetRack(context.Context, *connect.Request[v1.GetRackRequest]) (*connect.Response[v1.GetRackResponse], error)
-	CreateRack(context.Context, *connect.Request[v1.CreateRackRequest]) (*connect.Response[v1.CreateRackResponse], error)
-	UpdateRack(context.Context, *connect.Request[v1.UpdateRackRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRack(context.Context, *connect.Request[v1.DeleteRackRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRacks(context.Context, *v1.ListRacksRequest) (*v1.ListRacksResponse, error)
+	GetRack(context.Context, *v1.GetRackRequest) (*v1.GetRackResponse, error)
+	CreateRack(context.Context, *v1.CreateRackRequest) (*v1.CreateRackResponse, error)
+	UpdateRack(context.Context, *v1.UpdateRackRequest) (*emptypb.Empty, error)
+	DeleteRack(context.Context, *v1.DeleteRackRequest) (*emptypb.Empty, error)
 }
 
 // NewRackServiceClient constructs a client for the dcim.v1.RackService service. By default, it uses
@@ -109,37 +109,57 @@ type rackServiceClient struct {
 }
 
 // ListRacks calls dcim.v1.RackService.ListRacks.
-func (c *rackServiceClient) ListRacks(ctx context.Context, req *connect.Request[v1.ListRacksRequest]) (*connect.Response[v1.ListRacksResponse], error) {
-	return c.listRacks.CallUnary(ctx, req)
+func (c *rackServiceClient) ListRacks(ctx context.Context, req *v1.ListRacksRequest) (*v1.ListRacksResponse, error) {
+	response, err := c.listRacks.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetRack calls dcim.v1.RackService.GetRack.
-func (c *rackServiceClient) GetRack(ctx context.Context, req *connect.Request[v1.GetRackRequest]) (*connect.Response[v1.GetRackResponse], error) {
-	return c.getRack.CallUnary(ctx, req)
+func (c *rackServiceClient) GetRack(ctx context.Context, req *v1.GetRackRequest) (*v1.GetRackResponse, error) {
+	response, err := c.getRack.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateRack calls dcim.v1.RackService.CreateRack.
-func (c *rackServiceClient) CreateRack(ctx context.Context, req *connect.Request[v1.CreateRackRequest]) (*connect.Response[v1.CreateRackResponse], error) {
-	return c.createRack.CallUnary(ctx, req)
+func (c *rackServiceClient) CreateRack(ctx context.Context, req *v1.CreateRackRequest) (*v1.CreateRackResponse, error) {
+	response, err := c.createRack.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateRack calls dcim.v1.RackService.UpdateRack.
-func (c *rackServiceClient) UpdateRack(ctx context.Context, req *connect.Request[v1.UpdateRackRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateRack.CallUnary(ctx, req)
+func (c *rackServiceClient) UpdateRack(ctx context.Context, req *v1.UpdateRackRequest) (*emptypb.Empty, error) {
+	response, err := c.updateRack.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteRack calls dcim.v1.RackService.DeleteRack.
-func (c *rackServiceClient) DeleteRack(ctx context.Context, req *connect.Request[v1.DeleteRackRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteRack.CallUnary(ctx, req)
+func (c *rackServiceClient) DeleteRack(ctx context.Context, req *v1.DeleteRackRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteRack.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RackServiceHandler is an implementation of the dcim.v1.RackService service.
 type RackServiceHandler interface {
-	ListRacks(context.Context, *connect.Request[v1.ListRacksRequest]) (*connect.Response[v1.ListRacksResponse], error)
-	GetRack(context.Context, *connect.Request[v1.GetRackRequest]) (*connect.Response[v1.GetRackResponse], error)
-	CreateRack(context.Context, *connect.Request[v1.CreateRackRequest]) (*connect.Response[v1.CreateRackResponse], error)
-	UpdateRack(context.Context, *connect.Request[v1.UpdateRackRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRack(context.Context, *connect.Request[v1.DeleteRackRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRacks(context.Context, *v1.ListRacksRequest) (*v1.ListRacksResponse, error)
+	GetRack(context.Context, *v1.GetRackRequest) (*v1.GetRackResponse, error)
+	CreateRack(context.Context, *v1.CreateRackRequest) (*v1.CreateRackResponse, error)
+	UpdateRack(context.Context, *v1.UpdateRackRequest) (*emptypb.Empty, error)
+	DeleteRack(context.Context, *v1.DeleteRackRequest) (*emptypb.Empty, error)
 }
 
 // NewRackServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -149,31 +169,31 @@ type RackServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewRackServiceHandler(svc RackServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	rackServiceMethods := v1.File_v1_rack_proto.Services().ByName("RackService").Methods()
-	rackServiceListRacksHandler := connect.NewUnaryHandler(
+	rackServiceListRacksHandler := connect.NewUnaryHandlerSimple(
 		RackServiceListRacksProcedure,
 		svc.ListRacks,
 		connect.WithSchema(rackServiceMethods.ByName("ListRacks")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackServiceGetRackHandler := connect.NewUnaryHandler(
+	rackServiceGetRackHandler := connect.NewUnaryHandlerSimple(
 		RackServiceGetRackProcedure,
 		svc.GetRack,
 		connect.WithSchema(rackServiceMethods.ByName("GetRack")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackServiceCreateRackHandler := connect.NewUnaryHandler(
+	rackServiceCreateRackHandler := connect.NewUnaryHandlerSimple(
 		RackServiceCreateRackProcedure,
 		svc.CreateRack,
 		connect.WithSchema(rackServiceMethods.ByName("CreateRack")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackServiceUpdateRackHandler := connect.NewUnaryHandler(
+	rackServiceUpdateRackHandler := connect.NewUnaryHandlerSimple(
 		RackServiceUpdateRackProcedure,
 		svc.UpdateRack,
 		connect.WithSchema(rackServiceMethods.ByName("UpdateRack")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackServiceDeleteRackHandler := connect.NewUnaryHandler(
+	rackServiceDeleteRackHandler := connect.NewUnaryHandlerSimple(
 		RackServiceDeleteRackProcedure,
 		svc.DeleteRack,
 		connect.WithSchema(rackServiceMethods.ByName("DeleteRack")),
@@ -200,22 +220,22 @@ func NewRackServiceHandler(svc RackServiceHandler, opts ...connect.HandlerOption
 // UnimplementedRackServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedRackServiceHandler struct{}
 
-func (UnimplementedRackServiceHandler) ListRacks(context.Context, *connect.Request[v1.ListRacksRequest]) (*connect.Response[v1.ListRacksResponse], error) {
+func (UnimplementedRackServiceHandler) ListRacks(context.Context, *v1.ListRacksRequest) (*v1.ListRacksResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackService.ListRacks is not implemented"))
 }
 
-func (UnimplementedRackServiceHandler) GetRack(context.Context, *connect.Request[v1.GetRackRequest]) (*connect.Response[v1.GetRackResponse], error) {
+func (UnimplementedRackServiceHandler) GetRack(context.Context, *v1.GetRackRequest) (*v1.GetRackResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackService.GetRack is not implemented"))
 }
 
-func (UnimplementedRackServiceHandler) CreateRack(context.Context, *connect.Request[v1.CreateRackRequest]) (*connect.Response[v1.CreateRackResponse], error) {
+func (UnimplementedRackServiceHandler) CreateRack(context.Context, *v1.CreateRackRequest) (*v1.CreateRackResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackService.CreateRack is not implemented"))
 }
 
-func (UnimplementedRackServiceHandler) UpdateRack(context.Context, *connect.Request[v1.UpdateRackRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRackServiceHandler) UpdateRack(context.Context, *v1.UpdateRackRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackService.UpdateRack is not implemented"))
 }
 
-func (UnimplementedRackServiceHandler) DeleteRack(context.Context, *connect.Request[v1.DeleteRackRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRackServiceHandler) DeleteRack(context.Context, *v1.DeleteRackRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackService.DeleteRack is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/rack_row.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/rack_row.connect.go
@@ -53,11 +53,11 @@ const (
 
 // RackRowServiceClient is a client for the dcim.v1.RackRowService service.
 type RackRowServiceClient interface {
-	ListRackRows(context.Context, *connect.Request[v1.ListRackRowsRequest]) (*connect.Response[v1.ListRackRowsResponse], error)
-	GetRackRow(context.Context, *connect.Request[v1.GetRackRowRequest]) (*connect.Response[v1.GetRackRowResponse], error)
-	CreateRackRow(context.Context, *connect.Request[v1.CreateRackRowRequest]) (*connect.Response[v1.CreateRackRowResponse], error)
-	UpdateRackRow(context.Context, *connect.Request[v1.UpdateRackRowRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRackRow(context.Context, *connect.Request[v1.DeleteRackRowRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRackRows(context.Context, *v1.ListRackRowsRequest) (*v1.ListRackRowsResponse, error)
+	GetRackRow(context.Context, *v1.GetRackRowRequest) (*v1.GetRackRowResponse, error)
+	CreateRackRow(context.Context, *v1.CreateRackRowRequest) (*v1.CreateRackRowResponse, error)
+	UpdateRackRow(context.Context, *v1.UpdateRackRowRequest) (*emptypb.Empty, error)
+	DeleteRackRow(context.Context, *v1.DeleteRackRowRequest) (*emptypb.Empty, error)
 }
 
 // NewRackRowServiceClient constructs a client for the dcim.v1.RackRowService service. By default,
@@ -114,37 +114,57 @@ type rackRowServiceClient struct {
 }
 
 // ListRackRows calls dcim.v1.RackRowService.ListRackRows.
-func (c *rackRowServiceClient) ListRackRows(ctx context.Context, req *connect.Request[v1.ListRackRowsRequest]) (*connect.Response[v1.ListRackRowsResponse], error) {
-	return c.listRackRows.CallUnary(ctx, req)
+func (c *rackRowServiceClient) ListRackRows(ctx context.Context, req *v1.ListRackRowsRequest) (*v1.ListRackRowsResponse, error) {
+	response, err := c.listRackRows.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetRackRow calls dcim.v1.RackRowService.GetRackRow.
-func (c *rackRowServiceClient) GetRackRow(ctx context.Context, req *connect.Request[v1.GetRackRowRequest]) (*connect.Response[v1.GetRackRowResponse], error) {
-	return c.getRackRow.CallUnary(ctx, req)
+func (c *rackRowServiceClient) GetRackRow(ctx context.Context, req *v1.GetRackRowRequest) (*v1.GetRackRowResponse, error) {
+	response, err := c.getRackRow.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateRackRow calls dcim.v1.RackRowService.CreateRackRow.
-func (c *rackRowServiceClient) CreateRackRow(ctx context.Context, req *connect.Request[v1.CreateRackRowRequest]) (*connect.Response[v1.CreateRackRowResponse], error) {
-	return c.createRackRow.CallUnary(ctx, req)
+func (c *rackRowServiceClient) CreateRackRow(ctx context.Context, req *v1.CreateRackRowRequest) (*v1.CreateRackRowResponse, error) {
+	response, err := c.createRackRow.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateRackRow calls dcim.v1.RackRowService.UpdateRackRow.
-func (c *rackRowServiceClient) UpdateRackRow(ctx context.Context, req *connect.Request[v1.UpdateRackRowRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateRackRow.CallUnary(ctx, req)
+func (c *rackRowServiceClient) UpdateRackRow(ctx context.Context, req *v1.UpdateRackRowRequest) (*emptypb.Empty, error) {
+	response, err := c.updateRackRow.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteRackRow calls dcim.v1.RackRowService.DeleteRackRow.
-func (c *rackRowServiceClient) DeleteRackRow(ctx context.Context, req *connect.Request[v1.DeleteRackRowRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteRackRow.CallUnary(ctx, req)
+func (c *rackRowServiceClient) DeleteRackRow(ctx context.Context, req *v1.DeleteRackRowRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteRackRow.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RackRowServiceHandler is an implementation of the dcim.v1.RackRowService service.
 type RackRowServiceHandler interface {
-	ListRackRows(context.Context, *connect.Request[v1.ListRackRowsRequest]) (*connect.Response[v1.ListRackRowsResponse], error)
-	GetRackRow(context.Context, *connect.Request[v1.GetRackRowRequest]) (*connect.Response[v1.GetRackRowResponse], error)
-	CreateRackRow(context.Context, *connect.Request[v1.CreateRackRowRequest]) (*connect.Response[v1.CreateRackRowResponse], error)
-	UpdateRackRow(context.Context, *connect.Request[v1.UpdateRackRowRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRackRow(context.Context, *connect.Request[v1.DeleteRackRowRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRackRows(context.Context, *v1.ListRackRowsRequest) (*v1.ListRackRowsResponse, error)
+	GetRackRow(context.Context, *v1.GetRackRowRequest) (*v1.GetRackRowResponse, error)
+	CreateRackRow(context.Context, *v1.CreateRackRowRequest) (*v1.CreateRackRowResponse, error)
+	UpdateRackRow(context.Context, *v1.UpdateRackRowRequest) (*emptypb.Empty, error)
+	DeleteRackRow(context.Context, *v1.DeleteRackRowRequest) (*emptypb.Empty, error)
 }
 
 // NewRackRowServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -154,31 +174,31 @@ type RackRowServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewRackRowServiceHandler(svc RackRowServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	rackRowServiceMethods := v1.File_v1_rack_row_proto.Services().ByName("RackRowService").Methods()
-	rackRowServiceListRackRowsHandler := connect.NewUnaryHandler(
+	rackRowServiceListRackRowsHandler := connect.NewUnaryHandlerSimple(
 		RackRowServiceListRackRowsProcedure,
 		svc.ListRackRows,
 		connect.WithSchema(rackRowServiceMethods.ByName("ListRackRows")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackRowServiceGetRackRowHandler := connect.NewUnaryHandler(
+	rackRowServiceGetRackRowHandler := connect.NewUnaryHandlerSimple(
 		RackRowServiceGetRackRowProcedure,
 		svc.GetRackRow,
 		connect.WithSchema(rackRowServiceMethods.ByName("GetRackRow")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackRowServiceCreateRackRowHandler := connect.NewUnaryHandler(
+	rackRowServiceCreateRackRowHandler := connect.NewUnaryHandlerSimple(
 		RackRowServiceCreateRackRowProcedure,
 		svc.CreateRackRow,
 		connect.WithSchema(rackRowServiceMethods.ByName("CreateRackRow")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackRowServiceUpdateRackRowHandler := connect.NewUnaryHandler(
+	rackRowServiceUpdateRackRowHandler := connect.NewUnaryHandlerSimple(
 		RackRowServiceUpdateRackRowProcedure,
 		svc.UpdateRackRow,
 		connect.WithSchema(rackRowServiceMethods.ByName("UpdateRackRow")),
 		connect.WithHandlerOptions(opts...),
 	)
-	rackRowServiceDeleteRackRowHandler := connect.NewUnaryHandler(
+	rackRowServiceDeleteRackRowHandler := connect.NewUnaryHandlerSimple(
 		RackRowServiceDeleteRackRowProcedure,
 		svc.DeleteRackRow,
 		connect.WithSchema(rackRowServiceMethods.ByName("DeleteRackRow")),
@@ -205,22 +225,22 @@ func NewRackRowServiceHandler(svc RackRowServiceHandler, opts ...connect.Handler
 // UnimplementedRackRowServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedRackRowServiceHandler struct{}
 
-func (UnimplementedRackRowServiceHandler) ListRackRows(context.Context, *connect.Request[v1.ListRackRowsRequest]) (*connect.Response[v1.ListRackRowsResponse], error) {
+func (UnimplementedRackRowServiceHandler) ListRackRows(context.Context, *v1.ListRackRowsRequest) (*v1.ListRackRowsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackRowService.ListRackRows is not implemented"))
 }
 
-func (UnimplementedRackRowServiceHandler) GetRackRow(context.Context, *connect.Request[v1.GetRackRowRequest]) (*connect.Response[v1.GetRackRowResponse], error) {
+func (UnimplementedRackRowServiceHandler) GetRackRow(context.Context, *v1.GetRackRowRequest) (*v1.GetRackRowResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackRowService.GetRackRow is not implemented"))
 }
 
-func (UnimplementedRackRowServiceHandler) CreateRackRow(context.Context, *connect.Request[v1.CreateRackRowRequest]) (*connect.Response[v1.CreateRackRowResponse], error) {
+func (UnimplementedRackRowServiceHandler) CreateRackRow(context.Context, *v1.CreateRackRowRequest) (*v1.CreateRackRowResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackRowService.CreateRackRow is not implemented"))
 }
 
-func (UnimplementedRackRowServiceHandler) UpdateRackRow(context.Context, *connect.Request[v1.UpdateRackRowRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRackRowServiceHandler) UpdateRackRow(context.Context, *v1.UpdateRackRowRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackRowService.UpdateRackRow is not implemented"))
 }
 
-func (UnimplementedRackRowServiceHandler) DeleteRackRow(context.Context, *connect.Request[v1.DeleteRackRowRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRackRowServiceHandler) DeleteRackRow(context.Context, *v1.DeleteRackRowRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RackRowService.DeleteRackRow is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/room.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/room.connect.go
@@ -48,11 +48,11 @@ const (
 
 // RoomServiceClient is a client for the dcim.v1.RoomService service.
 type RoomServiceClient interface {
-	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)
-	GetRoom(context.Context, *connect.Request[v1.GetRoomRequest]) (*connect.Response[v1.GetRoomResponse], error)
-	CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error)
-	UpdateRoom(context.Context, *connect.Request[v1.UpdateRoomRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRoom(context.Context, *connect.Request[v1.DeleteRoomRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRooms(context.Context, *v1.ListRoomsRequest) (*v1.ListRoomsResponse, error)
+	GetRoom(context.Context, *v1.GetRoomRequest) (*v1.GetRoomResponse, error)
+	CreateRoom(context.Context, *v1.CreateRoomRequest) (*v1.CreateRoomResponse, error)
+	UpdateRoom(context.Context, *v1.UpdateRoomRequest) (*emptypb.Empty, error)
+	DeleteRoom(context.Context, *v1.DeleteRoomRequest) (*emptypb.Empty, error)
 }
 
 // NewRoomServiceClient constructs a client for the dcim.v1.RoomService service. By default, it uses
@@ -109,37 +109,57 @@ type roomServiceClient struct {
 }
 
 // ListRooms calls dcim.v1.RoomService.ListRooms.
-func (c *roomServiceClient) ListRooms(ctx context.Context, req *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error) {
-	return c.listRooms.CallUnary(ctx, req)
+func (c *roomServiceClient) ListRooms(ctx context.Context, req *v1.ListRoomsRequest) (*v1.ListRoomsResponse, error) {
+	response, err := c.listRooms.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetRoom calls dcim.v1.RoomService.GetRoom.
-func (c *roomServiceClient) GetRoom(ctx context.Context, req *connect.Request[v1.GetRoomRequest]) (*connect.Response[v1.GetRoomResponse], error) {
-	return c.getRoom.CallUnary(ctx, req)
+func (c *roomServiceClient) GetRoom(ctx context.Context, req *v1.GetRoomRequest) (*v1.GetRoomResponse, error) {
+	response, err := c.getRoom.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateRoom calls dcim.v1.RoomService.CreateRoom.
-func (c *roomServiceClient) CreateRoom(ctx context.Context, req *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error) {
-	return c.createRoom.CallUnary(ctx, req)
+func (c *roomServiceClient) CreateRoom(ctx context.Context, req *v1.CreateRoomRequest) (*v1.CreateRoomResponse, error) {
+	response, err := c.createRoom.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateRoom calls dcim.v1.RoomService.UpdateRoom.
-func (c *roomServiceClient) UpdateRoom(ctx context.Context, req *connect.Request[v1.UpdateRoomRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateRoom.CallUnary(ctx, req)
+func (c *roomServiceClient) UpdateRoom(ctx context.Context, req *v1.UpdateRoomRequest) (*emptypb.Empty, error) {
+	response, err := c.updateRoom.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteRoom calls dcim.v1.RoomService.DeleteRoom.
-func (c *roomServiceClient) DeleteRoom(ctx context.Context, req *connect.Request[v1.DeleteRoomRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteRoom.CallUnary(ctx, req)
+func (c *roomServiceClient) DeleteRoom(ctx context.Context, req *v1.DeleteRoomRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteRoom.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RoomServiceHandler is an implementation of the dcim.v1.RoomService service.
 type RoomServiceHandler interface {
-	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)
-	GetRoom(context.Context, *connect.Request[v1.GetRoomRequest]) (*connect.Response[v1.GetRoomResponse], error)
-	CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error)
-	UpdateRoom(context.Context, *connect.Request[v1.UpdateRoomRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteRoom(context.Context, *connect.Request[v1.DeleteRoomRequest]) (*connect.Response[emptypb.Empty], error)
+	ListRooms(context.Context, *v1.ListRoomsRequest) (*v1.ListRoomsResponse, error)
+	GetRoom(context.Context, *v1.GetRoomRequest) (*v1.GetRoomResponse, error)
+	CreateRoom(context.Context, *v1.CreateRoomRequest) (*v1.CreateRoomResponse, error)
+	UpdateRoom(context.Context, *v1.UpdateRoomRequest) (*emptypb.Empty, error)
+	DeleteRoom(context.Context, *v1.DeleteRoomRequest) (*emptypb.Empty, error)
 }
 
 // NewRoomServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -149,31 +169,31 @@ type RoomServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewRoomServiceHandler(svc RoomServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	roomServiceMethods := v1.File_v1_room_proto.Services().ByName("RoomService").Methods()
-	roomServiceListRoomsHandler := connect.NewUnaryHandler(
+	roomServiceListRoomsHandler := connect.NewUnaryHandlerSimple(
 		RoomServiceListRoomsProcedure,
 		svc.ListRooms,
 		connect.WithSchema(roomServiceMethods.ByName("ListRooms")),
 		connect.WithHandlerOptions(opts...),
 	)
-	roomServiceGetRoomHandler := connect.NewUnaryHandler(
+	roomServiceGetRoomHandler := connect.NewUnaryHandlerSimple(
 		RoomServiceGetRoomProcedure,
 		svc.GetRoom,
 		connect.WithSchema(roomServiceMethods.ByName("GetRoom")),
 		connect.WithHandlerOptions(opts...),
 	)
-	roomServiceCreateRoomHandler := connect.NewUnaryHandler(
+	roomServiceCreateRoomHandler := connect.NewUnaryHandlerSimple(
 		RoomServiceCreateRoomProcedure,
 		svc.CreateRoom,
 		connect.WithSchema(roomServiceMethods.ByName("CreateRoom")),
 		connect.WithHandlerOptions(opts...),
 	)
-	roomServiceUpdateRoomHandler := connect.NewUnaryHandler(
+	roomServiceUpdateRoomHandler := connect.NewUnaryHandlerSimple(
 		RoomServiceUpdateRoomProcedure,
 		svc.UpdateRoom,
 		connect.WithSchema(roomServiceMethods.ByName("UpdateRoom")),
 		connect.WithHandlerOptions(opts...),
 	)
-	roomServiceDeleteRoomHandler := connect.NewUnaryHandler(
+	roomServiceDeleteRoomHandler := connect.NewUnaryHandlerSimple(
 		RoomServiceDeleteRoomProcedure,
 		svc.DeleteRoom,
 		connect.WithSchema(roomServiceMethods.ByName("DeleteRoom")),
@@ -200,22 +220,22 @@ func NewRoomServiceHandler(svc RoomServiceHandler, opts ...connect.HandlerOption
 // UnimplementedRoomServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedRoomServiceHandler struct{}
 
-func (UnimplementedRoomServiceHandler) ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error) {
+func (UnimplementedRoomServiceHandler) ListRooms(context.Context, *v1.ListRoomsRequest) (*v1.ListRoomsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RoomService.ListRooms is not implemented"))
 }
 
-func (UnimplementedRoomServiceHandler) GetRoom(context.Context, *connect.Request[v1.GetRoomRequest]) (*connect.Response[v1.GetRoomResponse], error) {
+func (UnimplementedRoomServiceHandler) GetRoom(context.Context, *v1.GetRoomRequest) (*v1.GetRoomResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RoomService.GetRoom is not implemented"))
 }
 
-func (UnimplementedRoomServiceHandler) CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error) {
+func (UnimplementedRoomServiceHandler) CreateRoom(context.Context, *v1.CreateRoomRequest) (*v1.CreateRoomResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RoomService.CreateRoom is not implemented"))
 }
 
-func (UnimplementedRoomServiceHandler) UpdateRoom(context.Context, *connect.Request[v1.UpdateRoomRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRoomServiceHandler) UpdateRoom(context.Context, *v1.UpdateRoomRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RoomService.UpdateRoom is not implemented"))
 }
 
-func (UnimplementedRoomServiceHandler) DeleteRoom(context.Context, *connect.Request[v1.DeleteRoomRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedRoomServiceHandler) DeleteRoom(context.Context, *v1.DeleteRoomRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.RoomService.DeleteRoom is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/site.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/site.connect.go
@@ -48,11 +48,11 @@ const (
 
 // SiteServiceClient is a client for the dcim.v1.SiteService service.
 type SiteServiceClient interface {
-	ListSites(context.Context, *connect.Request[v1.ListSitesRequest]) (*connect.Response[v1.ListSitesResponse], error)
-	GetSite(context.Context, *connect.Request[v1.GetSiteRequest]) (*connect.Response[v1.GetSiteResponse], error)
-	CreateSite(context.Context, *connect.Request[v1.CreateSiteRequest]) (*connect.Response[v1.CreateSiteResponse], error)
-	UpdateSite(context.Context, *connect.Request[v1.UpdateSiteRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteSite(context.Context, *connect.Request[v1.DeleteSiteRequest]) (*connect.Response[emptypb.Empty], error)
+	ListSites(context.Context, *v1.ListSitesRequest) (*v1.ListSitesResponse, error)
+	GetSite(context.Context, *v1.GetSiteRequest) (*v1.GetSiteResponse, error)
+	CreateSite(context.Context, *v1.CreateSiteRequest) (*v1.CreateSiteResponse, error)
+	UpdateSite(context.Context, *v1.UpdateSiteRequest) (*emptypb.Empty, error)
+	DeleteSite(context.Context, *v1.DeleteSiteRequest) (*emptypb.Empty, error)
 }
 
 // NewSiteServiceClient constructs a client for the dcim.v1.SiteService service. By default, it uses
@@ -109,37 +109,57 @@ type siteServiceClient struct {
 }
 
 // ListSites calls dcim.v1.SiteService.ListSites.
-func (c *siteServiceClient) ListSites(ctx context.Context, req *connect.Request[v1.ListSitesRequest]) (*connect.Response[v1.ListSitesResponse], error) {
-	return c.listSites.CallUnary(ctx, req)
+func (c *siteServiceClient) ListSites(ctx context.Context, req *v1.ListSitesRequest) (*v1.ListSitesResponse, error) {
+	response, err := c.listSites.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetSite calls dcim.v1.SiteService.GetSite.
-func (c *siteServiceClient) GetSite(ctx context.Context, req *connect.Request[v1.GetSiteRequest]) (*connect.Response[v1.GetSiteResponse], error) {
-	return c.getSite.CallUnary(ctx, req)
+func (c *siteServiceClient) GetSite(ctx context.Context, req *v1.GetSiteRequest) (*v1.GetSiteResponse, error) {
+	response, err := c.getSite.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateSite calls dcim.v1.SiteService.CreateSite.
-func (c *siteServiceClient) CreateSite(ctx context.Context, req *connect.Request[v1.CreateSiteRequest]) (*connect.Response[v1.CreateSiteResponse], error) {
-	return c.createSite.CallUnary(ctx, req)
+func (c *siteServiceClient) CreateSite(ctx context.Context, req *v1.CreateSiteRequest) (*v1.CreateSiteResponse, error) {
+	response, err := c.createSite.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateSite calls dcim.v1.SiteService.UpdateSite.
-func (c *siteServiceClient) UpdateSite(ctx context.Context, req *connect.Request[v1.UpdateSiteRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateSite.CallUnary(ctx, req)
+func (c *siteServiceClient) UpdateSite(ctx context.Context, req *v1.UpdateSiteRequest) (*emptypb.Empty, error) {
+	response, err := c.updateSite.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteSite calls dcim.v1.SiteService.DeleteSite.
-func (c *siteServiceClient) DeleteSite(ctx context.Context, req *connect.Request[v1.DeleteSiteRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteSite.CallUnary(ctx, req)
+func (c *siteServiceClient) DeleteSite(ctx context.Context, req *v1.DeleteSiteRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteSite.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // SiteServiceHandler is an implementation of the dcim.v1.SiteService service.
 type SiteServiceHandler interface {
-	ListSites(context.Context, *connect.Request[v1.ListSitesRequest]) (*connect.Response[v1.ListSitesResponse], error)
-	GetSite(context.Context, *connect.Request[v1.GetSiteRequest]) (*connect.Response[v1.GetSiteResponse], error)
-	CreateSite(context.Context, *connect.Request[v1.CreateSiteRequest]) (*connect.Response[v1.CreateSiteResponse], error)
-	UpdateSite(context.Context, *connect.Request[v1.UpdateSiteRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteSite(context.Context, *connect.Request[v1.DeleteSiteRequest]) (*connect.Response[emptypb.Empty], error)
+	ListSites(context.Context, *v1.ListSitesRequest) (*v1.ListSitesResponse, error)
+	GetSite(context.Context, *v1.GetSiteRequest) (*v1.GetSiteResponse, error)
+	CreateSite(context.Context, *v1.CreateSiteRequest) (*v1.CreateSiteResponse, error)
+	UpdateSite(context.Context, *v1.UpdateSiteRequest) (*emptypb.Empty, error)
+	DeleteSite(context.Context, *v1.DeleteSiteRequest) (*emptypb.Empty, error)
 }
 
 // NewSiteServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -149,31 +169,31 @@ type SiteServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewSiteServiceHandler(svc SiteServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	siteServiceMethods := v1.File_v1_site_proto.Services().ByName("SiteService").Methods()
-	siteServiceListSitesHandler := connect.NewUnaryHandler(
+	siteServiceListSitesHandler := connect.NewUnaryHandlerSimple(
 		SiteServiceListSitesProcedure,
 		svc.ListSites,
 		connect.WithSchema(siteServiceMethods.ByName("ListSites")),
 		connect.WithHandlerOptions(opts...),
 	)
-	siteServiceGetSiteHandler := connect.NewUnaryHandler(
+	siteServiceGetSiteHandler := connect.NewUnaryHandlerSimple(
 		SiteServiceGetSiteProcedure,
 		svc.GetSite,
 		connect.WithSchema(siteServiceMethods.ByName("GetSite")),
 		connect.WithHandlerOptions(opts...),
 	)
-	siteServiceCreateSiteHandler := connect.NewUnaryHandler(
+	siteServiceCreateSiteHandler := connect.NewUnaryHandlerSimple(
 		SiteServiceCreateSiteProcedure,
 		svc.CreateSite,
 		connect.WithSchema(siteServiceMethods.ByName("CreateSite")),
 		connect.WithHandlerOptions(opts...),
 	)
-	siteServiceUpdateSiteHandler := connect.NewUnaryHandler(
+	siteServiceUpdateSiteHandler := connect.NewUnaryHandlerSimple(
 		SiteServiceUpdateSiteProcedure,
 		svc.UpdateSite,
 		connect.WithSchema(siteServiceMethods.ByName("UpdateSite")),
 		connect.WithHandlerOptions(opts...),
 	)
-	siteServiceDeleteSiteHandler := connect.NewUnaryHandler(
+	siteServiceDeleteSiteHandler := connect.NewUnaryHandlerSimple(
 		SiteServiceDeleteSiteProcedure,
 		svc.DeleteSite,
 		connect.WithSchema(siteServiceMethods.ByName("DeleteSite")),
@@ -200,22 +220,22 @@ func NewSiteServiceHandler(svc SiteServiceHandler, opts ...connect.HandlerOption
 // UnimplementedSiteServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedSiteServiceHandler struct{}
 
-func (UnimplementedSiteServiceHandler) ListSites(context.Context, *connect.Request[v1.ListSitesRequest]) (*connect.Response[v1.ListSitesResponse], error) {
+func (UnimplementedSiteServiceHandler) ListSites(context.Context, *v1.ListSitesRequest) (*v1.ListSitesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.SiteService.ListSites is not implemented"))
 }
 
-func (UnimplementedSiteServiceHandler) GetSite(context.Context, *connect.Request[v1.GetSiteRequest]) (*connect.Response[v1.GetSiteResponse], error) {
+func (UnimplementedSiteServiceHandler) GetSite(context.Context, *v1.GetSiteRequest) (*v1.GetSiteResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.SiteService.GetSite is not implemented"))
 }
 
-func (UnimplementedSiteServiceHandler) CreateSite(context.Context, *connect.Request[v1.CreateSiteRequest]) (*connect.Response[v1.CreateSiteResponse], error) {
+func (UnimplementedSiteServiceHandler) CreateSite(context.Context, *v1.CreateSiteRequest) (*v1.CreateSiteResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.SiteService.CreateSite is not implemented"))
 }
 
-func (UnimplementedSiteServiceHandler) UpdateSite(context.Context, *connect.Request[v1.UpdateSiteRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedSiteServiceHandler) UpdateSite(context.Context, *v1.UpdateSiteRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.SiteService.UpdateSite is not implemented"))
 }
 
-func (UnimplementedSiteServiceHandler) DeleteSite(context.Context, *connect.Request[v1.DeleteSiteRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedSiteServiceHandler) DeleteSite(context.Context, *v1.DeleteSiteRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.SiteService.DeleteSite is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/task.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/task.connect.go
@@ -62,11 +62,11 @@ const (
 
 // TaskServiceClient is a client for the dcim.v1.TaskService service.
 type TaskServiceClient interface {
-	ListTasks(context.Context, *connect.Request[v1.ListTasksRequest]) (*connect.Response[v1.ListTasksResponse], error)
-	GetTask(context.Context, *connect.Request[v1.GetTaskRequest]) (*connect.Response[v1.GetTaskResponse], error)
-	CreateTask(context.Context, *connect.Request[v1.CreateTaskRequest]) (*connect.Response[v1.CreateTaskResponse], error)
-	UpdateTask(context.Context, *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteTask(context.Context, *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[emptypb.Empty], error)
+	ListTasks(context.Context, *v1.ListTasksRequest) (*v1.ListTasksResponse, error)
+	GetTask(context.Context, *v1.GetTaskRequest) (*v1.GetTaskResponse, error)
+	CreateTask(context.Context, *v1.CreateTaskRequest) (*v1.CreateTaskResponse, error)
+	UpdateTask(context.Context, *v1.UpdateTaskRequest) (*emptypb.Empty, error)
+	DeleteTask(context.Context, *v1.DeleteTaskRequest) (*emptypb.Empty, error)
 }
 
 // NewTaskServiceClient constructs a client for the dcim.v1.TaskService service. By default, it uses
@@ -123,37 +123,57 @@ type taskServiceClient struct {
 }
 
 // ListTasks calls dcim.v1.TaskService.ListTasks.
-func (c *taskServiceClient) ListTasks(ctx context.Context, req *connect.Request[v1.ListTasksRequest]) (*connect.Response[v1.ListTasksResponse], error) {
-	return c.listTasks.CallUnary(ctx, req)
+func (c *taskServiceClient) ListTasks(ctx context.Context, req *v1.ListTasksRequest) (*v1.ListTasksResponse, error) {
+	response, err := c.listTasks.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetTask calls dcim.v1.TaskService.GetTask.
-func (c *taskServiceClient) GetTask(ctx context.Context, req *connect.Request[v1.GetTaskRequest]) (*connect.Response[v1.GetTaskResponse], error) {
-	return c.getTask.CallUnary(ctx, req)
+func (c *taskServiceClient) GetTask(ctx context.Context, req *v1.GetTaskRequest) (*v1.GetTaskResponse, error) {
+	response, err := c.getTask.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateTask calls dcim.v1.TaskService.CreateTask.
-func (c *taskServiceClient) CreateTask(ctx context.Context, req *connect.Request[v1.CreateTaskRequest]) (*connect.Response[v1.CreateTaskResponse], error) {
-	return c.createTask.CallUnary(ctx, req)
+func (c *taskServiceClient) CreateTask(ctx context.Context, req *v1.CreateTaskRequest) (*v1.CreateTaskResponse, error) {
+	response, err := c.createTask.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateTask calls dcim.v1.TaskService.UpdateTask.
-func (c *taskServiceClient) UpdateTask(ctx context.Context, req *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateTask.CallUnary(ctx, req)
+func (c *taskServiceClient) UpdateTask(ctx context.Context, req *v1.UpdateTaskRequest) (*emptypb.Empty, error) {
+	response, err := c.updateTask.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteTask calls dcim.v1.TaskService.DeleteTask.
-func (c *taskServiceClient) DeleteTask(ctx context.Context, req *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteTask.CallUnary(ctx, req)
+func (c *taskServiceClient) DeleteTask(ctx context.Context, req *v1.DeleteTaskRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteTask.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // TaskServiceHandler is an implementation of the dcim.v1.TaskService service.
 type TaskServiceHandler interface {
-	ListTasks(context.Context, *connect.Request[v1.ListTasksRequest]) (*connect.Response[v1.ListTasksResponse], error)
-	GetTask(context.Context, *connect.Request[v1.GetTaskRequest]) (*connect.Response[v1.GetTaskResponse], error)
-	CreateTask(context.Context, *connect.Request[v1.CreateTaskRequest]) (*connect.Response[v1.CreateTaskResponse], error)
-	UpdateTask(context.Context, *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteTask(context.Context, *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[emptypb.Empty], error)
+	ListTasks(context.Context, *v1.ListTasksRequest) (*v1.ListTasksResponse, error)
+	GetTask(context.Context, *v1.GetTaskRequest) (*v1.GetTaskResponse, error)
+	CreateTask(context.Context, *v1.CreateTaskRequest) (*v1.CreateTaskResponse, error)
+	UpdateTask(context.Context, *v1.UpdateTaskRequest) (*emptypb.Empty, error)
+	DeleteTask(context.Context, *v1.DeleteTaskRequest) (*emptypb.Empty, error)
 }
 
 // NewTaskServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -163,31 +183,31 @@ type TaskServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	taskServiceMethods := v1.File_v1_task_proto.Services().ByName("TaskService").Methods()
-	taskServiceListTasksHandler := connect.NewUnaryHandler(
+	taskServiceListTasksHandler := connect.NewUnaryHandlerSimple(
 		TaskServiceListTasksProcedure,
 		svc.ListTasks,
 		connect.WithSchema(taskServiceMethods.ByName("ListTasks")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskServiceGetTaskHandler := connect.NewUnaryHandler(
+	taskServiceGetTaskHandler := connect.NewUnaryHandlerSimple(
 		TaskServiceGetTaskProcedure,
 		svc.GetTask,
 		connect.WithSchema(taskServiceMethods.ByName("GetTask")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskServiceCreateTaskHandler := connect.NewUnaryHandler(
+	taskServiceCreateTaskHandler := connect.NewUnaryHandlerSimple(
 		TaskServiceCreateTaskProcedure,
 		svc.CreateTask,
 		connect.WithSchema(taskServiceMethods.ByName("CreateTask")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskServiceUpdateTaskHandler := connect.NewUnaryHandler(
+	taskServiceUpdateTaskHandler := connect.NewUnaryHandlerSimple(
 		TaskServiceUpdateTaskProcedure,
 		svc.UpdateTask,
 		connect.WithSchema(taskServiceMethods.ByName("UpdateTask")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskServiceDeleteTaskHandler := connect.NewUnaryHandler(
+	taskServiceDeleteTaskHandler := connect.NewUnaryHandlerSimple(
 		TaskServiceDeleteTaskProcedure,
 		svc.DeleteTask,
 		connect.WithSchema(taskServiceMethods.ByName("DeleteTask")),
@@ -214,32 +234,32 @@ func NewTaskServiceHandler(svc TaskServiceHandler, opts ...connect.HandlerOption
 // UnimplementedTaskServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTaskServiceHandler struct{}
 
-func (UnimplementedTaskServiceHandler) ListTasks(context.Context, *connect.Request[v1.ListTasksRequest]) (*connect.Response[v1.ListTasksResponse], error) {
+func (UnimplementedTaskServiceHandler) ListTasks(context.Context, *v1.ListTasksRequest) (*v1.ListTasksResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskService.ListTasks is not implemented"))
 }
 
-func (UnimplementedTaskServiceHandler) GetTask(context.Context, *connect.Request[v1.GetTaskRequest]) (*connect.Response[v1.GetTaskResponse], error) {
+func (UnimplementedTaskServiceHandler) GetTask(context.Context, *v1.GetTaskRequest) (*v1.GetTaskResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskService.GetTask is not implemented"))
 }
 
-func (UnimplementedTaskServiceHandler) CreateTask(context.Context, *connect.Request[v1.CreateTaskRequest]) (*connect.Response[v1.CreateTaskResponse], error) {
+func (UnimplementedTaskServiceHandler) CreateTask(context.Context, *v1.CreateTaskRequest) (*v1.CreateTaskResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskService.CreateTask is not implemented"))
 }
 
-func (UnimplementedTaskServiceHandler) UpdateTask(context.Context, *connect.Request[v1.UpdateTaskRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedTaskServiceHandler) UpdateTask(context.Context, *v1.UpdateTaskRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskService.UpdateTask is not implemented"))
 }
 
-func (UnimplementedTaskServiceHandler) DeleteTask(context.Context, *connect.Request[v1.DeleteTaskRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedTaskServiceHandler) DeleteTask(context.Context, *v1.DeleteTaskRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskService.DeleteTask is not implemented"))
 }
 
 // TaskStepServiceClient is a client for the dcim.v1.TaskStepService service.
 type TaskStepServiceClient interface {
-	ListTaskSteps(context.Context, *connect.Request[v1.ListTaskStepsRequest]) (*connect.Response[v1.ListTaskStepsResponse], error)
-	CreateTaskStep(context.Context, *connect.Request[v1.CreateTaskStepRequest]) (*connect.Response[v1.CreateTaskStepResponse], error)
-	UpdateTaskStep(context.Context, *connect.Request[v1.UpdateTaskStepRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteTaskStep(context.Context, *connect.Request[v1.DeleteTaskStepRequest]) (*connect.Response[emptypb.Empty], error)
+	ListTaskSteps(context.Context, *v1.ListTaskStepsRequest) (*v1.ListTaskStepsResponse, error)
+	CreateTaskStep(context.Context, *v1.CreateTaskStepRequest) (*v1.CreateTaskStepResponse, error)
+	UpdateTaskStep(context.Context, *v1.UpdateTaskStepRequest) (*emptypb.Empty, error)
+	DeleteTaskStep(context.Context, *v1.DeleteTaskStepRequest) (*emptypb.Empty, error)
 }
 
 // NewTaskStepServiceClient constructs a client for the dcim.v1.TaskStepService service. By default,
@@ -289,31 +309,47 @@ type taskStepServiceClient struct {
 }
 
 // ListTaskSteps calls dcim.v1.TaskStepService.ListTaskSteps.
-func (c *taskStepServiceClient) ListTaskSteps(ctx context.Context, req *connect.Request[v1.ListTaskStepsRequest]) (*connect.Response[v1.ListTaskStepsResponse], error) {
-	return c.listTaskSteps.CallUnary(ctx, req)
+func (c *taskStepServiceClient) ListTaskSteps(ctx context.Context, req *v1.ListTaskStepsRequest) (*v1.ListTaskStepsResponse, error) {
+	response, err := c.listTaskSteps.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateTaskStep calls dcim.v1.TaskStepService.CreateTaskStep.
-func (c *taskStepServiceClient) CreateTaskStep(ctx context.Context, req *connect.Request[v1.CreateTaskStepRequest]) (*connect.Response[v1.CreateTaskStepResponse], error) {
-	return c.createTaskStep.CallUnary(ctx, req)
+func (c *taskStepServiceClient) CreateTaskStep(ctx context.Context, req *v1.CreateTaskStepRequest) (*v1.CreateTaskStepResponse, error) {
+	response, err := c.createTaskStep.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateTaskStep calls dcim.v1.TaskStepService.UpdateTaskStep.
-func (c *taskStepServiceClient) UpdateTaskStep(ctx context.Context, req *connect.Request[v1.UpdateTaskStepRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.updateTaskStep.CallUnary(ctx, req)
+func (c *taskStepServiceClient) UpdateTaskStep(ctx context.Context, req *v1.UpdateTaskStepRequest) (*emptypb.Empty, error) {
+	response, err := c.updateTaskStep.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteTaskStep calls dcim.v1.TaskStepService.DeleteTaskStep.
-func (c *taskStepServiceClient) DeleteTaskStep(ctx context.Context, req *connect.Request[v1.DeleteTaskStepRequest]) (*connect.Response[emptypb.Empty], error) {
-	return c.deleteTaskStep.CallUnary(ctx, req)
+func (c *taskStepServiceClient) DeleteTaskStep(ctx context.Context, req *v1.DeleteTaskStepRequest) (*emptypb.Empty, error) {
+	response, err := c.deleteTaskStep.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // TaskStepServiceHandler is an implementation of the dcim.v1.TaskStepService service.
 type TaskStepServiceHandler interface {
-	ListTaskSteps(context.Context, *connect.Request[v1.ListTaskStepsRequest]) (*connect.Response[v1.ListTaskStepsResponse], error)
-	CreateTaskStep(context.Context, *connect.Request[v1.CreateTaskStepRequest]) (*connect.Response[v1.CreateTaskStepResponse], error)
-	UpdateTaskStep(context.Context, *connect.Request[v1.UpdateTaskStepRequest]) (*connect.Response[emptypb.Empty], error)
-	DeleteTaskStep(context.Context, *connect.Request[v1.DeleteTaskStepRequest]) (*connect.Response[emptypb.Empty], error)
+	ListTaskSteps(context.Context, *v1.ListTaskStepsRequest) (*v1.ListTaskStepsResponse, error)
+	CreateTaskStep(context.Context, *v1.CreateTaskStepRequest) (*v1.CreateTaskStepResponse, error)
+	UpdateTaskStep(context.Context, *v1.UpdateTaskStepRequest) (*emptypb.Empty, error)
+	DeleteTaskStep(context.Context, *v1.DeleteTaskStepRequest) (*emptypb.Empty, error)
 }
 
 // NewTaskStepServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -323,25 +359,25 @@ type TaskStepServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewTaskStepServiceHandler(svc TaskStepServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	taskStepServiceMethods := v1.File_v1_task_proto.Services().ByName("TaskStepService").Methods()
-	taskStepServiceListTaskStepsHandler := connect.NewUnaryHandler(
+	taskStepServiceListTaskStepsHandler := connect.NewUnaryHandlerSimple(
 		TaskStepServiceListTaskStepsProcedure,
 		svc.ListTaskSteps,
 		connect.WithSchema(taskStepServiceMethods.ByName("ListTaskSteps")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskStepServiceCreateTaskStepHandler := connect.NewUnaryHandler(
+	taskStepServiceCreateTaskStepHandler := connect.NewUnaryHandlerSimple(
 		TaskStepServiceCreateTaskStepProcedure,
 		svc.CreateTaskStep,
 		connect.WithSchema(taskStepServiceMethods.ByName("CreateTaskStep")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskStepServiceUpdateTaskStepHandler := connect.NewUnaryHandler(
+	taskStepServiceUpdateTaskStepHandler := connect.NewUnaryHandlerSimple(
 		TaskStepServiceUpdateTaskStepProcedure,
 		svc.UpdateTaskStep,
 		connect.WithSchema(taskStepServiceMethods.ByName("UpdateTaskStep")),
 		connect.WithHandlerOptions(opts...),
 	)
-	taskStepServiceDeleteTaskStepHandler := connect.NewUnaryHandler(
+	taskStepServiceDeleteTaskStepHandler := connect.NewUnaryHandlerSimple(
 		TaskStepServiceDeleteTaskStepProcedure,
 		svc.DeleteTaskStep,
 		connect.WithSchema(taskStepServiceMethods.ByName("DeleteTaskStep")),
@@ -366,18 +402,18 @@ func NewTaskStepServiceHandler(svc TaskStepServiceHandler, opts ...connect.Handl
 // UnimplementedTaskStepServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTaskStepServiceHandler struct{}
 
-func (UnimplementedTaskStepServiceHandler) ListTaskSteps(context.Context, *connect.Request[v1.ListTaskStepsRequest]) (*connect.Response[v1.ListTaskStepsResponse], error) {
+func (UnimplementedTaskStepServiceHandler) ListTaskSteps(context.Context, *v1.ListTaskStepsRequest) (*v1.ListTaskStepsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskStepService.ListTaskSteps is not implemented"))
 }
 
-func (UnimplementedTaskStepServiceHandler) CreateTaskStep(context.Context, *connect.Request[v1.CreateTaskStepRequest]) (*connect.Response[v1.CreateTaskStepResponse], error) {
+func (UnimplementedTaskStepServiceHandler) CreateTaskStep(context.Context, *v1.CreateTaskStepRequest) (*v1.CreateTaskStepResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskStepService.CreateTaskStep is not implemented"))
 }
 
-func (UnimplementedTaskStepServiceHandler) UpdateTaskStep(context.Context, *connect.Request[v1.UpdateTaskStepRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedTaskStepServiceHandler) UpdateTaskStep(context.Context, *v1.UpdateTaskStepRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskStepService.UpdateTaskStep is not implemented"))
 }
 
-func (UnimplementedTaskStepServiceHandler) DeleteTaskStep(context.Context, *connect.Request[v1.DeleteTaskStepRequest]) (*connect.Response[emptypb.Empty], error) {
+func (UnimplementedTaskStepServiceHandler) DeleteTaskStep(context.Context, *v1.DeleteTaskStepRequest) (*emptypb.Empty, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.TaskStepService.DeleteTaskStep is not implemented"))
 }

--- a/dcim-api/pkg/proto/gen/v1/dcimv1connect/user.connect.go
+++ b/dcim-api/pkg/proto/gen/v1/dcimv1connect/user.connect.go
@@ -42,12 +42,12 @@ const (
 
 // UserServiceClient is a client for the dcim.v1.UserService service.
 type UserServiceClient interface {
-	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
+	ListUsers(context.Context, *v1.ListUsersRequest) (*v1.ListUsersResponse, error)
 	// GetCurrentUser resolves the authenticated caller onto their directory entry.
 	// The caller is identified by the JWT subject, which is matched against
 	// dcim.users.external_ref; the returned id is the internal user id that
 	// tasks are assigned to.
-	GetCurrentUser(context.Context, *connect.Request[v1.GetCurrentUserRequest]) (*connect.Response[v1.GetCurrentUserResponse], error)
+	GetCurrentUser(context.Context, *v1.GetCurrentUserRequest) (*v1.GetCurrentUserResponse, error)
 }
 
 // NewUserServiceClient constructs a client for the dcim.v1.UserService service. By default, it uses
@@ -83,23 +83,31 @@ type userServiceClient struct {
 }
 
 // ListUsers calls dcim.v1.UserService.ListUsers.
-func (c *userServiceClient) ListUsers(ctx context.Context, req *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error) {
-	return c.listUsers.CallUnary(ctx, req)
+func (c *userServiceClient) ListUsers(ctx context.Context, req *v1.ListUsersRequest) (*v1.ListUsersResponse, error) {
+	response, err := c.listUsers.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetCurrentUser calls dcim.v1.UserService.GetCurrentUser.
-func (c *userServiceClient) GetCurrentUser(ctx context.Context, req *connect.Request[v1.GetCurrentUserRequest]) (*connect.Response[v1.GetCurrentUserResponse], error) {
-	return c.getCurrentUser.CallUnary(ctx, req)
+func (c *userServiceClient) GetCurrentUser(ctx context.Context, req *v1.GetCurrentUserRequest) (*v1.GetCurrentUserResponse, error) {
+	response, err := c.getCurrentUser.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UserServiceHandler is an implementation of the dcim.v1.UserService service.
 type UserServiceHandler interface {
-	ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error)
+	ListUsers(context.Context, *v1.ListUsersRequest) (*v1.ListUsersResponse, error)
 	// GetCurrentUser resolves the authenticated caller onto their directory entry.
 	// The caller is identified by the JWT subject, which is matched against
 	// dcim.users.external_ref; the returned id is the internal user id that
 	// tasks are assigned to.
-	GetCurrentUser(context.Context, *connect.Request[v1.GetCurrentUserRequest]) (*connect.Response[v1.GetCurrentUserResponse], error)
+	GetCurrentUser(context.Context, *v1.GetCurrentUserRequest) (*v1.GetCurrentUserResponse, error)
 }
 
 // NewUserServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -109,13 +117,13 @@ type UserServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewUserServiceHandler(svc UserServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	userServiceMethods := v1.File_v1_user_proto.Services().ByName("UserService").Methods()
-	userServiceListUsersHandler := connect.NewUnaryHandler(
+	userServiceListUsersHandler := connect.NewUnaryHandlerSimple(
 		UserServiceListUsersProcedure,
 		svc.ListUsers,
 		connect.WithSchema(userServiceMethods.ByName("ListUsers")),
 		connect.WithHandlerOptions(opts...),
 	)
-	userServiceGetCurrentUserHandler := connect.NewUnaryHandler(
+	userServiceGetCurrentUserHandler := connect.NewUnaryHandlerSimple(
 		UserServiceGetCurrentUserProcedure,
 		svc.GetCurrentUser,
 		connect.WithSchema(userServiceMethods.ByName("GetCurrentUser")),
@@ -136,10 +144,10 @@ func NewUserServiceHandler(svc UserServiceHandler, opts ...connect.HandlerOption
 // UnimplementedUserServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedUserServiceHandler struct{}
 
-func (UnimplementedUserServiceHandler) ListUsers(context.Context, *connect.Request[v1.ListUsersRequest]) (*connect.Response[v1.ListUsersResponse], error) {
+func (UnimplementedUserServiceHandler) ListUsers(context.Context, *v1.ListUsersRequest) (*v1.ListUsersResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.UserService.ListUsers is not implemented"))
 }
 
-func (UnimplementedUserServiceHandler) GetCurrentUser(context.Context, *connect.Request[v1.GetCurrentUserRequest]) (*connect.Response[v1.GetCurrentUserResponse], error) {
+func (UnimplementedUserServiceHandler) GetCurrentUser(context.Context, *v1.GetCurrentUserRequest) (*v1.GetCurrentUserResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dcim.v1.UserService.GetCurrentUser is not implemented"))
 }

--- a/functl/pkg/cli/apikey.go
+++ b/functl/pkg/cli/apikey.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -27,12 +25,12 @@ func (c *APIKeyListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.APIKeys().ListAPIKeys(context.Background(), connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build()))
+	resp, err := apiClient.APIKeys().ListAPIKeys(context.Background(), organizationv1.ListAPIKeysRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list API keys: %w", err)
 	}
 
-	apiKeys := resp.Msg.GetApiKeys()
+	apiKeys := resp.GetApiKeys()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(apiKeys)
@@ -93,19 +91,19 @@ func (c *APIKeyCreateCmd) Run(ctx *Context) error {
 		ExpiresIn: c.ExpiresIn,
 	}.Build()
 
-	resp, err := apiClient.APIKeys().CreateAPIKey(context.Background(), connect.NewRequest(req))
+	resp, err := apiClient.APIKeys().CreateAPIKey(context.Background(), req)
 	if err != nil {
 		return fmt.Errorf("failed to create API key: %w", err)
 	}
 
 	if ctx.Output == OutputJSON {
-		return PrintJSON(resp.Msg)
+		return PrintJSON(resp)
 	}
 
 	fmt.Println("API key created successfully!")
 	fmt.Println()
-	fmt.Printf("ID:    %s\n", resp.Msg.GetId())
-	fmt.Printf("Token: %s\n", resp.Msg.GetToken())
+	fmt.Printf("ID:    %s\n", resp.GetId())
+	fmt.Printf("Token: %s\n", resp.GetToken())
 	fmt.Println()
 	fmt.Println("IMPORTANT: Copy this token now. You will not be able to see it again.")
 	return nil
@@ -123,9 +121,9 @@ func (c *APIKeyRevokeCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	_, err = apiClient.APIKeys().RevokeAPIKey(context.Background(), connect.NewRequest(organizationv1.RevokeAPIKeyRequest_builder{
+	_, err = apiClient.APIKeys().RevokeAPIKey(context.Background(), organizationv1.RevokeAPIKeyRequest_builder{
 		ApiKeyId: c.APIKeyID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to revoke API key: %w", err)
 	}
@@ -146,9 +144,9 @@ func (c *APIKeyDeleteCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	_, err = apiClient.APIKeys().DeleteAPIKey(context.Background(), connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
+	_, err = apiClient.APIKeys().DeleteAPIKey(context.Background(), organizationv1.DeleteAPIKeyRequest_builder{
 		ApiKeyId: c.APIKeyID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to delete API key: %w", err)
 	}

--- a/functl/pkg/cli/auth.go
+++ b/functl/pkg/cli/auth.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"connectrpc.com/connect"
-
 	authnv1 "github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1"
 	"github.com/fundament-oss/fundament/functl/pkg/client"
 	"github.com/fundament-oss/fundament/functl/pkg/config"
@@ -52,7 +50,7 @@ func (c *AuthLoginCmd) Run(ctx *Context) error {
 	}
 
 	testClient := client.New(apiKey, cfg.APIEndpoint, cfg.AuthnURL, "")
-	resp, err := testClient.Authn().GetUserInfo(context.Background(), connect.NewRequest(authnv1.GetUserInfoRequest_builder{}.Build()))
+	resp, err := testClient.Authn().GetUserInfo(context.Background(), authnv1.GetUserInfoRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("invalid API key: %w", err)
 	}
@@ -65,7 +63,7 @@ func (c *AuthLoginCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	fmt.Printf("Logged in as %s\n", resp.Msg.GetUser().GetName())
+	fmt.Printf("Logged in as %s\n", resp.GetUser().GetName())
 	return nil
 }
 
@@ -88,14 +86,14 @@ func (c *AuthStatusCmd) Run(ctx *Context) error {
 	}
 
 	apiClient := client.New(creds.APIKey, cfg.APIEndpoint, cfg.AuthnURL, "")
-	resp, err := apiClient.Authn().GetUserInfo(context.Background(), connect.NewRequest(authnv1.GetUserInfoRequest_builder{}.Build()))
+	resp, err := apiClient.Authn().GetUserInfo(context.Background(), authnv1.GetUserInfoRequest_builder{}.Build())
 	if err != nil {
 		fmt.Println("Authentication failed: credentials may be invalid or expired")
 		fmt.Println("Run 'functl auth login' to re-authenticate")
 		return nil
 	}
 
-	user := resp.Msg.GetUser()
+	user := resp.GetUser()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(map[string]any{

--- a/functl/pkg/cli/cluster.go
+++ b/functl/pkg/cli/cluster.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -27,12 +25,12 @@ func (c *ClusterListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Clusters().ListClusters(context.Background(), connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build()))
+	resp, err := apiClient.Clusters().ListClusters(context.Background(), organizationv1.ListClustersRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)
 	}
 
-	clusters := resp.Msg.GetClusters()
+	clusters := resp.GetClusters()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(clusters)
@@ -68,14 +66,14 @@ func (c *ClusterGetCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Clusters().GetCluster(context.Background(), connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	resp, err := apiClient.Clusters().GetCluster(context.Background(), organizationv1.GetClusterRequest_builder{
 		ClusterId: c.ClusterID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	cluster := resp.Msg.GetCluster()
+	cluster := resp.GetCluster()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(cluster)

--- a/functl/pkg/cli/cluster_kubeconfig.go
+++ b/functl/pkg/cli/cluster_kubeconfig.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -21,13 +19,13 @@ func (c *ClusterKubeconfigCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Clusters().GetKubeconfig(context.Background(), connect.NewRequest(organizationv1.GetKubeconfigRequest_builder{
+	resp, err := apiClient.Clusters().GetKubeconfig(context.Background(), organizationv1.GetKubeconfigRequest_builder{
 		ClusterId: c.ClusterID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 
-	fmt.Print(resp.Msg.GetKubeconfigContent())
+	fmt.Print(resp.GetKubeconfigContent())
 	return nil
 }

--- a/functl/pkg/cli/namespace.go
+++ b/functl/pkg/cli/namespace.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -32,14 +30,14 @@ func (c *NamespaceListCmd) Run(ctx *Context) error {
 	}
 
 	if c.Cluster != "" {
-		resp, err := apiClient.Namespaces().ListClusterNamespaces(context.Background(), connect.NewRequest(organizationv1.ListClusterNamespacesRequest_builder{
+		resp, err := apiClient.Namespaces().ListClusterNamespaces(context.Background(), organizationv1.ListClusterNamespacesRequest_builder{
 			ClusterId: c.Cluster,
-		}.Build()))
+		}.Build())
 		if err != nil {
 			return fmt.Errorf("failed to list namespaces: %w", err)
 		}
 
-		namespaces := resp.Msg.GetNamespaces()
+		namespaces := resp.GetNamespaces()
 
 		if ctx.Output == OutputJSON {
 			return PrintJSON(namespaces)
@@ -69,14 +67,14 @@ func (c *NamespaceListCmd) Run(ctx *Context) error {
 	}
 
 	// List by project
-	resp, err := apiClient.Namespaces().ListProjectNamespaces(context.Background(), connect.NewRequest(organizationv1.ListProjectNamespacesRequest_builder{
+	resp, err := apiClient.Namespaces().ListProjectNamespaces(context.Background(), organizationv1.ListProjectNamespacesRequest_builder{
 		ProjectId: c.Project,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	namespaces := resp.Msg.GetNamespaces()
+	namespaces := resp.GetNamespaces()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(namespaces)
@@ -117,15 +115,15 @@ func (c *NamespaceCreateCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Namespaces().CreateNamespace(context.Background(), connect.NewRequest(organizationv1.CreateNamespaceRequest_builder{
+	resp, err := apiClient.Namespaces().CreateNamespace(context.Background(), organizationv1.CreateNamespaceRequest_builder{
 		ProjectId: c.Project,
 		Name:      c.Name,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	namespaceID := resp.Msg.GetNamespaceId()
+	namespaceID := resp.GetNamespaceId()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(map[string]string{
@@ -151,9 +149,9 @@ func (c *NamespaceDeleteCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	_, err = apiClient.Namespaces().DeleteNamespace(context.Background(), connect.NewRequest(organizationv1.DeleteNamespaceRequest_builder{
+	_, err = apiClient.Namespaces().DeleteNamespace(context.Background(), organizationv1.DeleteNamespaceRequest_builder{
 		NamespaceId: c.NamespaceID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to delete namespace: %w", err)
 	}

--- a/functl/pkg/cli/org.go
+++ b/functl/pkg/cli/org.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	"github.com/fundament-oss/fundament/functl/pkg/config"
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
@@ -28,12 +26,12 @@ func (c *OrgListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Organizations().ListOrganizations(context.Background(), connect.NewRequest(organizationv1.ListOrganizationsRequest_builder{}.Build()))
+	resp, err := apiClient.Organizations().ListOrganizations(context.Background(), organizationv1.ListOrganizationsRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list organizations: %w", err)
 	}
 
-	orgs := resp.Msg.GetOrganizations()
+	orgs := resp.GetOrganizations()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(orgs)
@@ -73,13 +71,13 @@ func (c *OrgSetCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Organizations().ListOrganizations(context.Background(), connect.NewRequest(organizationv1.ListOrganizationsRequest_builder{}.Build()))
+	resp, err := apiClient.Organizations().ListOrganizations(context.Background(), organizationv1.ListOrganizationsRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list organizations: %w", err)
 	}
 
 	var match *organizationv1.Organization
-	for _, org := range resp.Msg.GetOrganizations() {
+	for _, org := range resp.GetOrganizations() {
 		if org.GetId() == c.OrgID {
 			match = org
 			break

--- a/functl/pkg/cli/org_member.go
+++ b/functl/pkg/cli/org_member.go
@@ -32,12 +32,12 @@ func (c *OrgMemberListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Members().ListMembers(context.Background(), connect.NewRequest(organizationv1.ListMembersRequest_builder{}.Build()))
+	resp, err := apiClient.Members().ListMembers(context.Background(), organizationv1.ListMembersRequest_builder{}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list members: %w", err)
 	}
 
-	members := resp.Msg.GetMembers()
+	members := resp.GetMembers()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(members)
@@ -80,17 +80,17 @@ func (c *OrgMemberInviteCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Invites().InviteMember(context.Background(), connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	resp, err := apiClient.Invites().InviteMember(context.Background(), organizationv1.InviteMemberRequest_builder{
 		Email:      c.Email,
 		Permission: c.Permission,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to invite member: %w", err)
 	}
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(map[string]string{
-			"invitation_id": resp.Msg.GetInvitationId(),
+			"invitation_id": resp.GetInvitationId(),
 		})
 	}
 
@@ -116,10 +116,10 @@ func (c *OrgMemberUpdatePermissionCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	_, err = apiClient.Members().UpdateMemberPermission(context.Background(), connect.NewRequest(organizationv1.UpdateMemberPermissionRequest_builder{
+	_, err = apiClient.Members().UpdateMemberPermission(context.Background(), organizationv1.UpdateMemberPermissionRequest_builder{
 		Id:         member.GetId(),
 		Permission: c.Permission,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to update member permission: %w", err)
 	}
@@ -166,9 +166,9 @@ func (c *OrgMemberRemoveCmd) Run(ctx *Context) error {
 		}
 	}
 
-	_, err = apiClient.Members().DeleteMember(context.Background(), connect.NewRequest(organizationv1.DeleteMemberRequest_builder{
+	_, err = apiClient.Members().DeleteMember(context.Background(), organizationv1.DeleteMemberRequest_builder{
 		Id: member.GetId(),
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to remove member: %w", err)
 	}
@@ -185,9 +185,9 @@ func (c *OrgMemberRemoveCmd) Run(ctx *Context) error {
 
 // findOrgMember resolves an org member from a user ID.
 func findOrgMember(apiClient *client.Client, userID string) (*organizationv1.Member, error) {
-	resp, err := apiClient.Members().GetMember(context.Background(), connect.NewRequest(organizationv1.GetMemberRequest_builder{
+	resp, err := apiClient.Members().GetMember(context.Background(), organizationv1.GetMemberRequest_builder{
 		UserId: proto.String(userID),
-	}.Build()))
+	}.Build())
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return nil, fmt.Errorf("user %s is not a member of this organization", userID)
@@ -195,5 +195,5 @@ func findOrgMember(apiClient *client.Client, userID string) (*organizationv1.Mem
 		return nil, fmt.Errorf("failed to get member: %w", err)
 	}
 
-	return resp.Msg.GetMember(), nil
+	return resp.GetMember(), nil
 }

--- a/functl/pkg/cli/project.go
+++ b/functl/pkg/cli/project.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -31,12 +29,12 @@ func (c *ProjectListCmd) Run(ctx *Context) error {
 	}
 
 	listReq := organizationv1.ListProjectsRequest_builder{ClusterId: c.Cluster}.Build()
-	resp, err := apiClient.Projects().ListProjects(context.Background(), connect.NewRequest(listReq))
+	resp, err := apiClient.Projects().ListProjects(context.Background(), listReq)
 	if err != nil {
 		return fmt.Errorf("failed to list projects: %w", err)
 	}
 
-	projects := resp.Msg.GetProjects()
+	projects := resp.GetProjects()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(projects)
@@ -77,14 +75,14 @@ func (c *ProjectGetCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Projects().GetProject(context.Background(), connect.NewRequest(organizationv1.GetProjectRequest_builder{
+	resp, err := apiClient.Projects().GetProject(context.Background(), organizationv1.GetProjectRequest_builder{
 		ProjectId: c.ProjectID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to get project: %w", err)
 	}
 
-	project := resp.Msg.GetProject()
+	project := resp.GetProject()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(project)
@@ -128,12 +126,12 @@ func (c *ProjectCreateCmd) Run(ctx *Context) error {
 		Alias:     &alias,
 	}.Build()
 
-	resp, err := apiClient.Projects().CreateProject(context.Background(), connect.NewRequest(req))
+	resp, err := apiClient.Projects().CreateProject(context.Background(), req)
 	if err != nil {
 		return fmt.Errorf("failed to create project: %w", err)
 	}
 
-	projectID := resp.Msg.GetProjectId()
+	projectID := resp.GetProjectId()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(map[string]string{
@@ -166,7 +164,7 @@ func (c *ProjectUpdateCmd) Run(ctx *Context) error {
 		Alias:     &alias,
 	}.Build()
 
-	_, err = apiClient.Projects().UpdateProject(context.Background(), connect.NewRequest(req))
+	_, err = apiClient.Projects().UpdateProject(context.Background(), req)
 	if err != nil {
 		return fmt.Errorf("failed to update project: %w", err)
 	}

--- a/functl/pkg/cli/project_member.go
+++ b/functl/pkg/cli/project_member.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"connectrpc.com/connect"
-
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 	"github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1/organizationv1connect"
 )
@@ -33,14 +31,14 @@ func (c *ProjectMemberListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Projects().ListProjectMembers(context.Background(), connect.NewRequest(organizationv1.ListProjectMembersRequest_builder{
+	resp, err := apiClient.Projects().ListProjectMembers(context.Background(), organizationv1.ListProjectMembersRequest_builder{
 		ProjectId: c.ProjectID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list project members: %w", err)
 	}
 
-	members := resp.Msg.GetMembers()
+	members := resp.GetMembers()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(members)
@@ -87,16 +85,16 @@ func (c *ProjectMemberAddCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	resp, err := apiClient.Projects().AddProjectMember(context.Background(), connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
+	resp, err := apiClient.Projects().AddProjectMember(context.Background(), organizationv1.AddProjectMemberRequest_builder{
 		ProjectId: c.ProjectID,
 		UserId:    c.UserID,
 		Role:      role,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to add project member: %w", err)
 	}
 
-	memberID := resp.Msg.GetMemberId()
+	memberID := resp.GetMemberId()
 
 	if ctx.Output == OutputJSON {
 		return PrintJSON(map[string]string{
@@ -137,10 +135,10 @@ func (c *ProjectMemberUpdateRoleCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	_, err = projectsClient.UpdateProjectMemberRole(context.Background(), connect.NewRequest(organizationv1.UpdateProjectMemberRoleRequest_builder{
+	_, err = projectsClient.UpdateProjectMemberRole(context.Background(), organizationv1.UpdateProjectMemberRoleRequest_builder{
 		MemberId: member.GetId(),
 		Role:     role,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to update project member role: %w", err)
 	}
@@ -191,9 +189,9 @@ func (c *ProjectMemberRemoveCmd) Run(ctx *Context) error {
 		}
 	}
 
-	_, err = projectsClient.RemoveProjectMember(context.Background(), connect.NewRequest(organizationv1.RemoveProjectMemberRequest_builder{
+	_, err = projectsClient.RemoveProjectMember(context.Background(), organizationv1.RemoveProjectMemberRequest_builder{
 		MemberId: member.GetId(),
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to remove project member: %w", err)
 	}
@@ -211,14 +209,14 @@ func (c *ProjectMemberRemoveCmd) Run(ctx *Context) error {
 
 // findProjectMember resolves a project member from a project ID and user ID.
 func findProjectMember(ctx context.Context, client organizationv1connect.ProjectServiceClient, projectID, userID string) (*organizationv1.ProjectMember, error) {
-	resp, err := client.ListProjectMembers(ctx, connect.NewRequest(organizationv1.ListProjectMembersRequest_builder{
+	resp, err := client.ListProjectMembers(ctx, organizationv1.ListProjectMembersRequest_builder{
 		ProjectId: projectID,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list project members: %w", err)
 	}
 
-	for _, member := range resp.Msg.GetMembers() {
+	for _, member := range resp.GetMembers() {
 		if member.GetUserId() == userID {
 			return member, nil
 		}

--- a/functl/pkg/client/client.go
+++ b/functl/pkg/client/client.go
@@ -63,17 +63,20 @@ func (c *Client) ensureToken(ctx context.Context) (string, error) {
 		return c.jwt, nil
 	}
 
-	// Exchange API key for JWT
-	req := connect.NewRequest(&authnv1.ExchangeTokenRequest{})
-	req.Header().Set("Authorization", "Bearer "+c.apiKey)
+	// Exchange API key for JWT. The client context created here must only be
+	// used for the nested ExchangeToken call and never flow into next() when
+	// ensureToken runs inside an interceptor: connect prohibits changing call
+	// info mid-flight and fails such requests.
+	ctx, callInfo := connect.NewClientContext(ctx)
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+c.apiKey)
 
-	resp, err := c.tokenClient.ExchangeToken(ctx, req)
+	resp, err := c.tokenClient.ExchangeToken(ctx, &authnv1.ExchangeTokenRequest{})
 	if err != nil {
 		return "", fmt.Errorf("failed to exchange API key for token: %w", err)
 	}
 
-	c.jwt = resp.Msg.GetAccessToken()
-	c.expiry = time.Now().Add(time.Duration(resp.Msg.GetExpiresIn()) * time.Second)
+	c.jwt = resp.GetAccessToken()
+	c.expiry = time.Now().Add(time.Duration(resp.GetExpiresIn()) * time.Second)
 
 	return c.jwt, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
-	connectrpc.com/connect v1.19.1
+	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/validate v0.6.0
 	github.com/alecthomas/kong v1.14.0
@@ -202,8 +202,8 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260727163830-6c54dddc4772 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720155508-bb71a54f79dc // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ buf.build/go/protovalidate v1.1.3 h1:m2GVEgQWd7rk+vIoAZ+f0ygGjvQTuqPQapBBdcpWVPE
 buf.build/go/protovalidate v1.1.3/go.mod h1:9XIuohWz+kj+9JVn3WQneHA5LZP50mjvneZMnbLkiIE=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
-connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
-connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 connectrpc.com/grpcreflect v1.3.0 h1:Y4V+ACf8/vOb1XOc251Qun7jMB75gCUNw6llvB9csXc=
 connectrpc.com/grpcreflect v1.3.0/go.mod h1:nfloOtCS8VUQOQ1+GTdFzVg2CJo4ZGaat8JIovCtDYs=
 connectrpc.com/validate v0.6.0 h1:DcrgDKt2ZScrUs/d/mh9itD2yeEa0UbBBa+i0mwzx+4=
@@ -606,10 +606,10 @@ gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/api v0.0.0-20260727163830-6c54dddc4772 h1:4namukbyF7JY83aWHQwi9J5ugNTnDReLJ9ZcpqOpRB4=
+google.golang.org/genproto/googleapis/api v0.0.0-20260727163830-6c54dddc4772/go.mod h1:1brfde68Npq6+WA75c1EHWPijZEG1kMus61ygPZfn4A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260720155508-bb71a54f79dc h1:3TtNq/QbJNrSY1nVdjcikfBw6ujnaNbdrd88wNr1OW4=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260720155508-bb71a54f79dc/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ opentofu = "1.11.3"
 # Protobuf
 "aqua:bufbuild/buf" = "1.66.0"
 "go:google.golang.org/protobuf/cmd/protoc-gen-go" = "1.36.11"
-"go:connectrpc.com/connect/cmd/protoc-gen-connect-go" = "1.19.1"
+"go:connectrpc.com/connect/cmd/protoc-gen-connect-go" = "1.20.0"
 
 # Go
 go = "1.26.5"

--- a/organization-api/pkg/organization/apikey_create.go
+++ b/organization-api/pkg/organization/apikey_create.go
@@ -20,8 +20,8 @@ import (
 
 func (s *Server) CreateAPIKey(
 	ctx context.Context,
-	req *connect.Request[organizationv1.CreateAPIKeyRequest],
-) (*connect.Response[organizationv1.CreateAPIKeyResponse], error) {
+	req *organizationv1.CreateAPIKeyRequest,
+) (*organizationv1.CreateAPIKeyResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -43,8 +43,8 @@ func (s *Server) CreateAPIKey(
 
 	expires := pgtype.Timestamptz{Valid: false}
 
-	if req.Msg.GetExpiresIn() != "" {
-		expiresIn, err := time.ParseDuration(req.Msg.GetExpiresIn())
+	if req.GetExpiresIn() != "" {
+		expiresIn, err := time.ParseDuration(req.GetExpiresIn())
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to parse expires_in: %w", err))
 		}
@@ -60,7 +60,7 @@ func (s *Server) CreateAPIKey(
 	params := db.APIKeyCreateParams{
 		OrganizationID: organizationID,
 		UserID:         userID,
-		Name:           req.Msg.GetName(),
+		Name:           req.GetName(),
 		TokenHash:      hash,
 		TokenPrefix:    prefix,
 		Expires:        expires,
@@ -81,12 +81,12 @@ func (s *Server) CreateAPIKey(
 		"api_key_id", id,
 		"organization_id", organizationID,
 		"user_id", userID,
-		"name", req.Msg.GetName(),
+		"name", req.GetName(),
 	)
 
-	return connect.NewResponse(organizationv1.CreateAPIKeyResponse_builder{
+	return organizationv1.CreateAPIKeyResponse_builder{
 		Id:          id.String(),
 		Token:       token,
 		TokenPrefix: prefix,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/apikey_create_test.go
+++ b/organization-api/pkg/organization/apikey_create_test.go
@@ -23,10 +23,10 @@ func Test_APIKey_Create_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.CreateAPIKey(context.Background(), connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	_, err := client.CreateAPIKey(context.Background(), organizationv1.CreateAPIKeyRequest_builder{
 		Name:      "my-first-key",
 		ExpiresIn: "",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -89,31 +89,33 @@ func Test_APIKey_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			createReq := connect.NewRequest(tc.CreateRequest)
-			createReq.Header().Set("Authorization", "Bearer "+token)
-			createReq.Header().Set("Fun-Organization", orgID.String())
+			createReq := tc.CreateRequest
+			createCtx, createCallInfo := connect.NewClientContext(context.Background())
+			createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			res, err := client.CreateAPIKey(context.Background(), createReq)
+			res, err := client.CreateAPIKey(createCtx, createReq)
 			require.NoError(t, err)
 
-			assert.True(t, strings.HasPrefix(res.Msg.GetToken(), "fun_"))
-			assert.Equal(t, 40, len(res.Msg.GetToken()))
-			assert.Equal(t, 8, len(res.Msg.GetTokenPrefix()))
+			assert.True(t, strings.HasPrefix(res.GetToken(), "fun_"))
+			assert.Equal(t, 40, len(res.GetToken()))
+			assert.Equal(t, 8, len(res.GetTokenPrefix()))
 
-			getReq := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
-				ApiKeyId: res.Msg.GetId(),
-			}.Build())
-			getReq.Header().Set("Authorization", "Bearer "+token)
-			getReq.Header().Set("Fun-Organization", orgID.String())
+			getReq := organizationv1.GetAPIKeyRequest_builder{
+				ApiKeyId: res.GetId(),
+			}.Build()
+			getCtx, getCallInfo := connect.NewClientContext(context.Background())
+			getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			getRes, err := client.GetAPIKey(context.Background(), getReq)
+			getRes, err := client.GetAPIKey(getCtx, getReq)
 			require.NoError(t, err)
 
 			if tc.WantExpiresAt == nil {
-				assert.False(t, getRes.Msg.GetApiKey().HasExpires())
+				assert.False(t, getRes.GetApiKey().HasExpires())
 			} else {
-				require.True(t, getRes.Msg.GetApiKey().HasExpires())
-				assert.Equal(t, *tc.WantExpiresAt, getRes.Msg.GetApiKey().GetExpires().AsTime())
+				require.True(t, getRes.GetApiKey().HasExpires())
+				assert.Equal(t, *tc.WantExpiresAt, getRes.GetApiKey().GetExpires().AsTime())
 			}
 		})
 	}
@@ -137,19 +139,20 @@ func Test_APIKey_Create_DuplicateName(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := func() *connect.Request[organizationv1.CreateAPIKeyRequest] {
-		req := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := func() *organizationv1.CreateAPIKeyRequest {
+		return organizationv1.CreateAPIKeyRequest_builder{
 			Name: "duplicate-key",
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
-		return req
+		}.Build()
 	}
 
-	_, err := client.CreateAPIKey(context.Background(), createReq())
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+
+	_, err := client.CreateAPIKey(ctx, createReq())
 	require.NoError(t, err)
 
-	_, err = client.CreateAPIKey(context.Background(), createReq())
+	_, err = client.CreateAPIKey(ctx, createReq())
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeAlreadyExists, connectErr.Code())

--- a/organization-api/pkg/organization/apikey_delete.go
+++ b/organization-api/pkg/organization/apikey_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteAPIKey(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteAPIKeyRequest],
-) (*connect.Response[organizationv1.DeleteAPIKeyResponse], error) {
-	apiKeyID := uuid.MustParse(req.Msg.GetApiKeyId())
+	req *organizationv1.DeleteAPIKeyRequest,
+) (*organizationv1.DeleteAPIKeyResponse, error) {
+	apiKeyID := uuid.MustParse(req.GetApiKeyId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.ApiKey(apiKeyID)); err != nil {
 		return nil, err
@@ -38,5 +38,5 @@ func (s *Server) DeleteAPIKey(
 
 	s.logger.InfoContext(ctx, "api key deleted", "api_key_id", apiKeyID)
 
-	return connect.NewResponse(organizationv1.DeleteAPIKeyResponse_builder{}.Build()), nil
+	return organizationv1.DeleteAPIKeyResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/apikey_delete_test.go
+++ b/organization-api/pkg/organization/apikey_delete_test.go
@@ -18,9 +18,9 @@ func Test_APIKey_Delete_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
+	req := organizationv1.DeleteAPIKeyRequest_builder{
 		ApiKeyId: uuid.New().String(),
-	}.Build())
+	}.Build()
 
 	_, err := client.DeleteAPIKey(context.Background(), req)
 
@@ -47,41 +47,45 @@ func Test_APIKey_Delete(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "my-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	deleteReq.Header().Set("Authorization", "Bearer "+token)
-	deleteReq.Header().Set("Fun-Organization", orgID.String())
+	deleteReq := organizationv1.DeleteAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	deleteCtx, deleteCallInfo := connect.NewClientContext(context.Background())
+	deleteCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	deleteCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.DeleteAPIKey(context.Background(), deleteReq)
+	_, err = client.DeleteAPIKey(deleteCtx, deleteReq)
 	require.NoError(t, err)
 
 	// Key should not appear in list after deletion.
-	listReq := connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListAPIKeysRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListAPIKeys(context.Background(), listReq)
+	listRes, err := client.ListAPIKeys(listCtx, listReq)
 	require.NoError(t, err)
-	assert.Empty(t, listRes.Msg.GetApiKeys())
+	assert.Empty(t, listRes.GetApiKeys())
 
 	// Get should return NotFound after deletion.
-	getReq := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.GetAPIKey(context.Background(), getReq)
+	_, err = client.GetAPIKey(getCtx, getReq)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
@@ -105,13 +109,14 @@ func Test_APIKey_Delete_NotFound(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
+	req := organizationv1.DeleteAPIKeyRequest_builder{
 		ApiKeyId: "00000000-0000-0000-0000-000000000000",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.DeleteAPIKey(context.Background(), req)
+	_, err := client.DeleteAPIKey(ctx, req)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
@@ -142,22 +147,24 @@ func Test_APIKey_Delete_OtherUser_NotFound(t *testing.T) {
 	tokenB := env.createAuthnToken(t, userBID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "user-a-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+tokenA)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenA)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	deleteReq.Header().Set("Authorization", "Bearer "+tokenB)
-	deleteReq.Header().Set("Fun-Organization", orgID.String())
+	deleteReq := organizationv1.DeleteAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	deleteCtx, deleteCallInfo := connect.NewClientContext(context.Background())
+	deleteCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenB)
+	deleteCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.DeleteAPIKey(context.Background(), deleteReq)
+	_, err = client.DeleteAPIKey(deleteCtx, deleteReq)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())

--- a/organization-api/pkg/organization/apikey_get.go
+++ b/organization-api/pkg/organization/apikey_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetAPIKey(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetAPIKeyRequest],
-) (*connect.Response[organizationv1.GetAPIKeyResponse], error) {
-	apiKeyID := uuid.MustParse(req.Msg.GetApiKeyId())
+	req *organizationv1.GetAPIKeyRequest,
+) (*organizationv1.GetAPIKeyResponse, error) {
+	apiKeyID := uuid.MustParse(req.GetApiKeyId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.ApiKey(apiKeyID)); err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func (s *Server) GetAPIKey(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get api key: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetAPIKeyResponse_builder{
+	return organizationv1.GetAPIKeyResponse_builder{
 		ApiKey: apiKeyFromGetRow(&key),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/apikey_get_test.go
+++ b/organization-api/pkg/organization/apikey_get_test.go
@@ -19,9 +19,9 @@ func Test_APIKey_Get_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
+	req := organizationv1.GetAPIKeyRequest_builder{
 		ApiKeyId: uuid.New().String(),
-	}.Build())
+	}.Build()
 
 	_, err := client.GetAPIKey(context.Background(), req)
 
@@ -48,25 +48,27 @@ func Test_APIKey_Get(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "my-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := client.GetAPIKey(context.Background(), getReq)
+	getRes, err := client.GetAPIKey(getCtx, getReq)
 	require.NoError(t, err)
 
-	key := getRes.Msg.GetApiKey()
+	key := getRes.GetApiKey()
 	assert.Equal(t, "my-key", key.GetName())
 	assert.True(t, key.HasCreated())
 	assert.Equal(t, apitoken.PrefixDisplayLength, len(key.GetTokenPrefix()))
@@ -90,13 +92,14 @@ func Test_APIKey_Get_NotFound(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
+	req := organizationv1.GetAPIKeyRequest_builder{
 		ApiKeyId: "00000000-0000-0000-0000-000000000000",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.GetAPIKey(context.Background(), req)
+	_, err := client.GetAPIKey(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -128,22 +131,24 @@ func Test_APIKey_Get_OtherUser_NotFound(t *testing.T) {
 	tokenB := env.createAuthnToken(t, userBID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "user-a-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+tokenA)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenA)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+tokenB)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenB)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.GetAPIKey(context.Background(), getReq)
+	_, err = client.GetAPIKey(getCtx, getReq)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/apikey_isolation_test.go
+++ b/organization-api/pkg/organization/apikey_isolation_test.go
@@ -38,22 +38,24 @@ func Test_APIKey_Isolation_List(t *testing.T) {
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
 	createKey := func(token, name string) {
-		req := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+		req := organizationv1.CreateAPIKeyRequest_builder{
 			Name: name,
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
-		_, err := client.CreateAPIKey(context.Background(), req)
+		}.Build()
+		ctx, callInfo := connect.NewClientContext(context.Background())
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+		_, err := client.CreateAPIKey(ctx, req)
 		require.NoError(t, err)
 	}
 
 	listKeys := func(token string) []*organizationv1.APIKey {
-		req := connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
-		res, err := client.ListAPIKeys(context.Background(), req)
+		req := organizationv1.ListAPIKeysRequest_builder{}.Build()
+		ctx, callInfo := connect.NewClientContext(context.Background())
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+		res, err := client.ListAPIKeys(ctx, req)
 		require.NoError(t, err)
-		return res.Msg.GetApiKeys()
+		return res.GetApiKeys()
 	}
 
 	createKey(tokenA, "key-a-1")

--- a/organization-api/pkg/organization/apikey_list.go
+++ b/organization-api/pkg/organization/apikey_list.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListAPIKeys(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListAPIKeysRequest],
-) (*connect.Response[organizationv1.ListAPIKeysResponse], error) {
+	req *organizationv1.ListAPIKeysRequest,
+) (*organizationv1.ListAPIKeysResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -42,7 +42,7 @@ func (s *Server) ListAPIKeys(
 		result = append(result, apiKeyFromListRow(&keys[idx]))
 	}
 
-	return connect.NewResponse(organizationv1.ListAPIKeysResponse_builder{
+	return organizationv1.ListAPIKeysResponse_builder{
 		ApiKeys: result,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/apikey_list_test.go
+++ b/organization-api/pkg/organization/apikey_list_test.go
@@ -18,7 +18,7 @@ func Test_APIKey_List_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.ListAPIKeys(context.Background(), connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build()))
+	_, err := client.ListAPIKeys(context.Background(), organizationv1.ListAPIKeysRequest_builder{}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -43,13 +43,14 @@ func Test_APIKey_List_Empty(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	req := organizationv1.ListAPIKeysRequest_builder{}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.ListAPIKeys(context.Background(), req)
+	res, err := client.ListAPIKeys(ctx, req)
 	require.NoError(t, err)
-	assert.Empty(t, res.Msg.GetApiKeys())
+	assert.Empty(t, res.GetApiKeys())
 }
 
 func Test_APIKey_List(t *testing.T) {
@@ -70,26 +71,28 @@ func Test_APIKey_List(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "my-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	listReq := connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListAPIKeysRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListAPIKeys(context.Background(), listReq)
+	listRes, err := client.ListAPIKeys(listCtx, listReq)
 	require.NoError(t, err)
 
-	require.Len(t, listRes.Msg.GetApiKeys(), 1)
-	key := listRes.Msg.GetApiKeys()[0]
-	assert.Equal(t, createRes.Msg.GetId(), key.GetId())
+	require.Len(t, listRes.GetApiKeys(), 1)
+	key := listRes.GetApiKeys()[0]
+	assert.Equal(t, createRes.GetId(), key.GetId())
 	assert.Equal(t, "my-key", key.GetName())
-	assert.Equal(t, createRes.Msg.GetTokenPrefix(), key.GetTokenPrefix())
+	assert.Equal(t, createRes.GetTokenPrefix(), key.GetTokenPrefix())
 	assert.Equal(t, 8, len(key.GetTokenPrefix()))
 }

--- a/organization-api/pkg/organization/apikey_revoke.go
+++ b/organization-api/pkg/organization/apikey_revoke.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) RevokeAPIKey(
 	ctx context.Context,
-	req *connect.Request[organizationv1.RevokeAPIKeyRequest],
-) (*connect.Response[organizationv1.RevokeAPIKeyResponse], error) {
-	apiKeyID := uuid.MustParse(req.Msg.GetApiKeyId())
+	req *organizationv1.RevokeAPIKeyRequest,
+) (*organizationv1.RevokeAPIKeyResponse, error) {
+	apiKeyID := uuid.MustParse(req.GetApiKeyId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.ApiKey(apiKeyID)); err != nil {
 		return nil, err
@@ -38,5 +38,5 @@ func (s *Server) RevokeAPIKey(
 
 	s.logger.InfoContext(ctx, "api key revoked", "api_key_id", apiKeyID)
 
-	return connect.NewResponse(organizationv1.RevokeAPIKeyResponse_builder{}.Build()), nil
+	return organizationv1.RevokeAPIKeyResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/apikey_revoke_test.go
+++ b/organization-api/pkg/organization/apikey_revoke_test.go
@@ -18,9 +18,9 @@ func Test_APIKey_Revoke_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.RevokeAPIKeyRequest_builder{
+	req := organizationv1.RevokeAPIKeyRequest_builder{
 		ApiKeyId: uuid.New().String(),
-	}.Build())
+	}.Build()
 
 	_, err := client.RevokeAPIKey(context.Background(), req)
 
@@ -47,43 +47,47 @@ func Test_APIKey_Revoke(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "my-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	revokeReq := connect.NewRequest(organizationv1.RevokeAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	revokeReq.Header().Set("Authorization", "Bearer "+token)
-	revokeReq.Header().Set("Fun-Organization", orgID.String())
+	revokeReq := organizationv1.RevokeAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	revokeCtx, revokeCallInfo := connect.NewClientContext(context.Background())
+	revokeCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	revokeCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.RevokeAPIKey(context.Background(), revokeReq)
+	_, err = client.RevokeAPIKey(revokeCtx, revokeReq)
 	require.NoError(t, err)
 
 	// Key should still be gettable with revoked timestamp set.
-	getReq := connect.NewRequest(organizationv1.GetAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := client.GetAPIKey(context.Background(), getReq)
+	getRes, err := client.GetAPIKey(getCtx, getReq)
 	require.NoError(t, err)
-	assert.True(t, getRes.Msg.GetApiKey().HasRevoked())
+	assert.True(t, getRes.GetApiKey().HasRevoked())
 
 	// Key should still appear in list.
-	listReq := connect.NewRequest(organizationv1.ListAPIKeysRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListAPIKeysRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListAPIKeys(context.Background(), listReq)
+	listRes, err := client.ListAPIKeys(listCtx, listReq)
 	require.NoError(t, err)
-	assert.Len(t, listRes.Msg.GetApiKeys(), 1)
+	assert.Len(t, listRes.GetApiKeys(), 1)
 }
 
 func Test_APIKey_Revoke_AlreadyRevoked(t *testing.T) {
@@ -104,28 +108,30 @@ func Test_APIKey_Revoke_AlreadyRevoked(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "my-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	revokeReq := func() *connect.Request[organizationv1.RevokeAPIKeyRequest] {
-		req := connect.NewRequest(organizationv1.RevokeAPIKeyRequest_builder{
-			ApiKeyId: createRes.Msg.GetId(),
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
-		return req
+	revokeReq := func() *organizationv1.RevokeAPIKeyRequest {
+		return organizationv1.RevokeAPIKeyRequest_builder{
+			ApiKeyId: createRes.GetId(),
+		}.Build()
 	}
 
-	_, err = client.RevokeAPIKey(context.Background(), revokeReq())
+	revokeCtx, revokeCallInfo := connect.NewClientContext(context.Background())
+	revokeCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	revokeCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+
+	_, err = client.RevokeAPIKey(revokeCtx, revokeReq())
 	require.NoError(t, err)
 
-	_, err = client.RevokeAPIKey(context.Background(), revokeReq())
+	_, err = client.RevokeAPIKey(revokeCtx, revokeReq())
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
@@ -156,22 +162,24 @@ func Test_APIKey_Revoke_OtherUser_NotFound(t *testing.T) {
 	tokenB := env.createAuthnToken(t, userBID)
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	createReq := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "user-a-key",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+tokenA)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenA)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateAPIKey(context.Background(), createReq)
+	createRes, err := client.CreateAPIKey(createCtx, createReq)
 	require.NoError(t, err)
 
-	revokeReq := connect.NewRequest(organizationv1.RevokeAPIKeyRequest_builder{
-		ApiKeyId: createRes.Msg.GetId(),
-	}.Build())
-	revokeReq.Header().Set("Authorization", "Bearer "+tokenB)
-	revokeReq.Header().Set("Fun-Organization", orgID.String())
+	revokeReq := organizationv1.RevokeAPIKeyRequest_builder{
+		ApiKeyId: createRes.GetId(),
+	}.Build()
+	revokeCtx, revokeCallInfo := connect.NewClientContext(context.Background())
+	revokeCallInfo.RequestHeader().Set("Authorization", "Bearer "+tokenB)
+	revokeCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.RevokeAPIKey(context.Background(), revokeReq)
+	_, err = client.RevokeAPIKey(revokeCtx, revokeReq)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())

--- a/organization-api/pkg/organization/cluster_create.go
+++ b/organization-api/pkg/organization/cluster_create.go
@@ -19,8 +19,8 @@ import (
 
 func (s *Server) CreateCluster(
 	ctx context.Context,
-	req *connect.Request[organizationv1.CreateClusterRequest],
-) (*connect.Response[organizationv1.CreateClusterResponse], error) {
+	req *organizationv1.CreateClusterRequest,
+) (*organizationv1.CreateClusterResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -33,22 +33,22 @@ func (s *Server) CreateCluster(
 	// Resolve the (region, version) names against the catalog: creation is only
 	// valid for offered combinations (pre-validate with ListRegions).
 	offering, err := s.queries.RegionKubernetesVersionResolve(ctx, db.RegionKubernetesVersionResolveParams{
-		RegionName: req.Msg.GetRegion(),
-		Version:    req.Msg.GetKubernetesVersion(),
+		RegionName: req.GetRegion(),
+		Version:    req.GetKubernetesVersion(),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("kubernetes version %q is not offered in region %q", req.Msg.GetKubernetesVersion(), req.Msg.GetRegion()))
+				fmt.Errorf("kubernetes version %q is not offered in region %q", req.GetKubernetesVersion(), req.GetRegion()))
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to resolve region offering: %w", err))
 	}
 
 	params := db.ClusterCreateParams{
 		OrganizationID:      organizationID,
-		Name:                req.Msg.GetName(),
-		Region:              req.Msg.GetRegion(),
-		KubernetesVersion:   req.Msg.GetKubernetesVersion(),
+		Name:                req.GetName(),
+		Region:              req.GetRegion(),
+		KubernetesVersion:   req.GetKubernetesVersion(),
 		RegionID:            pgtype.UUID{Bytes: offering.RegionID, Valid: true},
 		KubernetesVersionID: pgtype.UUID{Bytes: offering.KubernetesVersionID, Valid: true},
 	}
@@ -57,14 +57,14 @@ func (s *Server) CreateCluster(
 	if err != nil {
 		// ErrNoRows means the WHERE NOT EXISTS condition was false: a cluster with this name already exists
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("a cluster with the name %q already exists", req.Msg.GetName()))
+			return nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("a cluster with the name %q already exists", req.GetName()))
 		}
 		// Composite FK: the (region, version) pair vanished from the catalog
 		// between resolve and insert.
 		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok &&
 			pgErr.Code == pgerrcode.ForeignKeyViolation && pgErr.ConstraintName == dbconst.ConstraintClustersFkRegionVersion {
 			return nil, connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("kubernetes version %q is not offered in region %q", req.Msg.GetKubernetesVersion(), req.Msg.GetRegion()))
+				fmt.Errorf("kubernetes version %q is not offered in region %q", req.GetKubernetesVersion(), req.GetRegion()))
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create cluster: %w", err))
 	}
@@ -72,11 +72,11 @@ func (s *Server) CreateCluster(
 	s.logger.InfoContext(ctx, "cluster created",
 		"cluster_id", clusterID,
 		"organization_id", organizationID,
-		"name", req.Msg.GetName(),
-		"region", req.Msg.GetRegion(),
+		"name", req.GetName(),
+		"region", req.GetRegion(),
 	)
 
-	return connect.NewResponse(organizationv1.CreateClusterResponse_builder{
+	return organizationv1.CreateClusterResponse_builder{
 		ClusterId: clusterID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/cluster_create_test.go
+++ b/organization-api/pkg/organization/cluster_create_test.go
@@ -18,11 +18,11 @@ func Test_Cluster_Create_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.CreateCluster(context.Background(), connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	_, err := client.CreateCluster(context.Background(), organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -47,20 +47,21 @@ func Test_Cluster_Create(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.CreateCluster(context.Background(), createReq)
+	res, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
-	assert.NotEmpty(t, res.Msg.GetClusterId())
+	assert.NotEmpty(t, res.GetClusterId())
 
 	// Duplicate name in the same org must fail.
-	_, err = client.CreateCluster(context.Background(), createReq)
+	_, err = client.CreateCluster(createCtx, createReq)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/cluster_delete.go
+++ b/organization-api/pkg/organization/cluster_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteCluster(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteClusterRequest],
-) (*connect.Response[organizationv1.DeleteClusterResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.DeleteClusterRequest,
+) (*organizationv1.DeleteClusterResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -33,5 +33,5 @@ func (s *Server) DeleteCluster(
 
 	s.logger.InfoContext(ctx, "cluster deleted", "cluster_id", clusterID)
 
-	return connect.NewResponse(organizationv1.DeleteClusterResponse_builder{}.Build()), nil
+	return organizationv1.DeleteClusterResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/cluster_delete_test.go
+++ b/organization-api/pkg/organization/cluster_delete_test.go
@@ -18,9 +18,9 @@ func Test_Cluster_Delete_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.DeleteCluster(context.Background(), connect.NewRequest(organizationv1.DeleteClusterRequest_builder{
+	_, err := client.DeleteCluster(context.Background(), organizationv1.DeleteClusterRequest_builder{
 		ClusterId: uuid.New().String(),
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -45,42 +45,45 @@ func Test_Cluster_Delete(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteClusterRequest_builder{
+	deleteReq := organizationv1.DeleteClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	deleteReq.Header().Set("Authorization", "Bearer "+token)
-	deleteReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	deleteCtx, deleteCallInfo := connect.NewClientContext(context.Background())
+	deleteCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	deleteCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.DeleteCluster(context.Background(), deleteReq)
+	_, err = client.DeleteCluster(deleteCtx, deleteReq)
 	require.NoError(t, err)
 
 	// Soft delete: the cluster must no longer be visible via GetCluster.
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.GetCluster(context.Background(), getReq)
+	_, err = client.GetCluster(getCtx, getReq)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
 
 	// Deleting the same cluster again must return not found.
-	_, err = client.DeleteCluster(context.Background(), deleteReq)
+	_, err = client.DeleteCluster(deleteCtx, deleteReq)
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
 }

--- a/organization-api/pkg/organization/cluster_get.go
+++ b/organization-api/pkg/organization/cluster_get.go
@@ -23,10 +23,10 @@ const shootStatusReady = "ready"
 
 func (s *Server) GetClusterByName(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterByNameRequest],
-) (*connect.Response[organizationv1.GetClusterResponse], error) {
+	req *organizationv1.GetClusterByNameRequest,
+) (*organizationv1.GetClusterResponse, error) {
 	cluster, err := s.queries.ClusterGetByName(ctx, db.ClusterGetByNameParams{
-		Name: req.Msg.GetName(),
+		Name: req.GetName(),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -60,16 +60,16 @@ func (s *Server) GetClusterByName(
 	details := clusterDetailsFromRow(row)
 	details.SetObservabilityUrl(s.lookupObservabilityURL(ctx, row.ID, row.ShootStatus))
 
-	return connect.NewResponse(organizationv1.GetClusterResponse_builder{
+	return organizationv1.GetClusterResponse_builder{
 		Cluster: details,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetCluster(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterRequest],
-) (*connect.Response[organizationv1.GetClusterResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetClusterRequest,
+) (*organizationv1.GetClusterResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -92,16 +92,16 @@ func (s *Server) GetCluster(
 	details := clusterDetailsFromRow(&cluster)
 	details.SetObservabilityUrl(s.lookupObservabilityURL(ctx, cluster.ID, cluster.ShootStatus))
 
-	return connect.NewResponse(organizationv1.GetClusterResponse_builder{
+	return organizationv1.GetClusterResponse_builder{
 		Cluster: details,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetClusterActivity(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterActivityRequest],
-) (*connect.Response[organizationv1.GetClusterActivityResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetClusterActivityRequest,
+) (*organizationv1.GetClusterActivityResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (s *Server) GetClusterActivity(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get cluster: %w", err))
 	}
 
-	limit := req.Msg.GetLimit()
+	limit := req.GetLimit()
 	if limit <= 0 {
 		limit = 50
 	}
@@ -130,16 +130,16 @@ func (s *Server) GetClusterActivity(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get cluster events: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetClusterActivityResponse_builder{
+	return organizationv1.GetClusterActivityResponse_builder{
 		Events: clusterEventsFromRows(events),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetClusterMetricsCredentials(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterMetricsCredentialsRequest],
-) (*connect.Response[organizationv1.GetClusterMetricsCredentialsResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetClusterMetricsCredentialsRequest,
+) (*organizationv1.GetClusterMetricsCredentialsResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -173,17 +173,17 @@ func (s *Server) GetClusterMetricsCredentials(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to fetch metrics credentials"))
 	}
 
-	return connect.NewResponse(organizationv1.GetClusterMetricsCredentialsResponse_builder{
+	return organizationv1.GetClusterMetricsCredentialsResponse_builder{
 		Username: info.Username,
 		Password: info.Password,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetKubeconfig(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetKubeconfigRequest],
-) (*connect.Response[organizationv1.GetKubeconfigResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetKubeconfigRequest,
+) (*organizationv1.GetKubeconfigResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -210,9 +210,9 @@ func (s *Server) GetKubeconfig(
 
 	kubeconfig := buildKubeconfig(clusterID.String(), proxyURL)
 
-	return connect.NewResponse(organizationv1.GetKubeconfigResponse_builder{
+	return organizationv1.GetKubeconfigResponse_builder{
 		KubeconfigContent: kubeconfig,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // lookupObservabilityURL fetches the per-shoot Plutono URL for clusters that

--- a/organization-api/pkg/organization/cluster_get_test.go
+++ b/organization-api/pkg/organization/cluster_get_test.go
@@ -19,9 +19,9 @@ func Test_Cluster_Get_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.GetCluster(context.Background(), connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	_, err := client.GetCluster(context.Background(), organizationv1.GetClusterRequest_builder{
 		ClusterId: uuid.New().String(),
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -47,29 +47,31 @@ func Test_Cluster_Get(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.GetCluster(context.Background(), getReq)
+	res, err := client.GetCluster(getCtx, getReq)
 	require.NoError(t, err)
 
-	cluster := res.Msg.GetCluster()
+	cluster := res.GetCluster()
 	assert.Equal(t, clusterID, cluster.GetId())
 	assert.Equal(t, "test-cluster", cluster.GetName())
 	assert.Equal(t, "eu-west-1", cluster.GetRegion())
@@ -97,26 +99,28 @@ func Test_Cluster_Get_OtherOrg(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "org-a-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgAID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgAID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgBID.String())
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgBID.String())
 
-	_, err = client.GetCluster(context.Background(), getReq)
+	_, err = client.GetCluster(getCtx, getReq)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/cluster_kubeconfig_test.go
+++ b/organization-api/pkg/organization/cluster_kubeconfig_test.go
@@ -33,27 +33,29 @@ func Test_GetKubeconfig_ClusterNotReady(t *testing.T) {
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
 	// Create a cluster (shoot fields are not populated yet).
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "not-ready-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
 	// GetKubeconfig should fail because shoot fields are not populated.
-	kcReq := connect.NewRequest(organizationv1.GetKubeconfigRequest_builder{
+	kcReq := organizationv1.GetKubeconfigRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	kcReq.Header().Set("Authorization", "Bearer "+token)
-	kcReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	kcCtx, kcCallInfo := connect.NewClientContext(context.Background())
+	kcCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	kcCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.GetKubeconfig(context.Background(), kcReq)
+	_, err = client.GetKubeconfig(kcCtx, kcReq)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -82,18 +84,19 @@ func Test_GetKubeconfig_Ready(t *testing.T) {
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
 	// Create a cluster.
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "ready-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
 	// Simulate shoot becoming ready.
 	_, err = env.adminPool.Exec(t.Context(),
@@ -103,16 +106,17 @@ func Test_GetKubeconfig_Ready(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now GetKubeconfig should succeed.
-	kcReq := connect.NewRequest(organizationv1.GetKubeconfigRequest_builder{
+	kcReq := organizationv1.GetKubeconfigRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	kcReq.Header().Set("Authorization", "Bearer "+token)
-	kcReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	kcCtx, kcCallInfo := connect.NewClientContext(context.Background())
+	kcCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	kcCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.GetKubeconfig(context.Background(), kcReq)
+	res, err := client.GetKubeconfig(kcCtx, kcReq)
 	require.NoError(t, err)
 
-	kc := res.Msg.GetKubeconfigContent()
+	kc := res.GetKubeconfigContent()
 
 	// Kubeconfig should point at the proxy.
 	assert.Contains(t, kc, "server: https://k8s-api.example.com/clusters/"+clusterID)

--- a/organization-api/pkg/organization/cluster_list.go
+++ b/organization-api/pkg/organization/cluster_list.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListClusters(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListClustersRequest],
-) (*connect.Response[organizationv1.ListClustersResponse], error) {
+	req *organizationv1.ListClustersRequest,
+) (*organizationv1.ListClustersResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -34,9 +34,9 @@ func (s *Server) ListClusters(
 		summaries = append(summaries, clusterSummaryFromListRow(&clusters[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListClustersResponse_builder{
+	return organizationv1.ListClustersResponse_builder{
 		Clusters: summaries,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func clusterSummaryFromListRow(row *db.ClusterListRow) *organizationv1.ListClustersResponse_ClusterSummary {

--- a/organization-api/pkg/organization/cluster_list_test.go
+++ b/organization-api/pkg/organization/cluster_list_test.go
@@ -19,7 +19,7 @@ func Test_Cluster_List_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.ListClusters(context.Background(), connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build()))
+	_, err := client.ListClusters(context.Background(), organizationv1.ListClustersRequest_builder{}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -45,26 +45,28 @@ func Test_Cluster_List(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.CreateCluster(context.Background(), createReq)
+	_, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	listReq := connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListClustersRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.ListClusters(context.Background(), listReq)
+	res, err := client.ListClusters(listCtx, listReq)
 	require.NoError(t, err)
-	require.Len(t, res.Msg.GetClusters(), 1)
+	require.Len(t, res.GetClusters(), 1)
 
-	cluster := res.Msg.GetClusters()[0]
+	cluster := res.GetClusters()[0]
 	assert.Equal(t, "test-cluster", cluster.GetName())
 	assert.Equal(t, "eu-west-1", cluster.GetRegion())
 	// TODO: kubernetes version missing in cluster?
@@ -92,30 +94,33 @@ func Test_Cluster_List_MultiOrg(t *testing.T) {
 
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "org-a-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgAID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgAID.String())
 
-	_, err := client.CreateCluster(context.Background(), createReq)
+	_, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	listReq := connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgBID.String())
+	listReq := organizationv1.ListClustersRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgBID.String())
 
-	res, err := client.ListClusters(context.Background(), listReq)
+	res, err := client.ListClusters(listCtx, listReq)
 	require.NoError(t, err)
-	assert.Empty(t, res.Msg.GetClusters())
+	assert.Empty(t, res.GetClusters())
 
-	listReqOrgA := connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build())
-	listReqOrgA.Header().Set("Authorization", "Bearer "+token)
-	listReqOrgA.Header().Set("Fun-Organization", orgAID.String())
+	listReqOrgA := organizationv1.ListClustersRequest_builder{}.Build()
+	listCtxOrgA, listCallInfoOrgA := connect.NewClientContext(context.Background())
+	listCallInfoOrgA.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfoOrgA.RequestHeader().Set("Fun-Organization", orgAID.String())
 
-	resOrgA, err := client.ListClusters(context.Background(), listReqOrgA)
+	resOrgA, err := client.ListClusters(listCtxOrgA, listReqOrgA)
 	require.NoError(t, err)
-	assert.Len(t, resOrgA.Msg.GetClusters(), 1)
+	assert.Len(t, resOrgA.GetClusters(), 1)
 }

--- a/organization-api/pkg/organization/cluster_update.go
+++ b/organization-api/pkg/organization/cluster_update.go
@@ -17,9 +17,9 @@ import (
 
 func (s *Server) UpdateCluster(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateClusterRequest],
-) (*connect.Response[organizationv1.UpdateClusterResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.UpdateClusterRequest,
+) (*organizationv1.UpdateClusterResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (s *Server) UpdateCluster(
 		ID: clusterID,
 	}
 
-	if req.Msg.HasKubernetesVersion() {
+	if req.HasKubernetesVersion() {
 		// Resolve the new version against the catalog within the cluster's
 		// region; the text and the catalog reference update in lockstep.
 		cluster, err := s.queries.ClusterGetByID(ctx, db.ClusterGetByIDParams{ID: clusterID})
@@ -42,17 +42,17 @@ func (s *Server) UpdateCluster(
 
 		offering, err := s.queries.RegionKubernetesVersionResolve(ctx, db.RegionKubernetesVersionResolveParams{
 			RegionName: cluster.Region,
-			Version:    req.Msg.GetKubernetesVersion(),
+			Version:    req.GetKubernetesVersion(),
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, connect.NewError(connect.CodeInvalidArgument,
-					fmt.Errorf("kubernetes version %q is not offered in region %q", req.Msg.GetKubernetesVersion(), cluster.Region))
+					fmt.Errorf("kubernetes version %q is not offered in region %q", req.GetKubernetesVersion(), cluster.Region))
 			}
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to resolve region offering: %w", err))
 		}
 
-		params.KubernetesVersion = pgtype.Text{String: req.Msg.GetKubernetesVersion(), Valid: true}
+		params.KubernetesVersion = pgtype.Text{String: req.GetKubernetesVersion(), Valid: true}
 		params.KubernetesVersionID = pgtype.UUID{Bytes: offering.KubernetesVersionID, Valid: true}
 	}
 
@@ -67,5 +67,5 @@ func (s *Server) UpdateCluster(
 
 	s.logger.InfoContext(ctx, "cluster updated", "cluster_id", clusterID)
 
-	return connect.NewResponse(organizationv1.UpdateClusterResponse_builder{}.Build()), nil
+	return organizationv1.UpdateClusterResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/cluster_update_test.go
+++ b/organization-api/pkg/organization/cluster_update_test.go
@@ -19,10 +19,10 @@ func Test_Cluster_Update_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.UpdateCluster(context.Background(), connect.NewRequest(organizationv1.UpdateClusterRequest_builder{
+	_, err := client.UpdateCluster(context.Background(), organizationv1.UpdateClusterRequest_builder{
 		ClusterId:         uuid.New().String(),
 		KubernetesVersion: proto.String("1.29"),
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -47,38 +47,41 @@ func Test_Cluster_Update(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createRes, err := client.CreateCluster(context.Background(), createReq)
+	createRes, err := client.CreateCluster(createCtx, createReq)
 	require.NoError(t, err)
 
-	clusterID := createRes.Msg.GetClusterId()
+	clusterID := createRes.GetClusterId()
 
-	updateReq := connect.NewRequest(organizationv1.UpdateClusterRequest_builder{
+	updateReq := organizationv1.UpdateClusterRequest_builder{
 		ClusterId:         clusterID,
 		KubernetesVersion: proto.String("1.29"),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.UpdateCluster(context.Background(), updateReq)
+	_, err = client.UpdateCluster(updateCtx, updateReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := client.GetCluster(context.Background(), getReq)
+	getRes, err := client.GetCluster(getCtx, getReq)
 	require.NoError(t, err)
-	assert.Equal(t, "1.29", getRes.Msg.GetCluster().GetKubernetesVersion())
+	assert.Equal(t, "1.29", getRes.GetCluster().GetKubernetesVersion())
 }
 
 func Test_Cluster_Update_NotFound(t *testing.T) {
@@ -99,14 +102,15 @@ func Test_Cluster_Update_NotFound(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.UpdateClusterRequest_builder{
+	req := organizationv1.UpdateClusterRequest_builder{
 		ClusterId:         uuid.New().String(),
 		KubernetesVersion: proto.String("1.29"),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateCluster(context.Background(), req)
+	_, err := client.UpdateCluster(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/idempotency_test.go
+++ b/organization-api/pkg/organization/idempotency_test.go
@@ -35,27 +35,32 @@ func Test_Idempotency_CreateAPIKey_Replay(t *testing.T) {
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 	idempotencyKey := uuid.New().String()
 
-	newReq := func() *connect.Request[organizationv1.CreateAPIKeyRequest] {
-		req := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	newReq := func() *organizationv1.CreateAPIKeyRequest {
+		return organizationv1.CreateAPIKeyRequest_builder{
 			Name: "idempotent-key",
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
-		req.Header().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
-		return req
+		}.Build()
+	}
+	newCtx := func() (context.Context, connect.CallInfo) {
+		ctx, callInfo := connect.NewClientContext(context.Background())
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+		callInfo.RequestHeader().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
+		return ctx, callInfo
 	}
 
 	// First call: creates the API key.
-	res1, err := client.CreateAPIKey(context.Background(), newReq())
+	ctx1, callInfo1 := newCtx()
+	res1, err := client.CreateAPIKey(ctx1, newReq())
 	require.NoError(t, err)
-	assert.NotEmpty(t, res1.Msg.GetId())
-	assert.Equal(t, "processing", res1.Header().Get(idempotency.HeaderIdempotencyStatus))
+	assert.NotEmpty(t, res1.GetId())
+	assert.Equal(t, "processing", callInfo1.ResponseHeader().Get(idempotency.HeaderIdempotencyStatus))
 
 	// Replay: same idempotency key returns the cached response.
-	res2, err := client.CreateAPIKey(context.Background(), newReq())
+	ctx2, callInfo2 := newCtx()
+	res2, err := client.CreateAPIKey(ctx2, newReq())
 	require.NoError(t, err)
-	assert.Equal(t, res1.Msg.GetId(), res2.Msg.GetId())
-	assert.NotEmpty(t, res2.Header().Get(idempotency.HeaderIdempotencyStatus))
+	assert.Equal(t, res1.GetId(), res2.GetId())
+	assert.NotEmpty(t, callInfo2.ResponseHeader().Get(idempotency.HeaderIdempotencyStatus))
 }
 
 func Test_Idempotency_DifferentRequestBody_Rejected(t *testing.T) {
@@ -80,25 +85,27 @@ func Test_Idempotency_DifferentRequestBody_Rejected(t *testing.T) {
 	idempotencyKey := uuid.New().String()
 
 	// First call.
-	req1 := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	req1 := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "key-one",
-	}.Build())
-	req1.Header().Set("Authorization", "Bearer "+token)
-	req1.Header().Set("Fun-Organization", orgID.String())
-	req1.Header().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
+	}.Build()
+	ctx1, callInfo1 := connect.NewClientContext(context.Background())
+	callInfo1.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo1.RequestHeader().Set("Fun-Organization", orgID.String())
+	callInfo1.RequestHeader().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
 
-	_, err := client.CreateAPIKey(context.Background(), req1)
+	_, err := client.CreateAPIKey(ctx1, req1)
 	require.NoError(t, err)
 
 	// Replay with different request body should fail.
-	req2 := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	req2 := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "key-two",
-	}.Build())
-	req2.Header().Set("Authorization", "Bearer "+token)
-	req2.Header().Set("Fun-Organization", orgID.String())
-	req2.Header().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
+	}.Build()
+	ctx2, callInfo2 := connect.NewClientContext(context.Background())
+	callInfo2.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo2.RequestHeader().Set("Fun-Organization", orgID.String())
+	callInfo2.RequestHeader().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
 
-	_, err = client.CreateAPIKey(context.Background(), req2)
+	_, err = client.CreateAPIKey(ctx2, req2)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
@@ -125,16 +132,17 @@ func Test_Idempotency_NoHeader_Passthrough(t *testing.T) {
 	client := organizationv1connect.NewAPIKeyServiceClient(env.server.Client(), env.server.URL)
 
 	// Request without Idempotency-Key header should pass through normally.
-	req := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	req := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "no-idempotency",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.CreateAPIKey(context.Background(), req)
+	res, err := client.CreateAPIKey(ctx, req)
 	require.NoError(t, err)
-	assert.NotEmpty(t, res.Msg.GetId())
-	assert.Empty(t, res.Header().Get(idempotency.HeaderIdempotencyStatus))
+	assert.NotEmpty(t, res.GetId())
+	assert.Empty(t, callInfo.ResponseHeader().Get(idempotency.HeaderIdempotencyStatus))
 }
 
 func Test_Idempotency_DifferentUsers_SameKey(t *testing.T) {
@@ -165,26 +173,28 @@ func Test_Idempotency_DifferentUsers_SameKey(t *testing.T) {
 	idempotencyKey := uuid.New().String()
 
 	// User 1 creates with the key.
-	req1 := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	req1 := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "user1-key",
-	}.Build())
-	req1.Header().Set("Authorization", "Bearer "+env.createAuthnToken(t, user1ID))
-	req1.Header().Set("Fun-Organization", orgID.String())
-	req1.Header().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
+	}.Build()
+	ctx1, callInfo1 := connect.NewClientContext(context.Background())
+	callInfo1.RequestHeader().Set("Authorization", "Bearer "+env.createAuthnToken(t, user1ID))
+	callInfo1.RequestHeader().Set("Fun-Organization", orgID.String())
+	callInfo1.RequestHeader().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
 
-	res1, err := client.CreateAPIKey(context.Background(), req1)
+	res1, err := client.CreateAPIKey(ctx1, req1)
 	require.NoError(t, err)
 
 	// User 2 uses the same idempotency key — should create a separate resource.
-	req2 := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+	req2 := organizationv1.CreateAPIKeyRequest_builder{
 		Name: "user2-key",
-	}.Build())
-	req2.Header().Set("Authorization", "Bearer "+env.createAuthnToken(t, user2ID))
-	req2.Header().Set("Fun-Organization", orgID.String())
-	req2.Header().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
+	}.Build()
+	ctx2, callInfo2 := connect.NewClientContext(context.Background())
+	callInfo2.RequestHeader().Set("Authorization", "Bearer "+env.createAuthnToken(t, user2ID))
+	callInfo2.RequestHeader().Set("Fun-Organization", orgID.String())
+	callInfo2.RequestHeader().Set(idempotency.HeaderIdempotencyKey, idempotencyKey)
 
-	res2, err := client.CreateAPIKey(context.Background(), req2)
+	res2, err := client.CreateAPIKey(ctx2, req2)
 	require.NoError(t, err)
 
-	assert.NotEqual(t, res1.Msg.GetId(), res2.Msg.GetId())
+	assert.NotEqual(t, res1.GetId(), res2.GetId())
 }

--- a/organization-api/pkg/organization/invite_accept.go
+++ b/organization-api/pkg/organization/invite_accept.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) AcceptInvitation(
 	ctx context.Context,
-	req *connect.Request[organizationv1.AcceptInvitationRequest],
-) (*connect.Response[organizationv1.AcceptInvitationResponse], error) {
-	id := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.AcceptInvitationRequest,
+) (*organizationv1.AcceptInvitationResponse, error) {
+	id := uuid.MustParse(req.GetId())
 
 	rows, err := s.queries.InviteAccept(ctx, db.InviteAcceptParams{ID: id})
 	if err != nil {
@@ -26,5 +26,5 @@ func (s *Server) AcceptInvitation(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no pending invitation found"))
 	}
 
-	return connect.NewResponse(organizationv1.AcceptInvitationResponse_builder{}.Build()), nil
+	return organizationv1.AcceptInvitationResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/invite_accept_test.go
+++ b/organization-api/pkg/organization/invite_accept_test.go
@@ -19,9 +19,9 @@ func Test_AcceptInvitation_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.AcceptInvitation(context.Background(), connect.NewRequest(organizationv1.AcceptInvitationRequest_builder{
+	_, err := client.AcceptInvitation(context.Background(), organizationv1.AcceptInvitationRequest_builder{
 		Id: "arbitrary",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -47,13 +47,14 @@ func Test_AcceptInvitation_DoesNotExist(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.AcceptInvitationRequest_builder{
+	req := organizationv1.AcceptInvitationRequest_builder{
 		Id: uuid.New().String(),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.AcceptInvitation(context.Background(), req)
+	_, err := client.AcceptInvitation(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -85,41 +86,44 @@ func Test_AcceptInvitation_HappyFlow(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.InviteMember(context.Background(), req)
+	_, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
 	userToInviteToken := env.createAuthnToken(t, userToInviteUUID)
 
-	listReq := connect.NewRequest(&organizationv1.ListInvitationsRequest{})
-	listReq.Header().Set("Authorization", "Bearer "+userToInviteToken)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := &organizationv1.ListInvitationsRequest{}
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+userToInviteToken)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	invitationsRes, err := client.ListInvitations(context.Background(), listReq)
+	invitationsRes, err := client.ListInvitations(listCtx, listReq)
 	require.NoError(t, err)
 
 	require.NotNil(t, invitationsRes)
-	require.Len(t, invitationsRes.Msg.GetInvitations(), 1)
+	require.Len(t, invitationsRes.GetInvitations(), 1)
 
-	acceptInvitationReq := connect.NewRequest(organizationv1.AcceptInvitationRequest_builder{
-		Id: invitationsRes.Msg.GetInvitations()[0].GetId(),
-	}.Build())
-	acceptInvitationReq.Header().Set("Authorization", "Bearer "+userToInviteToken)
-	acceptInvitationReq.Header().Set("Fun-Organization", orgID.String())
+	acceptInvitationReq := organizationv1.AcceptInvitationRequest_builder{
+		Id: invitationsRes.GetInvitations()[0].GetId(),
+	}.Build()
+	acceptInvitationCtx, acceptInvitationCallInfo := connect.NewClientContext(context.Background())
+	acceptInvitationCallInfo.RequestHeader().Set("Authorization", "Bearer "+userToInviteToken)
+	acceptInvitationCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.AcceptInvitation(context.Background(), acceptInvitationReq)
+	res, err := client.AcceptInvitation(acceptInvitationCtx, acceptInvitationReq)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	invitationsRes, err = client.ListInvitations(context.Background(), listReq)
+	invitationsRes, err = client.ListInvitations(listCtx, listReq)
 	require.NoError(t, err)
 
 	require.NotNil(t, invitationsRes)
-	require.Len(t, invitationsRes.Msg.GetInvitations(), 0)
+	require.Len(t, invitationsRes.GetInvitations(), 0)
 }

--- a/organization-api/pkg/organization/invite_decline.go
+++ b/organization-api/pkg/organization/invite_decline.go
@@ -13,9 +13,9 @@ import (
 
 func (s *Server) DeclineInvitation(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeclineInvitationRequest],
-) (*connect.Response[organizationv1.DeclineInvitationResponse], error) {
-	id := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.DeclineInvitationRequest,
+) (*organizationv1.DeclineInvitationResponse, error) {
+	id := uuid.MustParse(req.GetId())
 
 	rows, err := s.queries.InviteDecline(ctx, db.InviteDeclineParams{ID: id})
 	if err != nil {
@@ -26,5 +26,5 @@ func (s *Server) DeclineInvitation(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no pending invitation found"))
 	}
 
-	return connect.NewResponse(organizationv1.DeclineInvitationResponse_builder{}.Build()), nil
+	return organizationv1.DeclineInvitationResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/invite_decline_test.go
+++ b/organization-api/pkg/organization/invite_decline_test.go
@@ -19,9 +19,9 @@ func Test_DeclineInvitation_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.DeclineInvitation(context.Background(), connect.NewRequest(organizationv1.DeclineInvitationRequest_builder{
+	_, err := client.DeclineInvitation(context.Background(), organizationv1.DeclineInvitationRequest_builder{
 		Id: "arbitrary",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -47,13 +47,14 @@ func Test_DeclineInvitation_DoesNotExist(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.DeclineInvitationRequest_builder{
+	req := organizationv1.DeclineInvitationRequest_builder{
 		Id: uuid.New().String(),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.DeclineInvitation(context.Background(), req)
+	_, err := client.DeclineInvitation(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -85,41 +86,44 @@ func Test_DeclineInvitation_HappyFlow(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.InviteMember(context.Background(), req)
+	_, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
 	userToInviteToken := env.createAuthnToken(t, userToInviteUUID)
 
-	listReq := connect.NewRequest(&organizationv1.ListInvitationsRequest{})
-	listReq.Header().Set("Authorization", "Bearer "+userToInviteToken)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := &organizationv1.ListInvitationsRequest{}
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+userToInviteToken)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	invitationsRes, err := client.ListInvitations(context.Background(), listReq)
+	invitationsRes, err := client.ListInvitations(listCtx, listReq)
 	require.NoError(t, err)
 
 	require.NotNil(t, invitationsRes)
-	require.Len(t, invitationsRes.Msg.GetInvitations(), 1)
+	require.Len(t, invitationsRes.GetInvitations(), 1)
 
-	declineInvitationReq := connect.NewRequest(organizationv1.DeclineInvitationRequest_builder{
-		Id: invitationsRes.Msg.GetInvitations()[0].GetId(),
-	}.Build())
-	declineInvitationReq.Header().Set("Authorization", "Bearer "+userToInviteToken)
-	declineInvitationReq.Header().Set("Fun-Organization", orgID.String())
+	declineInvitationReq := organizationv1.DeclineInvitationRequest_builder{
+		Id: invitationsRes.GetInvitations()[0].GetId(),
+	}.Build()
+	declineInvitationCtx, declineInvitationCallInfo := connect.NewClientContext(context.Background())
+	declineInvitationCallInfo.RequestHeader().Set("Authorization", "Bearer "+userToInviteToken)
+	declineInvitationCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.DeclineInvitation(context.Background(), declineInvitationReq)
+	res, err := client.DeclineInvitation(declineInvitationCtx, declineInvitationReq)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	invitationsRes, err = client.ListInvitations(context.Background(), listReq)
+	invitationsRes, err = client.ListInvitations(listCtx, listReq)
 	require.NoError(t, err)
 
 	require.NotNil(t, invitationsRes)
-	require.Len(t, invitationsRes.Msg.GetInvitations(), 0)
+	require.Len(t, invitationsRes.GetInvitations(), 0)
 }

--- a/organization-api/pkg/organization/invite_list.go
+++ b/organization-api/pkg/organization/invite_list.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListInvitations(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListInvitationsRequest],
-) (*connect.Response[organizationv1.ListInvitationsResponse], error) {
+	req *organizationv1.ListInvitationsRequest,
+) (*organizationv1.ListInvitationsResponse, error) {
 	userID, ok := UserIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
@@ -38,7 +38,7 @@ func (s *Server) ListInvitations(
 		}.Build())
 	}
 
-	return connect.NewResponse(organizationv1.ListInvitationsResponse_builder{
+	return organizationv1.ListInvitationsResponse_builder{
 		Invitations: invitations,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/invite_list_test.go
+++ b/organization-api/pkg/organization/invite_list_test.go
@@ -19,7 +19,7 @@ func Test_ListInvitations_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.ListInvitations(context.Background(), connect.NewRequest(&organizationv1.ListInvitationsRequest{}))
+	_, err := client.ListInvitations(context.Background(), &organizationv1.ListInvitationsRequest{})
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -50,29 +50,31 @@ func Test_ListInvitations_HappyFlow(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.InviteMember(context.Background(), req)
+	_, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
 	userToInviteToken := env.createAuthnToken(t, userToInviteUUID)
 
-	listReq := connect.NewRequest(&organizationv1.ListInvitationsRequest{})
-	listReq.Header().Set("Authorization", "Bearer "+userToInviteToken)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := &organizationv1.ListInvitationsRequest{}
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+userToInviteToken)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	invitationsRes, err := client.ListInvitations(context.Background(), listReq)
+	invitationsRes, err := client.ListInvitations(listCtx, listReq)
 	require.NoError(t, err)
 
 	require.NotNil(t, invitationsRes)
-	require.Len(t, invitationsRes.Msg.GetInvitations(), 1)
-	require.NotNil(t, invitationsRes.Msg.GetInvitations()[0].GetCreated().AsTime())
-	require.Equal(t, "viewer", invitationsRes.Msg.GetInvitations()[0].GetPermission())
-	require.Equal(t, orgID.String(), invitationsRes.Msg.GetInvitations()[0].GetOrganizationId())
-	require.Equal(t, "test-org", invitationsRes.Msg.GetInvitations()[0].GetOrganizationAlias())
+	require.Len(t, invitationsRes.GetInvitations(), 1)
+	require.NotNil(t, invitationsRes.GetInvitations()[0].GetCreated().AsTime())
+	require.Equal(t, "viewer", invitationsRes.GetInvitations()[0].GetPermission())
+	require.Equal(t, orgID.String(), invitationsRes.GetInvitations()[0].GetOrganizationId())
+	require.Equal(t, "test-org", invitationsRes.GetInvitations()[0].GetOrganizationAlias())
 }

--- a/organization-api/pkg/organization/invite_member.go
+++ b/organization-api/pkg/organization/invite_member.go
@@ -18,8 +18,8 @@ import (
 
 func (s *Server) InviteMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.InviteMemberRequest],
-) (*connect.Response[organizationv1.InviteMemberResponse], error) {
+	req *organizationv1.InviteMemberRequest,
+) (*organizationv1.InviteMemberResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -29,8 +29,8 @@ func (s *Server) InviteMember(
 		return nil, err
 	}
 
-	email := req.Msg.GetEmail()
-	permission := req.Msg.GetPermission()
+	email := req.GetEmail()
+	permission := req.GetPermission()
 
 	// Find existing user by email, or create a new one
 	var userID uuid.UUID
@@ -65,7 +65,7 @@ func (s *Server) InviteMember(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create membership: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.InviteMemberResponse_builder{
+	return organizationv1.InviteMemberResponse_builder{
 		InvitationId: membershipRow.ID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/invite_member_test.go
+++ b/organization-api/pkg/organization/invite_member_test.go
@@ -20,10 +20,10 @@ func Test_InviteMember_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.InviteMember(context.Background(), connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	_, err := client.InviteMember(context.Background(), organizationv1.InviteMemberRequest_builder{
 		Email:      "arbitrary",
 		Permission: "arbitrary",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -49,18 +49,19 @@ func Test_InviteMember_NewUser(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.InviteMember(context.Background(), req)
+	res, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
-	require.NotNil(t, res.Msg)
-	assert.NotEqual(t, "", res.Msg.GetInvitationId())
+	require.NotNil(t, res)
+	assert.NotEqual(t, "", res.GetInvitationId())
 }
 
 func Test_InviteMember_ExistingUser(t *testing.T) {
@@ -93,18 +94,19 @@ func Test_InviteMember_ExistingUser(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgAID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgAID.String())
 
-	res, err := client.InviteMember(context.Background(), req)
+	res, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
-	require.NotNil(t, res.Msg.GetInvitationId())
-	assert.NotEqual(t, "", res.Msg.GetInvitationId())
+	require.NotNil(t, res.GetInvitationId())
+	assert.NotEqual(t, "", res.GetInvitationId())
 }
 
 func Test_InviteMember_ExistingUser_AlreadyMember(t *testing.T) {
@@ -137,17 +139,18 @@ func Test_InviteMember_ExistingUser_AlreadyMember(t *testing.T) {
 
 	client := organizationv1connect.NewInviteServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	req := organizationv1.InviteMemberRequest_builder{
 		Email:      "foo@bar.baz",
 		Permission: "viewer",
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgAID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgAID.String())
 
-	_, err := client.InviteMember(context.Background(), req)
+	_, err := client.InviteMember(ctx, req)
 	require.NoError(t, err)
 
-	_, err = client.InviteMember(context.Background(), req)
+	_, err = client.InviteMember(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/member_delete.go
+++ b/organization-api/pkg/organization/member_delete.go
@@ -14,8 +14,8 @@ import (
 
 func (s *Server) DeleteMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteMemberRequest],
-) (*connect.Response[organizationv1.DeleteMemberResponse], error) {
+	req *organizationv1.DeleteMemberRequest,
+) (*organizationv1.DeleteMemberResponse, error) {
 	userID, ok := UserIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
@@ -30,7 +30,7 @@ func (s *Server) DeleteMember(
 		return nil, err
 	}
 
-	id := uuid.MustParse(req.Msg.GetId())
+	id := uuid.MustParse(req.GetId())
 
 	member, err := s.queries.MemberGetByID(ctx, db.MemberGetByIDParams{ID: id})
 	if err != nil {
@@ -45,5 +45,5 @@ func (s *Server) DeleteMember(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete member: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.DeleteMemberResponse_builder{}.Build()), nil
+	return organizationv1.DeleteMemberResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/member_delete_test.go
+++ b/organization-api/pkg/organization/member_delete_test.go
@@ -19,9 +19,9 @@ func Test_MemberDelete_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.DeleteMember(context.Background(), connect.NewRequest(organizationv1.DeleteMemberRequest_builder{
+	_, err := client.DeleteMember(context.Background(), organizationv1.DeleteMemberRequest_builder{
 		Id: "arbitrary",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -54,15 +54,16 @@ func Test_MemberDelete(t *testing.T) {
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
 	// List members to discover the target member's membership ID
-	theReq := connect.NewRequest(&organizationv1.ListMembersRequest{})
-	theReq.Header().Set("Authorization", "Bearer "+token)
-	theReq.Header().Set("Fun-Organization", orgID.String())
+	theReq := &organizationv1.ListMembersRequest{}
+	theCtx, theCallInfo := connect.NewClientContext(context.Background())
+	theCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	theCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListMembers(context.Background(), theReq)
+	listRes, err := client.ListMembers(theCtx, theReq)
 	require.NoError(t, err)
 
 	var targetMemberID string
-	for _, m := range listRes.Msg.GetMembers() {
+	for _, m := range listRes.GetMembers() {
 		if m.GetUserId() == targetUserID.String() {
 			targetMemberID = m.GetId()
 			break
@@ -93,11 +94,12 @@ func Test_MemberDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			req := connect.NewRequest(tc.Request)
-			req.Header().Set("Authorization", "Bearer "+token)
-			req.Header().Set("Fun-Organization", orgID.String())
+			req := tc.Request
+			ctx, callInfo := connect.NewClientContext(context.Background())
+			callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			res, err := client.DeleteMember(context.Background(), req)
+			res, err := client.DeleteMember(ctx, req)
 
 			if tc.WantErr {
 				var connectErr *connect.Error
@@ -107,15 +109,16 @@ func Test_MemberDelete(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, "", res.Msg.String())
+			assert.Equal(t, "", res.String())
 
-			getReq := connect.NewRequest(organizationv1.GetMemberRequest_builder{
+			getReq := organizationv1.GetMemberRequest_builder{
 				UserId: new(targetUserID.String()),
-			}.Build())
-			getReq.Header().Set("Authorization", "Bearer "+token)
-			getReq.Header().Set("Fun-Organization", orgID.String())
+			}.Build()
+			getCtx, getCallInfo := connect.NewClientContext(context.Background())
+			getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			_, err = client.GetMember(context.Background(), getReq)
+			_, err = client.GetMember(getCtx, getReq)
 
 			var connectErr *connect.Error
 			require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/member_get.go
+++ b/organization-api/pkg/organization/member_get.go
@@ -18,13 +18,13 @@ import (
 
 func (s *Server) GetMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetMemberRequest],
-) (*connect.Response[organizationv1.GetMemberResponse], error) {
+	req *organizationv1.GetMemberRequest,
+) (*organizationv1.GetMemberResponse, error) {
 	var member *organizationv1.Member
 
-	switch req.Msg.WhichLookup() {
+	switch req.WhichLookup() {
 	case organizationv1.GetMemberRequest_Id_case:
-		id := uuid.MustParse(req.Msg.GetId())
+		id := uuid.MustParse(req.GetId())
 		row, err := s.queries.MemberGetByID(ctx, db.MemberGetByIDParams{ID: id})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -35,7 +35,7 @@ func (s *Server) GetMember(
 		member = buildMember(row.ID, row.UserID, row.Name, row.ExternalRef, row.Email, row.Permission, row.Status, row.Created)
 
 	case organizationv1.GetMemberRequest_UserId_case:
-		userID := uuid.MustParse(req.Msg.GetUserId())
+		userID := uuid.MustParse(req.GetUserId())
 		row, err := s.queries.MemberGetByUserID(ctx, db.MemberGetByUserIDParams{UserID: userID})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -49,9 +49,9 @@ func (s *Server) GetMember(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("either id or user_id must be provided"))
 	}
 
-	return connect.NewResponse(organizationv1.GetMemberResponse_builder{
+	return organizationv1.GetMemberResponse_builder{
 		Member: member,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func buildMember(

--- a/organization-api/pkg/organization/member_get_test.go
+++ b/organization-api/pkg/organization/member_get_test.go
@@ -20,9 +20,9 @@ func Test_Member_Get_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.GetMember(context.Background(), connect.NewRequest(organizationv1.GetMemberRequest_builder{
+	_, err := client.GetMember(context.Background(), organizationv1.GetMemberRequest_builder{
 		Id: proto.String(uuid.New().String()),
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -55,15 +55,16 @@ func Test_Member_Get(t *testing.T) {
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
 	// List members to discover the target member's membership ID
-	listReq := connect.NewRequest(organizationv1.ListMembersRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListMembersRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListMembers(context.Background(), listReq)
+	listRes, err := client.ListMembers(listCtx, listReq)
 	require.NoError(t, err)
 
 	var targetMemberID string
-	for _, m := range listRes.Msg.GetMembers() {
+	for _, m := range listRes.GetMembers() {
 		if m.GetUserId() == targetUserID.String() {
 			targetMemberID = m.GetId()
 			break
@@ -106,11 +107,12 @@ func Test_Member_Get(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			req := connect.NewRequest(tc.Request)
-			req.Header().Set("Authorization", "Bearer "+token)
-			req.Header().Set("Fun-Organization", orgID.String())
+			req := tc.Request
+			ctx, callInfo := connect.NewClientContext(context.Background())
+			callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			res, err := client.GetMember(context.Background(), req)
+			res, err := client.GetMember(ctx, req)
 
 			if tc.WantErr {
 				var connectErr *connect.Error
@@ -121,7 +123,7 @@ func Test_Member_Get(t *testing.T) {
 
 			require.NoError(t, err)
 
-			member := res.Msg.GetMember()
+			member := res.GetMember()
 			assert.Equal(t, targetMemberID, member.GetId())
 			assert.Equal(t, targetUserID.String(), member.GetUserId())
 			assert.Equal(t, "target-user", member.GetName())

--- a/organization-api/pkg/organization/member_list.go
+++ b/organization-api/pkg/organization/member_list.go
@@ -14,8 +14,8 @@ import (
 
 func (s *Server) ListMembers(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListMembersRequest],
-) (*connect.Response[organizationv1.ListMembersResponse], error) {
+	req *organizationv1.ListMembersRequest,
+) (*organizationv1.ListMembersResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("organization_id missing from context"))
@@ -35,9 +35,9 @@ func (s *Server) ListMembers(
 		result = append(result, memberFromListRow(&members[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListMembersResponse_builder{
+	return organizationv1.ListMembersResponse_builder{
 		Members: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func memberFromListRow(m *db.MemberListRow) *organizationv1.Member {

--- a/organization-api/pkg/organization/member_list_test.go
+++ b/organization-api/pkg/organization/member_list_test.go
@@ -19,7 +19,7 @@ func Test_Member_List_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.ListMembers(context.Background(), connect.NewRequest(&organizationv1.ListMembersRequest{}))
+	_, err := client.ListMembers(context.Background(), &organizationv1.ListMembersRequest{})
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -60,12 +60,13 @@ func Test_Member_List(t *testing.T) {
 
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	listReq := connect.NewRequest(&organizationv1.ListMembersRequest{})
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := &organizationv1.ListMembersRequest{}
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListMembers(context.Background(), listReq)
+	listRes, err := client.ListMembers(listCtx, listReq)
 	require.NoError(t, err)
 
-	require.Len(t, listRes.Msg.GetMembers(), 3)
+	require.Len(t, listRes.GetMembers(), 3)
 }

--- a/organization-api/pkg/organization/member_update.go
+++ b/organization-api/pkg/organization/member_update.go
@@ -15,8 +15,8 @@ import (
 
 func (s *Server) UpdateMemberPermission(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateMemberPermissionRequest],
-) (*connect.Response[organizationv1.UpdateMemberPermissionResponse], error) {
+	req *organizationv1.UpdateMemberPermissionRequest,
+) (*organizationv1.UpdateMemberPermissionResponse, error) {
 	organizationID, ok := OrganizationIDFromContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
@@ -27,7 +27,7 @@ func (s *Server) UpdateMemberPermission(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("user_id missing from context"))
 	}
 
-	memberID := uuid.MustParse(req.Msg.GetId())
+	memberID := uuid.MustParse(req.GetId())
 	if err := s.checkPermission(ctx, authz.CanEditMember(), authz.Organization(organizationID)); err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (s *Server) UpdateMemberPermission(
 
 	rowsAffected, err := s.queries.MemberUpdatePermission(ctx, db.MemberUpdatePermissionParams{
 		ID:         memberID,
-		Permission: dbconst.OrganizationsUserPermission(req.Msg.GetPermission()),
+		Permission: dbconst.OrganizationsUserPermission(req.GetPermission()),
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update member permission: %w", err))
@@ -55,8 +55,8 @@ func (s *Server) UpdateMemberPermission(
 
 	s.logger.InfoContext(ctx, "organization member permission updated",
 		"member_id", memberID,
-		"permission", req.Msg.GetPermission(),
+		"permission", req.GetPermission(),
 	)
 
-	return connect.NewResponse(organizationv1.UpdateMemberPermissionResponse_builder{}.Build()), nil
+	return organizationv1.UpdateMemberPermissionResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/member_update_test.go
+++ b/organization-api/pkg/organization/member_update_test.go
@@ -19,10 +19,10 @@ func Test_Member_Update_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.UpdateMemberPermission(context.Background(), connect.NewRequest(organizationv1.UpdateMemberPermissionRequest_builder{
+	_, err := client.UpdateMemberPermission(context.Background(), organizationv1.UpdateMemberPermissionRequest_builder{
 		Id:         uuid.New().String(),
 		Permission: "viewer",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -54,15 +54,16 @@ func Test_Member_Update(t *testing.T) {
 
 	client := organizationv1connect.NewMemberServiceClient(env.server.Client(), env.server.URL)
 
-	listReq := connect.NewRequest(organizationv1.ListMembersRequest_builder{}.Build())
-	listReq.Header().Set("Authorization", "Bearer "+token)
-	listReq.Header().Set("Fun-Organization", orgID.String())
+	listReq := organizationv1.ListMembersRequest_builder{}.Build()
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	listRes, err := client.ListMembers(context.Background(), listReq)
+	listRes, err := client.ListMembers(listCtx, listReq)
 	require.NoError(t, err)
 
 	var callerMemberID, targetMemberID string
-	for _, m := range listRes.Msg.GetMembers() {
+	for _, m := range listRes.GetMembers() {
 		switch m.GetUserId() {
 		case callerUserID.String():
 			callerMemberID = m.GetId()
@@ -101,14 +102,15 @@ func Test_Member_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			req := connect.NewRequest(organizationv1.UpdateMemberPermissionRequest_builder{
+			req := organizationv1.UpdateMemberPermissionRequest_builder{
 				Id:         tc.id,
 				Permission: tc.permission,
-			}.Build())
-			req.Header().Set("Authorization", "Bearer "+token)
-			req.Header().Set("Fun-Organization", orgID.String())
+			}.Build()
+			ctx, callInfo := connect.NewClientContext(context.Background())
+			callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			_, err := client.UpdateMemberPermission(context.Background(), req)
+			_, err := client.UpdateMemberPermission(ctx, req)
 
 			if tc.wantErr {
 				var connectErr *connect.Error
@@ -119,15 +121,16 @@ func Test_Member_Update(t *testing.T) {
 
 			require.NoError(t, err)
 
-			getReq := connect.NewRequest(organizationv1.GetMemberRequest_builder{
+			getReq := organizationv1.GetMemberRequest_builder{
 				Id: proto.String(tc.id),
-			}.Build())
-			getReq.Header().Set("Authorization", "Bearer "+token)
-			getReq.Header().Set("Fun-Organization", orgID.String())
+			}.Build()
+			getCtx, getCallInfo := connect.NewClientContext(context.Background())
+			getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			getRes, err := client.GetMember(context.Background(), getReq)
+			getRes, err := client.GetMember(getCtx, getReq)
 			require.NoError(t, err)
-			assert.Equal(t, tc.permission, getRes.Msg.GetMember().GetPermission())
+			assert.Equal(t, tc.permission, getRes.GetMember().GetPermission())
 		})
 	}
 }

--- a/organization-api/pkg/organization/metrics.go
+++ b/organization-api/pkg/organization/metrics.go
@@ -44,9 +44,9 @@ func (s *Server) promClient() prom.Client {
 
 func (s *Server) GetClusterWorkloadMetrics(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterWorkloadMetricsRequest],
-) (*connect.Response[organizationv1.GetClusterWorkloadMetricsResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetClusterWorkloadMetricsRequest,
+) (*organizationv1.GetClusterWorkloadMetricsResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -134,18 +134,18 @@ func (s *Server) GetClusterWorkloadMetrics(
 		Pods:   makeResourceUsage(podsUsed, podsTotal, "pods"),
 	}.Build()
 
-	return connect.NewResponse(organizationv1.GetClusterWorkloadMetricsResponse_builder{
+	return organizationv1.GetClusterWorkloadMetricsResponse_builder{
 		Totals:     totals,
 		Nodes:      buildNodeMetrics(nodeCPUUsed, nodeCPUTotal, nodeMemUsed, nodeMemTotal, nodePodsUsed, nodePodsTotal),
 		Namespaces: buildNamespaceMetrics(nsCPU, nsMem, nsPods, nsCPUReq, nsCPULim, nsMemReq, nsMemLim, nsNetRx, nsNetTx),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetClusterWorkloadTimeSeries(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetClusterWorkloadTimeSeriesRequest],
-) (*connect.Response[organizationv1.GetWorkloadTimeSeriesResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.GetClusterWorkloadTimeSeriesRequest,
+) (*organizationv1.GetWorkloadTimeSeriesResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (s *Server) GetClusterWorkloadTimeSeries(
 	}
 
 	client := s.promClient()
-	start, end, step := resolveTimeRange(req.Msg.HasStart(), req.Msg.GetStart().AsTime(), req.Msg.HasEnd(), req.Msg.GetEnd().AsTime(), req.Msg.GetStepSeconds())
+	start, end, step := resolveTimeRange(req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	var (
 		cpuSeries, memSeries, podSeries []prom.TimeSeries
@@ -189,21 +189,21 @@ func (s *Server) GetClusterWorkloadTimeSeries(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	return connect.NewResponse(organizationv1.GetWorkloadTimeSeriesResponse_builder{
+	return organizationv1.GetWorkloadTimeSeriesResponse_builder{
 		CpuCores:           timeSeriesFirstToProto(cpuSeries, 1),
 		MemoryGib:          timeSeriesFirstToProto(memSeries, 1.0/bytesPerGiB),
 		PodCount:           timeSeriesFirstToProto(podSeries, 1),
 		NetworkReceiveMbS:  timeSeriesFirstToProto(netRxSeries, 1.0/bytesPerMB),
 		NetworkTransmitMbS: timeSeriesFirstToProto(netTxSeries, 1.0/bytesPerMB),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // -- Org-level RPCs --
 
 func (s *Server) GetOrgWorkloadMetrics(
 	ctx context.Context,
-	_ *connect.Request[organizationv1.GetOrgWorkloadMetricsRequest],
-) (*connect.Response[organizationv1.GetOrgWorkloadMetricsResponse], error) {
+	_ *organizationv1.GetOrgWorkloadMetricsRequest,
+) (*organizationv1.GetOrgWorkloadMetricsResponse, error) {
 	clusters, err := s.queries.ClusterList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list clusters: %w", err))
@@ -341,23 +341,23 @@ func (s *Server) GetOrgWorkloadMetrics(
 	nsNetRx := mergeSamples(allNsNetRx, "namespace")
 	nsNetTx := mergeSamples(allNsNetTx, "namespace")
 
-	return connect.NewResponse(organizationv1.GetOrgWorkloadMetricsResponse_builder{
+	return organizationv1.GetOrgWorkloadMetricsResponse_builder{
 		Totals:     totals,
 		Clusters:   clusterSummaries,
 		Namespaces: buildNamespaceMetrics(nsCPU, nsMem, nsPods, nsCPUReq, nsCPULim, nsMemReq, nsMemLim, nsNetRx, nsNetTx),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetOrgWorkloadTimeSeries(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetOrgWorkloadTimeSeriesRequest],
-) (*connect.Response[organizationv1.GetWorkloadTimeSeriesResponse], error) {
+	req *organizationv1.GetOrgWorkloadTimeSeriesRequest,
+) (*organizationv1.GetWorkloadTimeSeriesResponse, error) {
 	clusters, err := s.queries.ClusterList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list clusters: %w", err))
 	}
 
-	start, end, step := resolveTimeRange(req.Msg.HasStart(), req.Msg.GetStart().AsTime(), req.Msg.HasEnd(), req.Msg.GetEnd().AsTime(), req.Msg.GetStepSeconds())
+	start, end, step := resolveTimeRange(req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	type clusterTSResult struct {
 		cpu, mem, pods, netRx, netTx []prom.TimeSeries
@@ -413,22 +413,22 @@ func (s *Server) GetOrgWorkloadTimeSeries(
 		allNetTx[i] = r.netTx
 	}
 
-	return connect.NewResponse(organizationv1.GetWorkloadTimeSeriesResponse_builder{
+	return organizationv1.GetWorkloadTimeSeriesResponse_builder{
 		CpuCores:           timeSeriesFirstToProto(sumTimeSeries(allCPU), 1),
 		MemoryGib:          timeSeriesFirstToProto(sumTimeSeries(allMem), 1.0/bytesPerGiB),
 		PodCount:           timeSeriesFirstToProto(sumTimeSeries(allPods), 1),
 		NetworkReceiveMbS:  timeSeriesFirstToProto(sumTimeSeries(allNetRx), 1.0/bytesPerMB),
 		NetworkTransmitMbS: timeSeriesFirstToProto(sumTimeSeries(allNetTx), 1.0/bytesPerMB),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // -- Project-level RPCs --
 
 func (s *Server) GetProjectWorkloadMetrics(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectWorkloadMetricsRequest],
-) (*connect.Response[organizationv1.GetProjectWorkloadMetricsResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.GetProjectWorkloadMetricsRequest,
+) (*organizationv1.GetProjectWorkloadMetricsResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -440,10 +440,10 @@ func (s *Server) GetProjectWorkloadMetrics(
 	}
 
 	if len(namespaces) == 0 {
-		return connect.NewResponse(organizationv1.GetProjectWorkloadMetricsResponse_builder{
+		return organizationv1.GetProjectWorkloadMetricsResponse_builder{
 			Totals:     organizationv1.ResourceUsageInfo_builder{}.Build(),
 			Namespaces: nil,
-		}.Build()), nil
+		}.Build(), nil
 	}
 
 	// All namespaces in a project are expected to live on the same cluster.
@@ -519,21 +519,21 @@ func (s *Server) GetProjectWorkloadMetrics(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	return connect.NewResponse(organizationv1.GetProjectWorkloadMetricsResponse_builder{
+	return organizationv1.GetProjectWorkloadMetricsResponse_builder{
 		Totals: organizationv1.ResourceUsageInfo_builder{
 			Cpu:    makeResourceUsage(cpuUsed, cpuTotal, "cores"),
 			Memory: makeResourceUsage(memUsed/bytesPerGiB, memTotal/bytesPerGiB, "GiB"),
 			Pods:   makeResourceUsage(podsUsed, podsTotal, "pods"),
 		}.Build(),
 		Namespaces: buildNamespaceMetrics(nsCPU, nsMem, nsPods, nsCPUReq, nsCPULim, nsMemReq, nsMemLim, nsNetRx, nsNetTx),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetProjectWorkloadTimeSeries(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectWorkloadTimeSeriesRequest],
-) (*connect.Response[organizationv1.GetWorkloadTimeSeriesResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.GetProjectWorkloadTimeSeriesRequest,
+) (*organizationv1.GetWorkloadTimeSeriesResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -545,7 +545,7 @@ func (s *Server) GetProjectWorkloadTimeSeries(
 	}
 
 	if len(namespaces) == 0 {
-		return connect.NewResponse(organizationv1.GetWorkloadTimeSeriesResponse_builder{}.Build()), nil
+		return organizationv1.GetWorkloadTimeSeriesResponse_builder{}.Build(), nil
 	}
 
 	// All namespaces in a project are expected to live on the same cluster.
@@ -564,7 +564,7 @@ func (s *Server) GetProjectWorkloadTimeSeries(
 
 	client := s.promClient()
 	nsFilter := buildNamespaceFilter(namespaceNames(namespaces))
-	start, end, step := resolveTimeRange(req.Msg.HasStart(), req.Msg.GetStart().AsTime(), req.Msg.HasEnd(), req.Msg.GetEnd().AsTime(), req.Msg.GetStepSeconds())
+	start, end, step := resolveTimeRange(req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	var (
 		cpuSeries, memSeries, podSeries []prom.TimeSeries
@@ -594,13 +594,13 @@ func (s *Server) GetProjectWorkloadTimeSeries(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	return connect.NewResponse(organizationv1.GetWorkloadTimeSeriesResponse_builder{
+	return organizationv1.GetWorkloadTimeSeriesResponse_builder{
 		CpuCores:           timeSeriesFirstToProto(cpuSeries, 1),
 		MemoryGib:          timeSeriesFirstToProto(memSeries, 1.0/bytesPerGiB),
 		PodCount:           timeSeriesFirstToProto(podSeries, 1),
 		NetworkReceiveMbS:  timeSeriesFirstToProto(netRxSeries, 1.0/bytesPerMB),
 		NetworkTransmitMbS: timeSeriesFirstToProto(netTxSeries, 1.0/bytesPerMB),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 // -- Helper functions --
@@ -872,10 +872,10 @@ const streamInterval = 15 * time.Second
 // StreamOrgWorkloadMetrics streams org-wide metrics every 15 seconds.
 func (s *Server) StreamOrgWorkloadMetrics(
 	ctx context.Context,
-	req *connect.Request[organizationv1.StreamOrgWorkloadMetricsRequest],
+	req *organizationv1.StreamOrgWorkloadMetricsRequest,
 	stream *connect.ServerStream[organizationv1.StreamWorkloadMetricsResponse],
 ) error {
-	if err := s.sendOrgSnapshot(ctx, req.Msg, stream); err != nil {
+	if err := s.sendOrgSnapshot(ctx, req, stream); err != nil {
 		return err
 	}
 	ticker := time.NewTicker(streamInterval)
@@ -885,7 +885,7 @@ func (s *Server) StreamOrgWorkloadMetrics(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := s.sendOrgSnapshot(ctx, req.Msg, stream); err != nil {
+			if err := s.sendOrgSnapshot(ctx, req, stream); err != nil {
 				return err
 			}
 		}
@@ -895,10 +895,10 @@ func (s *Server) StreamOrgWorkloadMetrics(
 // StreamClusterWorkloadMetrics streams cluster metrics every 15 seconds.
 func (s *Server) StreamClusterWorkloadMetrics(
 	ctx context.Context,
-	req *connect.Request[organizationv1.StreamClusterWorkloadMetricsRequest],
+	req *organizationv1.StreamClusterWorkloadMetricsRequest,
 	stream *connect.ServerStream[organizationv1.StreamWorkloadMetricsResponse],
 ) error {
-	if err := s.sendClusterSnapshot(ctx, req.Msg, stream); err != nil {
+	if err := s.sendClusterSnapshot(ctx, req, stream); err != nil {
 		return err
 	}
 	ticker := time.NewTicker(streamInterval)
@@ -908,7 +908,7 @@ func (s *Server) StreamClusterWorkloadMetrics(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := s.sendClusterSnapshot(ctx, req.Msg, stream); err != nil {
+			if err := s.sendClusterSnapshot(ctx, req, stream); err != nil {
 				return err
 			}
 		}
@@ -918,10 +918,10 @@ func (s *Server) StreamClusterWorkloadMetrics(
 // StreamProjectWorkloadMetrics streams project metrics every 15 seconds.
 func (s *Server) StreamProjectWorkloadMetrics(
 	ctx context.Context,
-	req *connect.Request[organizationv1.StreamProjectWorkloadMetricsRequest],
+	req *organizationv1.StreamProjectWorkloadMetricsRequest,
 	stream *connect.ServerStream[organizationv1.StreamWorkloadMetricsResponse],
 ) error {
-	if err := s.sendProjectSnapshot(ctx, req.Msg, stream); err != nil {
+	if err := s.sendProjectSnapshot(ctx, req, stream); err != nil {
 		return err
 	}
 	ticker := time.NewTicker(streamInterval)
@@ -931,7 +931,7 @@ func (s *Server) StreamProjectWorkloadMetrics(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := s.sendProjectSnapshot(ctx, req.Msg, stream); err != nil {
+			if err := s.sendProjectSnapshot(ctx, req, stream); err != nil {
 				return err
 			}
 		}
@@ -946,22 +946,22 @@ func (s *Server) sendOrgSnapshot(
 	start, end, step := resolveStreamTimeRange(req.GetWindowSeconds(), req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	var (
-		workload *connect.Response[organizationv1.GetOrgWorkloadMetricsResponse]
-		ts       *connect.Response[organizationv1.GetWorkloadTimeSeriesResponse]
+		workload *organizationv1.GetOrgWorkloadMetricsResponse
+		ts       *organizationv1.GetWorkloadTimeSeriesResponse
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var err error
-		workload, err = s.GetOrgWorkloadMetrics(gctx, connect.NewRequest(organizationv1.GetOrgWorkloadMetricsRequest_builder{}.Build()))
+		workload, err = s.GetOrgWorkloadMetrics(gctx, organizationv1.GetOrgWorkloadMetricsRequest_builder{}.Build())
 		return err
 	})
 	g.Go(func() error {
 		var err error
-		ts, err = s.GetOrgWorkloadTimeSeries(gctx, connect.NewRequest(organizationv1.GetOrgWorkloadTimeSeriesRequest_builder{
+		ts, err = s.GetOrgWorkloadTimeSeries(gctx, organizationv1.GetOrgWorkloadTimeSeriesRequest_builder{
 			Start:       timestamppb.New(start),
 			End:         timestamppb.New(end),
 			StepSeconds: int32(step.Seconds()),
-		}.Build()))
+		}.Build())
 		return err
 	})
 	if err := g.Wait(); err != nil {
@@ -969,10 +969,10 @@ func (s *Server) sendOrgSnapshot(
 	}
 
 	return stream.Send(organizationv1.StreamWorkloadMetricsResponse_builder{
-		Totals:      workload.Msg.GetTotals(),
-		Clusters:    workload.Msg.GetClusters(),
-		Namespaces:  workload.Msg.GetNamespaces(),
-		TimeSeries:  ts.Msg,
+		Totals:      workload.GetTotals(),
+		Clusters:    workload.GetClusters(),
+		Namespaces:  workload.GetNamespaces(),
+		TimeSeries:  ts,
 		RefreshedAt: timestamppb.Now(),
 	}.Build())
 }
@@ -985,25 +985,25 @@ func (s *Server) sendClusterSnapshot(
 	start, end, step := resolveStreamTimeRange(req.GetWindowSeconds(), req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	var (
-		workload *connect.Response[organizationv1.GetClusterWorkloadMetricsResponse]
-		ts       *connect.Response[organizationv1.GetWorkloadTimeSeriesResponse]
+		workload *organizationv1.GetClusterWorkloadMetricsResponse
+		ts       *organizationv1.GetWorkloadTimeSeriesResponse
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var err error
-		workload, err = s.GetClusterWorkloadMetrics(gctx, connect.NewRequest(organizationv1.GetClusterWorkloadMetricsRequest_builder{
+		workload, err = s.GetClusterWorkloadMetrics(gctx, organizationv1.GetClusterWorkloadMetricsRequest_builder{
 			ClusterId: req.GetClusterId(),
-		}.Build()))
+		}.Build())
 		return err
 	})
 	g.Go(func() error {
 		var err error
-		ts, err = s.GetClusterWorkloadTimeSeries(gctx, connect.NewRequest(organizationv1.GetClusterWorkloadTimeSeriesRequest_builder{
+		ts, err = s.GetClusterWorkloadTimeSeries(gctx, organizationv1.GetClusterWorkloadTimeSeriesRequest_builder{
 			ClusterId:   req.GetClusterId(),
 			Start:       timestamppb.New(start),
 			End:         timestamppb.New(end),
 			StepSeconds: int32(step.Seconds()),
-		}.Build()))
+		}.Build())
 		return err
 	})
 	if err := g.Wait(); err != nil {
@@ -1011,10 +1011,10 @@ func (s *Server) sendClusterSnapshot(
 	}
 
 	return stream.Send(organizationv1.StreamWorkloadMetricsResponse_builder{
-		Totals:      workload.Msg.GetTotals(),
-		Nodes:       workload.Msg.GetNodes(),
-		Namespaces:  workload.Msg.GetNamespaces(),
-		TimeSeries:  ts.Msg,
+		Totals:      workload.GetTotals(),
+		Nodes:       workload.GetNodes(),
+		Namespaces:  workload.GetNamespaces(),
+		TimeSeries:  ts,
 		RefreshedAt: timestamppb.Now(),
 	}.Build())
 }
@@ -1027,25 +1027,25 @@ func (s *Server) sendProjectSnapshot(
 	start, end, step := resolveStreamTimeRange(req.GetWindowSeconds(), req.HasStart(), req.GetStart().AsTime(), req.HasEnd(), req.GetEnd().AsTime(), req.GetStepSeconds())
 
 	var (
-		workload *connect.Response[organizationv1.GetProjectWorkloadMetricsResponse]
-		ts       *connect.Response[organizationv1.GetWorkloadTimeSeriesResponse]
+		workload *organizationv1.GetProjectWorkloadMetricsResponse
+		ts       *organizationv1.GetWorkloadTimeSeriesResponse
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var err error
-		workload, err = s.GetProjectWorkloadMetrics(gctx, connect.NewRequest(organizationv1.GetProjectWorkloadMetricsRequest_builder{
+		workload, err = s.GetProjectWorkloadMetrics(gctx, organizationv1.GetProjectWorkloadMetricsRequest_builder{
 			ProjectId: req.GetProjectId(),
-		}.Build()))
+		}.Build())
 		return err
 	})
 	g.Go(func() error {
 		var err error
-		ts, err = s.GetProjectWorkloadTimeSeries(gctx, connect.NewRequest(organizationv1.GetProjectWorkloadTimeSeriesRequest_builder{
+		ts, err = s.GetProjectWorkloadTimeSeries(gctx, organizationv1.GetProjectWorkloadTimeSeriesRequest_builder{
 			ProjectId:   req.GetProjectId(),
 			Start:       timestamppb.New(start),
 			End:         timestamppb.New(end),
 			StepSeconds: int32(step.Seconds()),
-		}.Build()))
+		}.Build())
 		return err
 	})
 	if err := g.Wait(); err != nil {
@@ -1053,9 +1053,9 @@ func (s *Server) sendProjectSnapshot(
 	}
 
 	return stream.Send(organizationv1.StreamWorkloadMetricsResponse_builder{
-		Totals:      workload.Msg.GetTotals(),
-		Namespaces:  workload.Msg.GetNamespaces(),
-		TimeSeries:  ts.Msg,
+		Totals:      workload.GetTotals(),
+		Namespaces:  workload.GetNamespaces(),
+		TimeSeries:  ts,
 		RefreshedAt: timestamppb.Now(),
 	}.Build())
 }

--- a/organization-api/pkg/organization/namespace_create.go
+++ b/organization-api/pkg/organization/namespace_create.go
@@ -19,9 +19,9 @@ import (
 
 func (s *Server) CreateNamespace(
 	ctx context.Context,
-	req *connect.Request[organizationv1.CreateNamespaceRequest],
-) (*connect.Response[organizationv1.CreateNamespaceResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.CreateNamespaceRequest,
+) (*organizationv1.CreateNamespaceResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	// Retry: a namespace is often created right after its project, before the
 	// project's authz tuple has synced to OpenFGA (see checkPermissionWithRetry).
@@ -32,13 +32,13 @@ func (s *Server) CreateNamespace(
 	// The name is materialized verbatim into a v1/Namespace on the shoot, so reject
 	// anything that isn't a usable (DNS-1123, non-reserved, length-bounded) name
 	// here rather than letting the cluster-worker sync fail indefinitely.
-	if err := kubename.ValidateNamespace(req.Msg.GetName()); err != nil {
+	if err := kubename.ValidateNamespace(req.GetName()); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	params := db.NamespaceCreateParams{
 		ProjectID: projectID,
-		Name:      req.Msg.GetName(),
+		Name:      req.GetName(),
 	}
 
 	namespaceID, err := s.queries.NamespaceCreate(ctx, params)
@@ -46,7 +46,7 @@ func (s *Server) CreateNamespace(
 		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 			if pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == dbconst.ConstraintNamespacesUqName {
 				return nil, connect.NewError(connect.CodeAlreadyExists,
-					fmt.Errorf("a namespace with the name %q already exists in this project", req.Msg.GetName()))
+					fmt.Errorf("a namespace with the name %q already exists in this project", req.GetName()))
 			}
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create namespace: %w", err))
@@ -55,10 +55,10 @@ func (s *Server) CreateNamespace(
 	s.logger.InfoContext(ctx, "namespace created",
 		"namespace_id", namespaceID,
 		"project_id", projectID,
-		"name", req.Msg.GetName(),
+		"name", req.GetName(),
 	)
 
-	return connect.NewResponse(organizationv1.CreateNamespaceResponse_builder{
+	return organizationv1.CreateNamespaceResponse_builder{
 		NamespaceId: namespaceID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/namespace_delete.go
+++ b/organization-api/pkg/organization/namespace_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteNamespace(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteNamespaceRequest],
-) (*connect.Response[organizationv1.DeleteNamespaceResponse], error) {
-	namespaceID := uuid.MustParse(req.Msg.GetNamespaceId())
+	req *organizationv1.DeleteNamespaceRequest,
+) (*organizationv1.DeleteNamespaceResponse, error) {
+	namespaceID := uuid.MustParse(req.GetNamespaceId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.Namespace(namespaceID)); err != nil {
 		return nil, err
@@ -33,5 +33,5 @@ func (s *Server) DeleteNamespace(
 
 	s.logger.InfoContext(ctx, "namespace deleted", "namespace_id", namespaceID)
 
-	return connect.NewResponse(organizationv1.DeleteNamespaceResponse_builder{}.Build()), nil
+	return organizationv1.DeleteNamespaceResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/namespace_get.go
+++ b/organization-api/pkg/organization/namespace_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetNamespace(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetNamespaceRequest],
-) (*connect.Response[organizationv1.GetNamespaceResponse], error) {
-	namespaceID := uuid.MustParse(req.Msg.GetNamespaceId())
+	req *organizationv1.GetNamespaceRequest,
+) (*organizationv1.GetNamespaceResponse, error) {
+	namespaceID := uuid.MustParse(req.GetNamespaceId())
 
 	namespace, err := s.queries.NamespaceGetByID(ctx, db.NamespaceGetByIDParams{ID: namespaceID})
 	if err != nil {
@@ -33,19 +33,19 @@ func (s *Server) GetNamespace(
 		return nil, err
 	}
 
-	return connect.NewResponse(organizationv1.GetNamespaceResponse_builder{
+	return organizationv1.GetNamespaceResponse_builder{
 		Namespace: namespaceFromRow((db.NamespaceListByClusterIDRow)(namespace)),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetNamespaceByProjectAndName(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetNamespaceByProjectAndNameRequest],
-) (*connect.Response[organizationv1.GetNamespaceByProjectAndNameResponse], error) {
+	req *organizationv1.GetNamespaceByProjectAndNameRequest,
+) (*organizationv1.GetNamespaceByProjectAndNameResponse, error) {
 	namespace, err := s.queries.NamespaceGetByProjectAndName(ctx, db.NamespaceGetByProjectAndNameParams{
-		ClusterName:   req.Msg.GetClusterName(),
-		ProjectName:   req.Msg.GetProjectName(),
-		NamespaceName: req.Msg.GetNamespaceName(),
+		ClusterName:   req.GetClusterName(),
+		ProjectName:   req.GetProjectName(),
+		NamespaceName: req.GetNamespaceName(),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -59,7 +59,7 @@ func (s *Server) GetNamespaceByProjectAndName(
 		return nil, err
 	}
 
-	return connect.NewResponse(organizationv1.GetNamespaceByProjectAndNameResponse_builder{
+	return organizationv1.GetNamespaceByProjectAndNameResponse_builder{
 		Namespace: namespaceFromRow((db.NamespaceListByClusterIDRow)(namespace)),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/namespace_list.go
+++ b/organization-api/pkg/organization/namespace_list.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) ListClusterNamespaces(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListClusterNamespacesRequest],
-) (*connect.Response[organizationv1.ListClusterNamespacesResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.ListClusterNamespacesRequest,
+) (*organizationv1.ListClusterNamespacesResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanListNamespaces(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -33,16 +33,16 @@ func (s *Server) ListClusterNamespaces(
 		result = append(result, namespaceFromRow(namespaces[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListClusterNamespacesResponse_builder{
+	return organizationv1.ListClusterNamespacesResponse_builder{
 		Namespaces: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) ListProjectNamespaces(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListProjectNamespacesRequest],
-) (*connect.Response[organizationv1.ListProjectNamespacesResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.ListProjectNamespacesRequest,
+) (*organizationv1.ListProjectNamespacesResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanListNamespaces(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -58,9 +58,9 @@ func (s *Server) ListProjectNamespaces(
 		result = append(result, namespaceFromRow((db.NamespaceListByClusterIDRow)(namespaces[i])))
 	}
 
-	return connect.NewResponse(organizationv1.ListProjectNamespacesResponse_builder{
+	return organizationv1.ListProjectNamespacesResponse_builder{
 		Namespaces: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func namespaceFromRow(row db.NamespaceListByClusterIDRow) *organizationv1.Namespace {

--- a/organization-api/pkg/organization/node_pool_create.go
+++ b/organization-api/pkg/organization/node_pool_create.go
@@ -20,9 +20,9 @@ import (
 
 func (s *Server) CreateNodePool(
 	ctx context.Context,
-	req *connect.Request[organizationv1.CreateNodePoolRequest],
-) (*connect.Response[organizationv1.CreateNodePoolResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.CreateNodePoolRequest,
+) (*organizationv1.CreateNodePoolResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	// Retry: the add-cluster wizard adds node pools immediately after creating
 	// the cluster, before its authz tuple has synced (see checkPermissionWithRetry).
@@ -42,23 +42,23 @@ func (s *Server) CreateNodePool(
 	// region: only offered types are valid (pre-validate with ListRegions).
 	offering, err := s.queries.RegionMachineTypeResolve(ctx, db.RegionMachineTypeResolveParams{
 		RegionName:      cluster.Region,
-		MachineTypeName: req.Msg.GetMachineType(),
+		MachineTypeName: req.GetMachineType(),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("machine type %q is not offered in region %q", req.Msg.GetMachineType(), cluster.Region))
+				fmt.Errorf("machine type %q is not offered in region %q", req.GetMachineType(), cluster.Region))
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to resolve machine type: %w", err))
 	}
 
 	params := db.NodePoolCreateParams{
 		ClusterID:           clusterID,
-		Name:                req.Msg.GetName(),
-		MachineType:         req.Msg.GetMachineType(),
+		Name:                req.GetName(),
+		MachineType:         req.GetMachineType(),
 		RegionMachineTypeID: pgtype.UUID{Bytes: offering, Valid: true},
-		AutoscaleMin:        req.Msg.GetAutoscaleMin(),
-		AutoscaleMax:        req.Msg.GetAutoscaleMax(),
+		AutoscaleMin:        req.GetAutoscaleMin(),
+		AutoscaleMax:        req.GetAutoscaleMax(),
 	}
 
 	nodePoolID, err := s.queries.NodePoolCreate(ctx, params)
@@ -73,7 +73,7 @@ func (s *Server) CreateNodePool(
 			}
 			if pgErr.Code == pgerrcode.ForeignKeyViolation && pgErr.ConstraintName == dbconst.ConstraintNodePoolsFkRegionMachineType {
 				return nil, connect.NewError(connect.CodeInvalidArgument,
-					fmt.Errorf("machine type %q is not offered in region %q", req.Msg.GetMachineType(), cluster.Region))
+					fmt.Errorf("machine type %q is not offered in region %q", req.GetMachineType(), cluster.Region))
 			}
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create node pool: %w", err))
@@ -82,10 +82,10 @@ func (s *Server) CreateNodePool(
 	s.logger.InfoContext(ctx, "node pool created",
 		"node_pool_id", nodePoolID,
 		"cluster_id", clusterID,
-		"name", req.Msg.GetName(),
+		"name", req.GetName(),
 	)
 
-	return connect.NewResponse(organizationv1.CreateNodePoolResponse_builder{
+	return organizationv1.CreateNodePoolResponse_builder{
 		NodePoolId: nodePoolID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/node_pool_delete.go
+++ b/organization-api/pkg/organization/node_pool_delete.go
@@ -14,9 +14,9 @@ import (
 
 func (s *Server) DeleteNodePool(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteNodePoolRequest],
-) (*connect.Response[organizationv1.DeleteNodePoolResponse], error) {
-	nodePoolID := uuid.MustParse(req.Msg.GetNodePoolId())
+	req *organizationv1.DeleteNodePoolRequest,
+) (*organizationv1.DeleteNodePoolResponse, error) {
+	nodePoolID := uuid.MustParse(req.GetNodePoolId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.NodePool(nodePoolID)); err != nil {
 		return nil, err
@@ -33,5 +33,5 @@ func (s *Server) DeleteNodePool(
 
 	s.logger.InfoContext(ctx, "node pool deleted", "node_pool_id", nodePoolID)
 
-	return connect.NewResponse(organizationv1.DeleteNodePoolResponse_builder{}.Build()), nil
+	return organizationv1.DeleteNodePoolResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/node_pool_get.go
+++ b/organization-api/pkg/organization/node_pool_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetNodePool(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetNodePoolRequest],
-) (*connect.Response[organizationv1.GetNodePoolResponse], error) {
-	nodePoolID := uuid.MustParse(req.Msg.GetNodePoolId())
+	req *organizationv1.GetNodePoolRequest,
+) (*organizationv1.GetNodePoolResponse, error) {
+	nodePoolID := uuid.MustParse(req.GetNodePoolId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.NodePool(nodePoolID)); err != nil {
 		return nil, err
@@ -32,9 +32,9 @@ func (s *Server) GetNodePool(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get node pool: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetNodePoolResponse_builder{
+	return organizationv1.GetNodePoolResponse_builder{
 		NodePool: nodePoolFromRow(&nodePool),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func nodePoolFromRow(row *db.TenantNodePool) *organizationv1.NodePool {

--- a/organization-api/pkg/organization/node_pool_list.go
+++ b/organization-api/pkg/organization/node_pool_list.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) ListNodePools(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListNodePoolsRequest],
-) (*connect.Response[organizationv1.ListNodePoolsResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.ListNodePoolsRequest,
+) (*organizationv1.ListNodePoolsResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanListNodePools(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -41,9 +41,9 @@ func (s *Server) ListNodePools(
 		result = append(result, nodePoolFromListRow(&nodePools[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListNodePoolsResponse_builder{
+	return organizationv1.ListNodePoolsResponse_builder{
 		NodePools: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func nodePoolFromListRow(row *db.TenantNodePool) *organizationv1.NodePool {

--- a/organization-api/pkg/organization/node_pool_update.go
+++ b/organization-api/pkg/organization/node_pool_update.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) UpdateNodePool(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateNodePoolRequest],
-) (*connect.Response[organizationv1.UpdateNodePoolResponse], error) {
-	nodePoolID := uuid.MustParse(req.Msg.GetNodePoolId())
+	req *organizationv1.UpdateNodePoolRequest,
+) (*organizationv1.UpdateNodePoolResponse, error) {
+	nodePoolID := uuid.MustParse(req.GetNodePoolId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.NodePool(nodePoolID)); err != nil {
 		return nil, err
@@ -25,8 +25,8 @@ func (s *Server) UpdateNodePool(
 
 	params := db.NodePoolUpdateParams{
 		ID:           nodePoolID,
-		AutoscaleMin: pgtype.Int4{Int32: req.Msg.GetAutoscaleMin(), Valid: true},
-		AutoscaleMax: pgtype.Int4{Int32: req.Msg.GetAutoscaleMax(), Valid: true},
+		AutoscaleMin: pgtype.Int4{Int32: req.GetAutoscaleMin(), Valid: true},
+		AutoscaleMax: pgtype.Int4{Int32: req.GetAutoscaleMax(), Valid: true},
 	}
 
 	rowsAffected, err := s.queries.NodePoolUpdate(ctx, params)
@@ -40,5 +40,5 @@ func (s *Server) UpdateNodePool(
 
 	s.logger.InfoContext(ctx, "node pool updated", "node_pool_id", nodePoolID)
 
-	return connect.NewResponse(organizationv1.UpdateNodePoolResponse_builder{}.Build()), nil
+	return organizationv1.UpdateNodePoolResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/organization_get.go
+++ b/organization-api/pkg/organization/organization_get.go
@@ -17,9 +17,9 @@ import (
 
 func (s *Server) GetOrganization(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetOrganizationRequest],
-) (*connect.Response[organizationv1.GetOrganizationResponse], error) {
-	organizationID := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.GetOrganizationRequest,
+) (*organizationv1.GetOrganizationResponse, error) {
+	organizationID := uuid.MustParse(req.GetId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Organization(organizationID)); err != nil {
 		return nil, err
@@ -33,9 +33,9 @@ func (s *Server) GetOrganization(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get organization: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetOrganizationResponse_builder{
+	return organizationv1.GetOrganizationResponse_builder{
 		Organization: organizationFromRow(&organization),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func organizationFromRow(row *db.OrganizationGetByIDRow) *organizationv1.Organization {

--- a/organization-api/pkg/organization/organization_limits_get.go
+++ b/organization-api/pkg/organization/organization_limits_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetOrganizationLimits(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetOrganizationLimitsRequest],
-) (*connect.Response[organizationv1.GetOrganizationLimitsResponse], error) {
-	organizationID := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.GetOrganizationLimitsRequest,
+) (*organizationv1.GetOrganizationLimitsResponse, error) {
+	organizationID := uuid.MustParse(req.GetId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Organization(organizationID)); err != nil {
 		return nil, err
@@ -27,18 +27,18 @@ func (s *Server) GetOrganizationLimits(
 	row, err := s.queries.OrganizationLimitsGet(ctx, db.OrganizationLimitsGetParams{OrganizationID: organizationID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return connect.NewResponse(organizationv1.GetOrganizationLimitsResponse_builder{
+			return organizationv1.GetOrganizationLimitsResponse_builder{
 				Limits:   organizationv1.OrganizationLimits_builder{}.Build(),
 				Defaults: organizationLimitDefaults(),
-			}.Build()), nil
+			}.Build(), nil
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get organization limits: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetOrganizationLimitsResponse_builder{
+	return organizationv1.GetOrganizationLimitsResponse_builder{
 		Limits:   organizationLimitsFromRow(&row),
 		Defaults: organizationLimitDefaults(),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func organizationLimitsFromRow(row *db.OrganizationLimitsGetRow) *organizationv1.OrganizationLimits {

--- a/organization-api/pkg/organization/organization_limits_get_test.go
+++ b/organization-api/pkg/organization/organization_limits_get_test.go
@@ -19,9 +19,9 @@ func Test_OrganizationLimits_Get_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.GetOrganizationLimits(context.Background(), connect.NewRequest(
+	_, err := client.GetOrganizationLimits(context.Background(),
 		organizationv1.GetOrganizationLimitsRequest_builder{Id: uuid.New().String()}.Build(),
-	))
+	)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -42,14 +42,15 @@ func Test_OrganizationLimits_Get_NoLimitsSet(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	req := organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.GetOrganizationLimits(context.Background(), req)
+	res, err := client.GetOrganizationLimits(ctx, req)
 	require.NoError(t, err)
 
-	limits := res.Msg.GetLimits()
+	limits := res.GetLimits()
 	require.NotNil(t, limits)
 	assert.False(t, limits.HasMaxNodesPerCluster())
 	assert.False(t, limits.HasMaxNodePoolsPerCluster())
@@ -60,7 +61,7 @@ func Test_OrganizationLimits_Get_NoLimitsSet(t *testing.T) {
 	assert.False(t, limits.HasDefaultCpuLimitM())
 
 	// Platform defaults are always returned, even when the organization has no limits set.
-	defaults := res.Msg.GetDefaults()
+	defaults := res.GetDefaults()
 	require.NotNil(t, defaults)
 	assert.EqualValues(t, 10, defaults.GetMaxNodesPerCluster())
 	assert.EqualValues(t, 5, defaults.GetMaxNodePoolsPerCluster())
@@ -85,7 +86,7 @@ func Test_OrganizationLimits_Get(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	updateReq := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	updateReq := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                     orgID.String(),
 		MaxNodesPerCluster:     proto.Int32(50),
 		MaxNodePoolsPerCluster: proto.Int32(10),
@@ -94,21 +95,23 @@ func Test_OrganizationLimits_Get(t *testing.T) {
 		DefaultMemoryLimitMi:   proto.Int32(256),
 		DefaultCpuRequestM:     proto.Int32(100),
 		DefaultCpuLimitM:       proto.Int32(500),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), updateReq)
+	_, err := client.UpdateOrganizationLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.GetOrganizationLimits(context.Background(), getReq)
+	res, err := client.GetOrganizationLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	limits := res.Msg.GetLimits()
+	limits := res.GetLimits()
 	require.NotNil(t, limits)
 	assert.EqualValues(t, 50, limits.GetMaxNodesPerCluster())
 	assert.EqualValues(t, 10, limits.GetMaxNodePoolsPerCluster())

--- a/organization-api/pkg/organization/organization_limits_update.go
+++ b/organization-api/pkg/organization/organization_limits_update.go
@@ -19,9 +19,9 @@ import (
 
 func (s *Server) UpdateOrganizationLimits(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateOrganizationLimitsRequest],
-) (*connect.Response[organizationv1.UpdateOrganizationLimitsResponse], error) {
-	organizationID := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.UpdateOrganizationLimitsRequest,
+) (*organizationv1.UpdateOrganizationLimitsResponse, error) {
+	organizationID := uuid.MustParse(req.GetId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Organization(organizationID)); err != nil {
 		return nil, err
@@ -29,13 +29,13 @@ func (s *Server) UpdateOrganizationLimits(
 
 	params := db.OrganizationLimitsUpsertParams{
 		OrganizationID:         organizationID,
-		MaxNodesPerCluster:     pgtype.Int4{Int32: req.Msg.GetMaxNodesPerCluster(), Valid: req.Msg.HasMaxNodesPerCluster()},
-		MaxNodePoolsPerCluster: pgtype.Int4{Int32: req.Msg.GetMaxNodePoolsPerCluster(), Valid: req.Msg.HasMaxNodePoolsPerCluster()},
-		MaxNodesPerNodePool:    pgtype.Int4{Int32: req.Msg.GetMaxNodesPerNodePool(), Valid: req.Msg.HasMaxNodesPerNodePool()},
-		DefaultMemoryRequestMi: pgtype.Int4{Int32: req.Msg.GetDefaultMemoryRequestMi(), Valid: req.Msg.HasDefaultMemoryRequestMi()},
-		DefaultMemoryLimitMi:   pgtype.Int4{Int32: req.Msg.GetDefaultMemoryLimitMi(), Valid: req.Msg.HasDefaultMemoryLimitMi()},
-		DefaultCpuRequestM:     pgtype.Int4{Int32: req.Msg.GetDefaultCpuRequestM(), Valid: req.Msg.HasDefaultCpuRequestM()},
-		DefaultCpuLimitM:       pgtype.Int4{Int32: req.Msg.GetDefaultCpuLimitM(), Valid: req.Msg.HasDefaultCpuLimitM()},
+		MaxNodesPerCluster:     pgtype.Int4{Int32: req.GetMaxNodesPerCluster(), Valid: req.HasMaxNodesPerCluster()},
+		MaxNodePoolsPerCluster: pgtype.Int4{Int32: req.GetMaxNodePoolsPerCluster(), Valid: req.HasMaxNodePoolsPerCluster()},
+		MaxNodesPerNodePool:    pgtype.Int4{Int32: req.GetMaxNodesPerNodePool(), Valid: req.HasMaxNodesPerNodePool()},
+		DefaultMemoryRequestMi: pgtype.Int4{Int32: req.GetDefaultMemoryRequestMi(), Valid: req.HasDefaultMemoryRequestMi()},
+		DefaultMemoryLimitMi:   pgtype.Int4{Int32: req.GetDefaultMemoryLimitMi(), Valid: req.HasDefaultMemoryLimitMi()},
+		DefaultCpuRequestM:     pgtype.Int4{Int32: req.GetDefaultCpuRequestM(), Valid: req.HasDefaultCpuRequestM()},
+		DefaultCpuLimitM:       pgtype.Int4{Int32: req.GetDefaultCpuLimitM(), Valid: req.HasDefaultCpuLimitM()},
 	}
 
 	if _, err := s.queries.OrganizationLimitsUpsert(ctx, params); err != nil {
@@ -52,5 +52,5 @@ func (s *Server) UpdateOrganizationLimits(
 
 	s.logger.InfoContext(ctx, "organization limits updated", "organization_id", organizationID)
 
-	return connect.NewResponse(organizationv1.UpdateOrganizationLimitsResponse_builder{}.Build()), nil
+	return organizationv1.UpdateOrganizationLimitsResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/organization_limits_update_test.go
+++ b/organization-api/pkg/organization/organization_limits_update_test.go
@@ -19,9 +19,9 @@ func Test_OrganizationLimits_Update_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), connect.NewRequest(
+	_, err := client.UpdateOrganizationLimits(context.Background(),
 		organizationv1.UpdateOrganizationLimitsRequest_builder{Id: uuid.New().String()}.Build(),
-	))
+	)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -42,7 +42,7 @@ func Test_OrganizationLimits_Update(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	updateReq := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	updateReq := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                     orgID.String(),
 		MaxNodesPerCluster:     proto.Int32(50),
 		MaxNodePoolsPerCluster: proto.Int32(10),
@@ -51,21 +51,23 @@ func Test_OrganizationLimits_Update(t *testing.T) {
 		DefaultMemoryLimitMi:   proto.Int32(256),
 		DefaultCpuRequestM:     proto.Int32(100),
 		DefaultCpuLimitM:       proto.Int32(500),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), updateReq)
+	_, err := client.UpdateOrganizationLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := client.GetOrganizationLimits(context.Background(), getReq)
+	getRes, err := client.GetOrganizationLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	limits := getRes.Msg.GetLimits()
+	limits := getRes.GetLimits()
 	require.NotNil(t, limits)
 	assert.EqualValues(t, 50, limits.GetMaxNodesPerCluster())
 	assert.EqualValues(t, 10, limits.GetMaxNodePoolsPerCluster())
@@ -90,34 +92,37 @@ func Test_OrganizationLimits_Update_Overwrites(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	firstUpdate := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	firstUpdate := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                 orgID.String(),
 		MaxNodesPerCluster: proto.Int32(50),
-	}.Build())
-	firstUpdate.Header().Set("Authorization", "Bearer "+token)
-	firstUpdate.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	firstUpdateCtx, firstUpdateCallInfo := connect.NewClientContext(context.Background())
+	firstUpdateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	firstUpdateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), firstUpdate)
+	_, err := client.UpdateOrganizationLimits(firstUpdateCtx, firstUpdate)
 	require.NoError(t, err)
 
-	secondUpdate := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	secondUpdate := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                 orgID.String(),
 		MaxNodesPerCluster: proto.Int32(100),
-	}.Build())
-	secondUpdate.Header().Set("Authorization", "Bearer "+token)
-	secondUpdate.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	secondUpdateCtx, secondUpdateCallInfo := connect.NewClientContext(context.Background())
+	secondUpdateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	secondUpdateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.UpdateOrganizationLimits(context.Background(), secondUpdate)
+	_, err = client.UpdateOrganizationLimits(secondUpdateCtx, secondUpdate)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetOrganizationLimitsRequest_builder{Id: orgID.String()}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := client.GetOrganizationLimits(context.Background(), getReq)
+	getRes, err := client.GetOrganizationLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 100, getRes.Msg.GetLimits().GetMaxNodesPerCluster())
+	assert.EqualValues(t, 100, getRes.GetLimits().GetMaxNodesPerCluster())
 }
 
 func Test_OrganizationLimits_Update_IsolatedBetweenOrgs(t *testing.T) {
@@ -139,24 +144,26 @@ func Test_OrganizationLimits_Update_IsolatedBetweenOrgs(t *testing.T) {
 	token2 := env.createAuthnToken(t, user2ID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	updateReq := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	updateReq := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                 org1ID.String(),
 		MaxNodesPerCluster: proto.Int32(42),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token1)
-	updateReq.Header().Set("Fun-Organization", org1ID.String())
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token1)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", org1ID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), updateReq)
+	_, err := client.UpdateOrganizationLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
 	// org2 should see no limits
-	getReq := connect.NewRequest(organizationv1.GetOrganizationLimitsRequest_builder{Id: org2ID.String()}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token2)
-	getReq.Header().Set("Fun-Organization", org2ID.String())
+	getReq := organizationv1.GetOrganizationLimitsRequest_builder{Id: org2ID.String()}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token2)
+	getCallInfo.RequestHeader().Set("Fun-Organization", org2ID.String())
 
-	getRes, err := client.GetOrganizationLimits(context.Background(), getReq)
+	getRes, err := client.GetOrganizationLimits(getCtx, getReq)
 	require.NoError(t, err)
-	assert.False(t, getRes.Msg.GetLimits().HasMaxNodesPerCluster())
+	assert.False(t, getRes.GetLimits().HasMaxNodesPerCluster())
 }
 
 func Test_OrganizationLimits_Update_MemoryLimitLessThanRequest(t *testing.T) {
@@ -173,15 +180,16 @@ func Test_OrganizationLimits_Update_MemoryLimitLessThanRequest(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	req := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                     orgID.String(),
 		DefaultMemoryRequestMi: proto.Int32(256),
 		DefaultMemoryLimitMi:   proto.Int32(128),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), req)
+	_, err := client.UpdateOrganizationLimits(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -202,15 +210,16 @@ func Test_OrganizationLimits_Update_CpuLimitLessThanRequest(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	req := connect.NewRequest(organizationv1.UpdateOrganizationLimitsRequest_builder{
+	req := organizationv1.UpdateOrganizationLimitsRequest_builder{
 		Id:                 orgID.String(),
 		DefaultCpuRequestM: proto.Int32(500),
 		DefaultCpuLimitM:   proto.Int32(100),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.UpdateOrganizationLimits(context.Background(), req)
+	_, err := client.UpdateOrganizationLimits(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/organization_list.go
+++ b/organization-api/pkg/organization/organization_list.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListOrganizations(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListOrganizationsRequest],
-) (*connect.Response[organizationv1.ListOrganizationsResponse], error) {
+	req *organizationv1.ListOrganizationsRequest,
+) (*organizationv1.ListOrganizationsResponse, error) {
 	orgs, err := s.queries.OrganizationList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list organizations: %w", err))
@@ -25,9 +25,9 @@ func (s *Server) ListOrganizations(
 		result = append(result, toOrg(org))
 	}
 
-	return connect.NewResponse(organizationv1.ListOrganizationsResponse_builder{
+	return organizationv1.ListOrganizationsResponse_builder{
 		Organizations: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func toOrg(org db.OrganizationListRow) *organizationv1.Organization {

--- a/organization-api/pkg/organization/organization_list_test.go
+++ b/organization-api/pkg/organization/organization_list_test.go
@@ -19,7 +19,7 @@ func Test_Organization_List_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.ListOrganizations(context.Background(), connect.NewRequest(&organizationv1.ListOrganizationsRequest{}))
+	_, err := client.ListOrganizations(context.Background(), &organizationv1.ListOrganizationsRequest{})
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -49,11 +49,12 @@ func Test_Organization_List(t *testing.T) {
 
 	client := organizationv1connect.NewOrganizationServiceClient(env.server.Client(), env.server.URL)
 
-	listReq := connect.NewRequest(&organizationv1.ListOrganizationsRequest{})
-	listReq.Header().Set("Authorization", "Bearer "+token)
+	listReq := &organizationv1.ListOrganizationsRequest{}
+	listCtx, listCallInfo := connect.NewClientContext(context.Background())
+	listCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
 
-	listRes, err := client.ListOrganizations(context.Background(), listReq)
+	listRes, err := client.ListOrganizations(listCtx, listReq)
 	require.NoError(t, err)
 
-	require.Len(t, listRes.Msg.GetOrganizations(), 2)
+	require.Len(t, listRes.GetOrganizations(), 2)
 }

--- a/organization-api/pkg/organization/organization_update.go
+++ b/organization-api/pkg/organization/organization_update.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) UpdateOrganization(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateOrganizationRequest],
-) (*connect.Response[organizationv1.UpdateOrganizationResponse], error) {
-	organizationID := uuid.MustParse(req.Msg.GetId())
+	req *organizationv1.UpdateOrganizationRequest,
+) (*organizationv1.UpdateOrganizationResponse, error) {
+	organizationID := uuid.MustParse(req.GetId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Organization(organizationID)); err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func (s *Server) UpdateOrganization(
 
 	params := db.OrganizationUpdateParams{
 		ID:    organizationID,
-		Alias: req.Msg.GetAlias(),
+		Alias: req.GetAlias(),
 	}
 
 	organization, err := s.queries.OrganizationUpdate(ctx, params)
@@ -39,5 +39,5 @@ func (s *Server) UpdateOrganization(
 
 	s.logger.InfoContext(ctx, "organization updated", "organization_id", organization.ID, "name", organization.Name, "alias", organization.Alias)
 
-	return connect.NewResponse(organizationv1.UpdateOrganizationResponse_builder{}.Build()), nil
+	return organizationv1.UpdateOrganizationResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/plugin_definition_get.go
+++ b/organization-api/pkg/organization/plugin_definition_get.go
@@ -15,10 +15,10 @@ import (
 
 func (s *Server) GetPluginDefinition(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetPluginDefinitionRequest],
-) (*connect.Response[organizationv1.GetPluginDefinitionResponse], error) {
-	name := req.Msg.GetPluginName()
-	version := req.Msg.GetPluginVersion()
+	req *organizationv1.GetPluginDefinitionRequest,
+) (*organizationv1.GetPluginDefinitionResponse, error) {
+	name := req.GetPluginName()
+	version := req.GetPluginVersion()
 	if name == "" || version == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("plugin_name and plugin_version are required"))
 	}
@@ -35,11 +35,11 @@ func (s *Server) GetPluginDefinition(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("parse stored manifest: %w", err))
 	}
-	return connect.NewResponse(organizationv1.GetPluginDefinitionResponse_builder{
+	return organizationv1.GetPluginDefinitionResponse_builder{
 		Manifest:   row.Manifest,
 		Hash:       row.Hash,
 		Definition: pluginDefinitionToProto(&parsed),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func pluginDefinitionToProto(def *pluginruntime.PluginDefinition) *organizationv1.PluginDefinition {

--- a/organization-api/pkg/organization/plugin_definition_list.go
+++ b/organization-api/pkg/organization/plugin_definition_list.go
@@ -16,9 +16,9 @@ import (
 // choices. An unknown plugin simply yields an empty list.
 func (s *Server) ListPluginDefinitions(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListPluginDefinitionsRequest],
-) (*connect.Response[organizationv1.ListPluginDefinitionsResponse], error) {
-	pluginID, err := uuid.Parse(req.Msg.GetPluginId())
+	req *organizationv1.ListPluginDefinitionsRequest,
+) (*organizationv1.ListPluginDefinitionsResponse, error) {
+	pluginID, err := uuid.Parse(req.GetPluginId())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("plugin_id must be a valid uuid: %w", err))
 	}
@@ -36,7 +36,7 @@ func (s *Server) ListPluginDefinitions(
 		}.Build())
 	}
 
-	return connect.NewResponse(organizationv1.ListPluginDefinitionsResponse_builder{
+	return organizationv1.ListPluginDefinitionsResponse_builder{
 		Definitions: defs,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/plugin_definition_put.go
+++ b/organization-api/pkg/organization/plugin_definition_put.go
@@ -27,11 +27,11 @@ const maxManifestBytes = 1 << 20
 
 func (s *Server) PutPluginDefinition(
 	ctx context.Context,
-	req *connect.Request[organizationv1.PutPluginDefinitionRequest],
-) (*connect.Response[organizationv1.PutPluginDefinitionResponse], error) {
-	pluginIDStr := req.Msg.GetPluginId()
-	version := req.Msg.GetPluginVersion()
-	manifest := req.Msg.GetManifest()
+	req *organizationv1.PutPluginDefinitionRequest,
+) (*organizationv1.PutPluginDefinitionResponse, error) {
+	pluginIDStr := req.GetPluginId()
+	version := req.GetPluginVersion()
+	manifest := req.GetManifest()
 	if pluginIDStr == "" || version == "" || len(manifest) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("plugin_id, plugin_version and manifest are required"))
 	}
@@ -83,14 +83,14 @@ func (s *Server) PutPluginDefinition(
 	if existing, err := s.queries.PluginDefinitionGetByPluginVersionHash(ctx, db.PluginDefinitionGetByPluginVersionHashParams{
 		PluginID: pluginID, PluginVersion: version, Hash: hash,
 	}); err == nil {
-		return connect.NewResponse(organizationv1.PutPluginDefinitionResponse_builder{
+		return organizationv1.PutPluginDefinitionResponse_builder{
 			Id: existing.ID.String(), PluginId: pluginID.String(), PluginVersion: version, Hash: hash,
-		}.Build()), nil
+		}.Build(), nil
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("lookup plugin definition: %w", err))
 	}
 
-	replace := req.Msg.GetReplace()
+	replace := req.GetReplace()
 
 	// An active definition for (plugin_id, version) with a different hash already
 	// exists. Reject it unless the caller asked to replace — a pinned definition
@@ -145,7 +145,7 @@ func (s *Server) PutPluginDefinition(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("commit transaction: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.PutPluginDefinitionResponse_builder{
+	return organizationv1.PutPluginDefinitionResponse_builder{
 		Id: inserted.ID.String(), PluginId: pluginID.String(), PluginVersion: version, Hash: hash,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/plugin_definition_test.go
+++ b/organization-api/pkg/organization/plugin_definition_test.go
@@ -57,42 +57,45 @@ func TestPutPluginDefinition_IdempotentAndConflict(t *testing.T) {
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
 
-	putReq1 := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq1 := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq1.Header().Set("Authorization", "Bearer "+token)
-	putReq1.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx1, putCallInfo1 := connect.NewClientContext(ctx)
+	putCallInfo1.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo1.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	resp1, err := client.PutPluginDefinition(ctx, putReq1)
+	resp1, err := client.PutPluginDefinition(putCtx1, putReq1)
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(resp1.Msg.GetHash(), "sha256:"))
-	assert.Equal(t, pluginID.String(), resp1.Msg.GetPluginId())
+	assert.True(t, strings.HasPrefix(resp1.GetHash(), "sha256:"))
+	assert.Equal(t, pluginID.String(), resp1.GetPluginId())
 
 	// Same bytes → idempotent, same hash.
-	putReq2 := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq2 := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq2.Header().Set("Authorization", "Bearer "+token)
-	putReq2.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx2, putCallInfo2 := connect.NewClientContext(ctx)
+	putCallInfo2.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo2.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	resp2, err := client.PutPluginDefinition(ctx, putReq2)
+	resp2, err := client.PutPluginDefinition(putCtx2, putReq2)
 	require.NoError(t, err)
-	assert.Equal(t, resp1.Msg.GetHash(), resp2.Msg.GetHash())
+	assert.Equal(t, resp1.GetHash(), resp2.GetHash())
 
 	// Different bytes, same (plugin_id, version) → FAILED_PRECONDITION.
-	putReq3 := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq3 := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      append(testManifest, byte('\n')),
-	}.Build())
-	putReq3.Header().Set("Authorization", "Bearer "+token)
-	putReq3.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx3, putCallInfo3 := connect.NewClientContext(ctx)
+	putCallInfo3.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo3.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.PutPluginDefinition(ctx, putReq3)
+	_, err = client.PutPluginDefinition(putCtx3, putReq3)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 }
@@ -120,15 +123,16 @@ func TestPutPluginDefinition_RequiresOrganization(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(context.Background())
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
 	// No Fun-Organization header.
 
-	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -156,15 +160,16 @@ func TestPutPluginDefinition_RejectsVersionMismatch(t *testing.T) {
 	client := newPluginServiceClient(env)
 
 	// testManifest declares metadata.version v1; send a different plugin_version.
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v2",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(context.Background())
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -193,15 +198,16 @@ func TestPutPluginDefinition_RejectsImagelessTemplate(t *testing.T) {
 
 	template := []byte("apiVersion: fundament.io/v1\nkind: PluginDefinition\nmetadata:\n  name: test-plugin-def\n  version: v1\nspec:\n  permissions:\n    rbac: []\n")
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      template,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(ctx)
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(ctx, putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -227,15 +233,16 @@ func TestPutPluginDefinition_UnknownPluginID(t *testing.T) {
 	ctx := context.Background()
 
 	unknownID := uuid.New()
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      unknownID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(ctx)
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(ctx, putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 }
@@ -260,15 +267,16 @@ func TestPutPluginDefinition_InvalidPluginID(t *testing.T) {
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      "not-a-uuid",
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(ctx)
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(ctx, putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -296,15 +304,16 @@ func TestPutPluginDefinition_RejectsNameMismatch(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 	client := newPluginServiceClient(env)
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(context.Background())
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -335,15 +344,16 @@ func TestPutPluginDefinition_RejectsOversizedManifest(t *testing.T) {
 	// read limit so the handler (not the transport) rejects it.
 	oversized := make([]byte, (1<<20)+1)
 
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      oversized,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(context.Background())
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(context.Background(), putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -371,15 +381,16 @@ func TestPutPluginDefinition_Replace(t *testing.T) {
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
 
-	put := func(manifest []byte, replace bool) (*connect.Response[organizationv1.PutPluginDefinitionResponse], error) {
-		req := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	put := func(manifest []byte, replace bool) (*organizationv1.PutPluginDefinitionResponse, error) {
+		req := organizationv1.PutPluginDefinitionRequest_builder{
 			PluginId:      pluginID.String(),
 			PluginVersion: "v1",
 			Manifest:      manifest,
 			Replace:       replace,
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
+		}.Build()
+		ctx, callInfo := connect.NewClientContext(ctx)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 		return client.PutPluginDefinition(ctx, req)
 	}
 
@@ -391,16 +402,16 @@ func TestPutPluginDefinition_Replace(t *testing.T) {
 	revised := append(append([]byte{}, testManifest...), []byte("# rev2\n")...)
 	resp2, err := put(revised, true)
 	require.NoError(t, err)
-	assert.NotEqual(t, resp1.Msg.GetHash(), resp2.Msg.GetHash())
+	assert.NotEqual(t, resp1.GetHash(), resp2.GetHash())
 
 	// Get now serves the replacement.
-	getReq := connect.NewRequest(organizationv1.GetPluginDefinitionRequest_builder{
+	getReq := organizationv1.GetPluginDefinitionRequest_builder{
 		PluginName:    testPluginName,
 		PluginVersion: "v1",
-	}.Build())
+	}.Build()
 	getResp, err := client.GetPluginDefinition(ctx, getReq)
 	require.NoError(t, err)
-	assert.Equal(t, resp2.Msg.GetHash(), getResp.Msg.GetHash())
+	assert.Equal(t, resp2.GetHash(), getResp.GetHash())
 }
 
 // TestListPlugins_SurfacesLatestDefinition verifies ListPlugins and
@@ -429,12 +440,13 @@ func TestListPlugins_SurfacesLatestDefinition(t *testing.T) {
 
 	findSummary := func(t *testing.T) *organizationv1.PluginSummary {
 		t.Helper()
-		req := connect.NewRequest(organizationv1.ListPluginsRequest_builder{}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
+		req := organizationv1.ListPluginsRequest_builder{}.Build()
+		ctx, callInfo := connect.NewClientContext(ctx)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 		resp, err := client.ListPlugins(ctx, req)
 		require.NoError(t, err)
-		for _, p := range resp.Msg.GetPlugins() {
+		for _, p := range resp.GetPlugins() {
 			if p.GetName() == testPluginName {
 				return p
 			}
@@ -450,16 +462,17 @@ func TestListPlugins_SurfacesLatestDefinition(t *testing.T) {
 
 	put := func(version string, manifest []byte) string {
 		t.Helper()
-		req := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+		req := organizationv1.PutPluginDefinitionRequest_builder{
 			PluginId:      pluginID.String(),
 			PluginVersion: version,
 			Manifest:      manifest,
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
+		}.Build()
+		ctx, callInfo := connect.NewClientContext(ctx)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 		resp, err := client.PutPluginDefinition(ctx, req)
 		require.NoError(t, err)
-		return resp.Msg.GetHash()
+		return resp.GetHash()
 	}
 
 	// Publish v1, then v2 — the latest by created is v2.
@@ -472,15 +485,16 @@ func TestListPlugins_SurfacesLatestDefinition(t *testing.T) {
 	assert.Equal(t, v2Hash, after.GetDefinitionHash())
 
 	// GetPluginDetail reports the same.
-	detailReq := connect.NewRequest(organizationv1.GetPluginDetailRequest_builder{
+	detailReq := organizationv1.GetPluginDetailRequest_builder{
 		PluginId: pluginID.String(),
-	}.Build())
-	detailReq.Header().Set("Authorization", "Bearer "+token)
-	detailReq.Header().Set("Fun-Organization", orgID.String())
-	detailResp, err := client.GetPluginDetail(ctx, detailReq)
+	}.Build()
+	detailCtx, detailCallInfo := connect.NewClientContext(ctx)
+	detailCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	detailCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	detailResp, err := client.GetPluginDetail(detailCtx, detailReq)
 	require.NoError(t, err)
-	assert.Equal(t, "v2", detailResp.Msg.GetPlugin().GetPluginVersion())
-	assert.Equal(t, v2Hash, detailResp.Msg.GetPlugin().GetDefinitionHash())
+	assert.Equal(t, "v2", detailResp.GetPlugin().GetPluginVersion())
+	assert.Equal(t, v2Hash, detailResp.GetPlugin().GetDefinitionHash())
 }
 
 // TestListPluginDefinitions_LatestFirst verifies the endpoint returns all
@@ -509,14 +523,15 @@ func TestListPluginDefinitions_LatestFirst(t *testing.T) {
 
 	list := func(t *testing.T) []*organizationv1.PluginDefinitionVersion {
 		t.Helper()
-		req := connect.NewRequest(organizationv1.ListPluginDefinitionsRequest_builder{
+		req := organizationv1.ListPluginDefinitionsRequest_builder{
 			PluginId: pluginID.String(),
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
+		}.Build()
+		ctx, callInfo := connect.NewClientContext(ctx)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 		resp, err := client.ListPluginDefinitions(ctx, req)
 		require.NoError(t, err)
-		return resp.Msg.GetDefinitions()
+		return resp.GetDefinitions()
 	}
 
 	// No definitions published yet → empty list.
@@ -524,14 +539,15 @@ func TestListPluginDefinitions_LatestFirst(t *testing.T) {
 
 	put := func(version string, manifest []byte) string {
 		t.Helper()
-		req := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+		req := organizationv1.PutPluginDefinitionRequest_builder{
 			PluginId: pluginID.String(), PluginVersion: version, Manifest: manifest,
-		}.Build())
-		req.Header().Set("Authorization", "Bearer "+token)
-		req.Header().Set("Fun-Organization", orgID.String())
+		}.Build()
+		ctx, callInfo := connect.NewClientContext(ctx)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+		callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 		resp, err := client.PutPluginDefinition(ctx, req)
 		require.NoError(t, err)
-		return resp.Msg.GetHash()
+		return resp.GetHash()
 	}
 
 	put("v1", testManifest)
@@ -568,30 +584,31 @@ func TestGetPluginDefinition_ReturnsBytesHashAndProto(t *testing.T) {
 	ctx := context.Background()
 
 	// Arrange: Put a manifest first.
-	putReq := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	putReq := organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID.String(),
 		PluginVersion: "v1",
 		Manifest:      testManifest,
-	}.Build())
-	putReq.Header().Set("Authorization", "Bearer "+token)
-	putReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	putCtx, putCallInfo := connect.NewClientContext(ctx)
+	putCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	putCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err := client.PutPluginDefinition(ctx, putReq)
+	_, err := client.PutPluginDefinition(putCtx, putReq)
 	require.NoError(t, err)
 
 	// Act: Get the definition (public endpoint, no auth needed).
-	getReq := connect.NewRequest(organizationv1.GetPluginDefinitionRequest_builder{
+	getReq := organizationv1.GetPluginDefinitionRequest_builder{
 		PluginName:    testPluginName,
 		PluginVersion: "v1",
-	}.Build())
+	}.Build()
 
 	resp, err := client.GetPluginDefinition(ctx, getReq)
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.Msg.GetManifest())
-	assert.True(t, strings.HasPrefix(resp.Msg.GetHash(), "sha256:"))
-	assert.Equal(t, "repo@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", resp.Msg.GetDefinition().GetImage())
-	require.Len(t, resp.Msg.GetDefinition().GetPermissions().GetRbac(), 1)
-	assert.Equal(t, []string{"cert-manager.io"}, resp.Msg.GetDefinition().GetPermissions().GetRbac()[0].GetApiGroups())
+	assert.NotEmpty(t, resp.GetManifest())
+	assert.True(t, strings.HasPrefix(resp.GetHash(), "sha256:"))
+	assert.Equal(t, "repo@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", resp.GetDefinition().GetImage())
+	require.Len(t, resp.GetDefinition().GetPermissions().GetRbac(), 1)
+	assert.Equal(t, []string{"cert-manager.io"}, resp.GetDefinition().GetPermissions().GetRbac()[0].GetApiGroups())
 }
 
 func TestGetPluginDefinition_NotFound(t *testing.T) {
@@ -601,10 +618,10 @@ func TestGetPluginDefinition_NotFound(t *testing.T) {
 	client := newPluginServiceClient(env)
 	ctx := context.Background()
 
-	getReq := connect.NewRequest(organizationv1.GetPluginDefinitionRequest_builder{
+	getReq := organizationv1.GetPluginDefinitionRequest_builder{
 		PluginName:    "nope",
 		PluginVersion: "v1",
-	}.Build())
+	}.Build()
 
 	_, err := client.GetPluginDefinition(ctx, getReq)
 	require.Error(t, err)

--- a/organization-api/pkg/organization/plugin_get.go
+++ b/organization-api/pkg/organization/plugin_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetPluginDetail(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetPluginDetailRequest],
-) (*connect.Response[organizationv1.GetPluginDetailResponse], error) {
-	pluginID, err := uuid.Parse(req.Msg.GetPluginId())
+	req *organizationv1.GetPluginDetailRequest,
+) (*organizationv1.GetPluginDetailResponse, error) {
+	pluginID, err := uuid.Parse(req.GetPluginId())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid plugin_id: %w", err))
 	}
@@ -70,9 +70,9 @@ func (s *Server) GetPluginDetail(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get plugin details: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetPluginDetailResponse_builder{
+	return organizationv1.GetPluginDetailResponse_builder{
 		Plugin: pluginDetailFromRow(&plugin, tags, categories, docLinks),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func pluginDetailFromRow(

--- a/organization-api/pkg/organization/plugin_list.go
+++ b/organization-api/pkg/organization/plugin_list.go
@@ -14,8 +14,8 @@ import (
 
 func (s *Server) ListPlugins(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListPluginsRequest],
-) (*connect.Response[organizationv1.ListPluginsResponse], error) {
+	req *organizationv1.ListPluginsRequest,
+) (*organizationv1.ListPluginsResponse, error) {
 	var (
 		plugins    []db.PluginListRow
 		tags       []db.PluginTagsListRow
@@ -63,9 +63,9 @@ func (s *Server) ListPlugins(
 		result = append(result, pluginSummaryFromRow(&plugins[i], tagsByPlugin, categoriesByPlugin))
 	}
 
-	return connect.NewResponse(organizationv1.ListPluginsResponse_builder{
+	return organizationv1.ListPluginsResponse_builder{
 		Plugins: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func buildTagsByPlugin(tags []db.PluginTagsListRow) map[uuid.UUID][]*organizationv1.Tag {

--- a/organization-api/pkg/organization/preset_list.go
+++ b/organization-api/pkg/organization/preset_list.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListPresets(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListPresetsRequest],
-) (*connect.Response[organizationv1.ListPresetsResponse], error) {
+	req *organizationv1.ListPresetsRequest,
+) (*organizationv1.ListPresetsResponse, error) {
 	presets, err := s.queries.PresetList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list presets: %w", err))
@@ -32,9 +32,9 @@ func (s *Server) ListPresets(
 		result = append(result, presetFromRow(&presets[i], pluginsByPreset))
 	}
 
-	return connect.NewResponse(organizationv1.ListPresetsResponse_builder{
+	return organizationv1.ListPresetsResponse_builder{
 		Presets: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func buildPluginsByPreset(presetPlugins []db.AppstorePresetPlugin) map[uuid.UUID][]string {

--- a/organization-api/pkg/organization/project_create.go
+++ b/organization-api/pkg/organization/project_create.go
@@ -19,9 +19,9 @@ import (
 
 func (s *Server) CreateProject(
 	ctx context.Context,
-	req *connect.Request[organizationv1.CreateProjectRequest],
-) (*connect.Response[organizationv1.CreateProjectResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.CreateProjectRequest,
+) (*organizationv1.CreateProjectResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 	if err := s.checkPermissionWithRetry(ctx, authz.CanCreateProject(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (s *Server) CreateProject(
 	s.logger.DebugContext(ctx, "creating project with member",
 		"cluster_id", clusterID,
 		"user_id", userID,
-		"name", req.Msg.GetName(),
+		"name", req.GetName(),
 	)
 
 	tx, err := s.db.Pool.Begin(ctx)
@@ -45,14 +45,14 @@ func (s *Server) CreateProject(
 
 	qtx := s.queries.WithTx(tx)
 
-	alias := req.Msg.GetName()
-	if req.Msg.HasAlias() {
-		alias = req.Msg.GetAlias()
+	alias := req.GetName()
+	if req.HasAlias() {
+		alias = req.GetAlias()
 	}
 
 	projectID, err := qtx.ProjectCreate(ctx, db.ProjectCreateParams{
 		ClusterID: clusterID,
-		Name:      req.Msg.GetName(),
+		Name:      req.GetName(),
 		Alias:     alias,
 	})
 	if err != nil {
@@ -81,10 +81,10 @@ func (s *Server) CreateProject(
 		"project_id", projectID,
 		"cluster_id", clusterID,
 		"user_id", userID,
-		"name", req.Msg.GetName(),
+		"name", req.GetName(),
 	)
 
-	return connect.NewResponse(organizationv1.CreateProjectResponse_builder{
+	return organizationv1.CreateProjectResponse_builder{
 		ProjectId: projectID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_create_test.go
+++ b/organization-api/pkg/organization/project_create_test.go
@@ -18,10 +18,10 @@ func Test_Project_Create_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.CreateProject(context.Background(), connect.NewRequest(organizationv1.CreateProjectRequest_builder{
+	_, err := client.CreateProject(context.Background(), organizationv1.CreateProjectRequest_builder{
 		ClusterId: uuid.New().String(),
 		Name:      "test-project",
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -46,41 +46,44 @@ func Test_Project_Create(t *testing.T) {
 	token := env.createAuthnToken(t, userID)
 
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createClusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	createClusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: createClusterRes.Msg.GetClusterId(),
+	createReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: createClusterRes.GetClusterId(),
 		Name:      "test-project",
-	}.Build())
-	createReq.Header().Set("Authorization", "Bearer "+token)
-	createReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createCtx, createCallInfo := connect.NewClientContext(context.Background())
+	createCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.CreateProject(context.Background(), createReq)
+	res, err := client.CreateProject(createCtx, createReq)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, res.Msg.GetProjectId())
+	require.NotEmpty(t, res.GetProjectId())
 
-	listMembersReq := connect.NewRequest(organizationv1.ListProjectMembersRequest_builder{
-		ProjectId: res.Msg.GetProjectId(),
-	}.Build())
-	listMembersReq.Header().Set("Authorization", "Bearer "+token)
-	listMembersReq.Header().Set("Fun-Organization", orgID.String())
+	listMembersReq := organizationv1.ListProjectMembersRequest_builder{
+		ProjectId: res.GetProjectId(),
+	}.Build()
+	listMembersCtx, listMembersCallInfo := connect.NewClientContext(context.Background())
+	listMembersCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	listMembersCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	membersRes, err := client.ListProjectMembers(context.Background(), listMembersReq)
+	membersRes, err := client.ListProjectMembers(listMembersCtx, listMembersReq)
 	require.NoError(t, err)
 
-	members := membersRes.Msg.GetMembers()
+	members := membersRes.GetMembers()
 	require.Len(t, members, 1)
 	assert.Equal(t, userID.String(), members[0].GetUserId())
 	assert.Equal(t, organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_ADMIN, members[0].GetRole())

--- a/organization-api/pkg/organization/project_delete.go
+++ b/organization-api/pkg/organization/project_delete.go
@@ -17,9 +17,9 @@ import (
 
 func (s *Server) DeleteProject(
 	ctx context.Context,
-	req *connect.Request[organizationv1.DeleteProjectRequest],
-) (*connect.Response[organizationv1.DeleteProjectResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.DeleteProjectRequest,
+) (*organizationv1.DeleteProjectResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -41,5 +41,5 @@ func (s *Server) DeleteProject(
 
 	s.logger.InfoContext(ctx, "project deleted", "project_id", projectID)
 
-	return connect.NewResponse(organizationv1.DeleteProjectResponse_builder{}.Build()), nil
+	return organizationv1.DeleteProjectResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_get.go
+++ b/organization-api/pkg/organization/project_get.go
@@ -17,10 +17,10 @@ import (
 
 func (s *Server) GetProjectByName(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectByNameRequest],
-) (*connect.Response[organizationv1.GetProjectResponse], error) {
+	req *organizationv1.GetProjectByNameRequest,
+) (*organizationv1.GetProjectResponse, error) {
 	project, err := s.queries.ProjectGetByName(ctx, db.ProjectGetByNameParams{
-		Name: req.Msg.GetName(),
+		Name: req.GetName(),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -34,16 +34,16 @@ func (s *Server) GetProjectByName(
 		return nil, err
 	}
 
-	return connect.NewResponse(organizationv1.GetProjectResponse_builder{
+	return organizationv1.GetProjectResponse_builder{
 		Project: projectFromGetRow(&project),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func (s *Server) GetProject(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectRequest],
-) (*connect.Response[organizationv1.GetProjectResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.GetProjectRequest,
+) (*organizationv1.GetProjectResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -57,9 +57,9 @@ func (s *Server) GetProject(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get project: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetProjectResponse_builder{
+	return organizationv1.GetProjectResponse_builder{
 		Project: projectFromGetRow(&project),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func projectFromGetRow(row *db.TenantProject) *organizationv1.Project {

--- a/organization-api/pkg/organization/project_limits_get.go
+++ b/organization-api/pkg/organization/project_limits_get.go
@@ -16,9 +16,9 @@ import (
 
 func (s *Server) GetProjectLimits(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectLimitsRequest],
-) (*connect.Response[organizationv1.GetProjectLimitsResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.GetProjectLimitsRequest,
+) (*organizationv1.GetProjectLimitsResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -27,18 +27,18 @@ func (s *Server) GetProjectLimits(
 	row, err := s.queries.ProjectLimitsGet(ctx, db.ProjectLimitsGetParams{ProjectID: projectID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return connect.NewResponse(organizationv1.GetProjectLimitsResponse_builder{
+			return organizationv1.GetProjectLimitsResponse_builder{
 				Limits:   organizationv1.ProjectLimits_builder{}.Build(),
 				Defaults: projectLimitDefaults(),
-			}.Build()), nil
+			}.Build(), nil
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get project limits: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetProjectLimitsResponse_builder{
+	return organizationv1.GetProjectLimitsResponse_builder{
 		Limits:   projectLimitsFromRow(&row),
 		Defaults: projectLimitDefaults(),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func projectLimitsFromRow(row *db.ProjectLimitsGetRow) *organizationv1.ProjectLimits {

--- a/organization-api/pkg/organization/project_limits_get_test.go
+++ b/organization-api/pkg/organization/project_limits_get_test.go
@@ -19,9 +19,9 @@ func Test_ProjectLimits_Get_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.GetProjectLimits(context.Background(), connect.NewRequest(
+	_, err := client.GetProjectLimits(context.Background(),
 		organizationv1.GetProjectLimitsRequest_builder{ProjectId: uuid.New().String()}.Build(),
-	))
+	)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -43,32 +43,35 @@ func Test_ProjectLimits_Get_NoLimitsSet(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{
-		ProjectId: projectRes.Msg.GetProjectId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetProjectLimitsRequest_builder{
+		ProjectId: projectRes.GetProjectId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	res, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	limits := res.Msg.GetLimits()
+	limits := res.GetLimits()
 	require.NotNil(t, limits)
 	assert.False(t, limits.HasDefaultMemoryRequestMi())
 	assert.False(t, limits.HasDefaultMemoryLimitMi())
@@ -76,7 +79,7 @@ func Test_ProjectLimits_Get_NoLimitsSet(t *testing.T) {
 	assert.False(t, limits.HasDefaultCpuLimitM())
 
 	// Platform defaults are always returned, even when the project has no limits set.
-	defaults := res.Msg.GetDefaults()
+	defaults := res.GetDefaults()
 	require.NotNil(t, defaults)
 	assert.EqualValues(t, 256, defaults.GetDefaultMemoryRequestMi())
 	assert.EqualValues(t, 512, defaults.GetDefaultMemoryLimitMi())
@@ -99,43 +102,47 @@ func Test_ProjectLimits_Get(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
-	projectID := projectRes.Msg.GetProjectId()
+	projectID := projectRes.GetProjectId()
 
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
+	updateReq := organizationv1.UpdateProjectLimitsRequest_builder{
 		ProjectId:              projectID,
 		DefaultMemoryRequestMi: proto.Int32(128),
 		DefaultMemoryLimitMi:   proto.Int32(256),
 		DefaultCpuRequestM:     proto.Int32(100),
 		DefaultCpuLimitM:       proto.Int32(500),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
-	_, err = projectClient.UpdateProjectLimits(context.Background(), updateReq)
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	_, err = projectClient.UpdateProjectLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	res, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	limits := res.Msg.GetLimits()
+	limits := res.GetLimits()
 	require.NotNil(t, limits)
 	assert.EqualValues(t, 128, limits.GetDefaultMemoryRequestMi())
 	assert.EqualValues(t, 256, limits.GetDefaultMemoryLimitMi())

--- a/organization-api/pkg/organization/project_limits_update.go
+++ b/organization-api/pkg/organization/project_limits_update.go
@@ -19,9 +19,9 @@ import (
 
 func (s *Server) UpdateProjectLimits(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateProjectLimitsRequest],
-) (*connect.Response[organizationv1.UpdateProjectLimitsResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.UpdateProjectLimitsRequest,
+) (*organizationv1.UpdateProjectLimitsResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -29,10 +29,10 @@ func (s *Server) UpdateProjectLimits(
 
 	params := db.ProjectLimitsUpsertParams{
 		ProjectID:              projectID,
-		DefaultMemoryRequestMi: pgtype.Int4{Int32: req.Msg.GetDefaultMemoryRequestMi(), Valid: req.Msg.HasDefaultMemoryRequestMi()},
-		DefaultMemoryLimitMi:   pgtype.Int4{Int32: req.Msg.GetDefaultMemoryLimitMi(), Valid: req.Msg.HasDefaultMemoryLimitMi()},
-		DefaultCpuRequestM:     pgtype.Int4{Int32: req.Msg.GetDefaultCpuRequestM(), Valid: req.Msg.HasDefaultCpuRequestM()},
-		DefaultCpuLimitM:       pgtype.Int4{Int32: req.Msg.GetDefaultCpuLimitM(), Valid: req.Msg.HasDefaultCpuLimitM()},
+		DefaultMemoryRequestMi: pgtype.Int4{Int32: req.GetDefaultMemoryRequestMi(), Valid: req.HasDefaultMemoryRequestMi()},
+		DefaultMemoryLimitMi:   pgtype.Int4{Int32: req.GetDefaultMemoryLimitMi(), Valid: req.HasDefaultMemoryLimitMi()},
+		DefaultCpuRequestM:     pgtype.Int4{Int32: req.GetDefaultCpuRequestM(), Valid: req.HasDefaultCpuRequestM()},
+		DefaultCpuLimitM:       pgtype.Int4{Int32: req.GetDefaultCpuLimitM(), Valid: req.HasDefaultCpuLimitM()},
 	}
 
 	if _, err := s.queries.ProjectLimitsUpsert(ctx, params); err != nil {
@@ -49,5 +49,5 @@ func (s *Server) UpdateProjectLimits(
 
 	s.logger.InfoContext(ctx, "project limits updated", "project_id", projectID)
 
-	return connect.NewResponse(organizationv1.UpdateProjectLimitsResponse_builder{}.Build()), nil
+	return organizationv1.UpdateProjectLimitsResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_limits_update_test.go
+++ b/organization-api/pkg/organization/project_limits_update_test.go
@@ -19,9 +19,9 @@ func Test_ProjectLimits_Update_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.UpdateProjectLimits(context.Background(), connect.NewRequest(
+	_, err := client.UpdateProjectLimits(context.Background(),
 		organizationv1.UpdateProjectLimitsRequest_builder{ProjectId: uuid.New().String()}.Build(),
-	))
+	)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -43,44 +43,48 @@ func Test_ProjectLimits_Update(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
-	projectID := projectRes.Msg.GetProjectId()
+	projectID := projectRes.GetProjectId()
 
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
+	updateReq := organizationv1.UpdateProjectLimitsRequest_builder{
 		ProjectId:              projectID,
 		DefaultMemoryRequestMi: proto.Int32(128),
 		DefaultMemoryLimitMi:   proto.Int32(256),
 		DefaultCpuRequestM:     proto.Int32(100),
 		DefaultCpuLimitM:       proto.Int32(500),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = projectClient.UpdateProjectLimits(context.Background(), updateReq)
+	_, err = projectClient.UpdateProjectLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
+	getReq := organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	getRes, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	getRes, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	limits := getRes.Msg.GetLimits()
+	limits := getRes.GetLimits()
 	require.NotNil(t, limits)
 	assert.EqualValues(t, 128, limits.GetDefaultMemoryRequestMi())
 	assert.EqualValues(t, 256, limits.GetDefaultMemoryLimitMi())
@@ -103,48 +107,53 @@ func Test_ProjectLimits_Update_Overwrites(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
-	projectID := projectRes.Msg.GetProjectId()
+	projectID := projectRes.GetProjectId()
 
-	firstUpdate := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
+	firstUpdate := organizationv1.UpdateProjectLimitsRequest_builder{
 		ProjectId:            projectID,
 		DefaultMemoryLimitMi: proto.Int32(256),
-	}.Build())
-	firstUpdate.Header().Set("Authorization", "Bearer "+token)
-	firstUpdate.Header().Set("Fun-Organization", orgID.String())
-	_, err = projectClient.UpdateProjectLimits(context.Background(), firstUpdate)
+	}.Build()
+	firstUpdateCtx, firstUpdateCallInfo := connect.NewClientContext(context.Background())
+	firstUpdateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	firstUpdateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	_, err = projectClient.UpdateProjectLimits(firstUpdateCtx, firstUpdate)
 	require.NoError(t, err)
 
-	secondUpdate := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
+	secondUpdate := organizationv1.UpdateProjectLimitsRequest_builder{
 		ProjectId:            projectID,
 		DefaultMemoryLimitMi: proto.Int32(512),
-	}.Build())
-	secondUpdate.Header().Set("Authorization", "Bearer "+token)
-	secondUpdate.Header().Set("Fun-Organization", orgID.String())
-	_, err = projectClient.UpdateProjectLimits(context.Background(), secondUpdate)
+	}.Build()
+	secondUpdateCtx, secondUpdateCallInfo := connect.NewClientContext(context.Background())
+	secondUpdateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	secondUpdateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	_, err = projectClient.UpdateProjectLimits(secondUpdateCtx, secondUpdate)
 	require.NoError(t, err)
 
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
-	getRes, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	getReq := organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	getRes, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 512, getRes.Msg.GetLimits().GetDefaultMemoryLimitMi())
+	assert.EqualValues(t, 512, getRes.GetLimits().GetDefaultMemoryLimitMi())
 }
 
 func Test_ProjectLimits_Update_IsolatedBetweenProjects(t *testing.T) {
@@ -162,50 +171,55 @@ func Test_ProjectLimits_Update_IsolatedBetweenProjects(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
-	clusterID := clusterRes.Msg.GetClusterId()
+	clusterID := clusterRes.GetClusterId()
 
-	createProject1Req := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
+	createProject1Req := organizationv1.CreateProjectRequest_builder{
 		ClusterId: clusterID, Name: "project-one",
-	}.Build())
-	createProject1Req.Header().Set("Authorization", "Bearer "+token)
-	createProject1Req.Header().Set("Fun-Organization", orgID.String())
-	project1Res, err := projectClient.CreateProject(context.Background(), createProject1Req)
+	}.Build()
+	createProject1Ctx, createProject1CallInfo := connect.NewClientContext(context.Background())
+	createProject1CallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProject1CallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	project1Res, err := projectClient.CreateProject(createProject1Ctx, createProject1Req)
 	require.NoError(t, err)
 
-	createProject2Req := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
+	createProject2Req := organizationv1.CreateProjectRequest_builder{
 		ClusterId: clusterID, Name: "project-two",
-	}.Build())
-	createProject2Req.Header().Set("Authorization", "Bearer "+token)
-	createProject2Req.Header().Set("Fun-Organization", orgID.String())
-	project2Res, err := projectClient.CreateProject(context.Background(), createProject2Req)
+	}.Build()
+	createProject2Ctx, createProject2CallInfo := connect.NewClientContext(context.Background())
+	createProject2CallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProject2CallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	project2Res, err := projectClient.CreateProject(createProject2Ctx, createProject2Req)
 	require.NoError(t, err)
 
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
-		ProjectId:            project1Res.Msg.GetProjectId(),
+	updateReq := organizationv1.UpdateProjectLimitsRequest_builder{
+		ProjectId:            project1Res.GetProjectId(),
 		DefaultMemoryLimitMi: proto.Int32(256),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token)
-	updateReq.Header().Set("Fun-Organization", orgID.String())
-	_, err = projectClient.UpdateProjectLimits(context.Background(), updateReq)
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	_, err = projectClient.UpdateProjectLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
 	// project2 should see no limits
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{
-		ProjectId: project2Res.Msg.GetProjectId(),
-	}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token)
-	getReq.Header().Set("Fun-Organization", orgID.String())
-	getRes, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	getReq := organizationv1.GetProjectLimitsRequest_builder{
+		ProjectId: project2Res.GetProjectId(),
+	}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	getCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	getRes, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
 
-	assert.False(t, getRes.Msg.GetLimits().HasDefaultMemoryLimitMi())
+	assert.False(t, getRes.GetLimits().HasDefaultMemoryLimitMi())
 }
 
 func Test_ProjectLimits_Update_IsolatedBetweenOrgs(t *testing.T) {
@@ -229,40 +243,44 @@ func Test_ProjectLimits_Update_IsolatedBetweenOrgs(t *testing.T) {
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
 	// Create a cluster and project in org1
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token1)
-	createClusterReq.Header().Set("Fun-Organization", org1ID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token1)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", org1ID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token1)
-	createProjectReq.Header().Set("Fun-Organization", org1ID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token1)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", org1ID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
-	projectID := projectRes.Msg.GetProjectId()
+	projectID := projectRes.GetProjectId()
 
 	// Set limits on org1's project
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
+	updateReq := organizationv1.UpdateProjectLimitsRequest_builder{
 		ProjectId:            projectID,
 		DefaultMemoryLimitMi: proto.Int32(256),
-	}.Build())
-	updateReq.Header().Set("Authorization", "Bearer "+token1)
-	updateReq.Header().Set("Fun-Organization", org1ID.String())
-	_, err = projectClient.UpdateProjectLimits(context.Background(), updateReq)
+	}.Build()
+	updateCtx, updateCallInfo := connect.NewClientContext(context.Background())
+	updateCallInfo.RequestHeader().Set("Authorization", "Bearer "+token1)
+	updateCallInfo.RequestHeader().Set("Fun-Organization", org1ID.String())
+	_, err = projectClient.UpdateProjectLimits(updateCtx, updateReq)
 	require.NoError(t, err)
 
 	// user2 (org2) should not see org1's project limits
-	getReq := connect.NewRequest(organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build())
-	getReq.Header().Set("Authorization", "Bearer "+token2)
-	getReq.Header().Set("Fun-Organization", org2ID.String())
-	getRes, err := projectClient.GetProjectLimits(context.Background(), getReq)
+	getReq := organizationv1.GetProjectLimitsRequest_builder{ProjectId: projectID}.Build()
+	getCtx, getCallInfo := connect.NewClientContext(context.Background())
+	getCallInfo.RequestHeader().Set("Authorization", "Bearer "+token2)
+	getCallInfo.RequestHeader().Set("Fun-Organization", org2ID.String())
+	getRes, err := projectClient.GetProjectLimits(getCtx, getReq)
 	require.NoError(t, err)
-	assert.False(t, getRes.Msg.GetLimits().HasDefaultMemoryLimitMi())
+	assert.False(t, getRes.GetLimits().HasDefaultMemoryLimitMi())
 }
 
 func Test_ProjectLimits_Update_MemoryLimitLessThanRequest(t *testing.T) {
@@ -280,31 +298,34 @@ func Test_ProjectLimits_Update_MemoryLimitLessThanRequest(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
 
-	req := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
-		ProjectId:              projectRes.Msg.GetProjectId(),
+	req := organizationv1.UpdateProjectLimitsRequest_builder{
+		ProjectId:              projectRes.GetProjectId(),
 		DefaultMemoryRequestMi: proto.Int32(256),
 		DefaultMemoryLimitMi:   proto.Int32(128),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = projectClient.UpdateProjectLimits(context.Background(), req)
+	_, err = projectClient.UpdateProjectLimits(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -326,31 +347,34 @@ func Test_ProjectLimits_Update_CpuLimitLessThanRequest(t *testing.T) {
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 	projectClient := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name: "test-cluster", Region: "eu-west-1", KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
-	clusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	clusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: clusterRes.Msg.GetClusterId(), Name: "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
-	projectRes, err := projectClient.CreateProject(context.Background(), createProjectReq)
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: clusterRes.GetClusterId(), Name: "test-project",
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
+	projectRes, err := projectClient.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
 
-	req := connect.NewRequest(organizationv1.UpdateProjectLimitsRequest_builder{
-		ProjectId:          projectRes.Msg.GetProjectId(),
+	req := organizationv1.UpdateProjectLimitsRequest_builder{
+		ProjectId:          projectRes.GetProjectId(),
 		DefaultCpuRequestM: proto.Int32(500),
 		DefaultCpuLimitM:   proto.Int32(100),
-	}.Build())
-	req.Header().Set("Authorization", "Bearer "+token)
-	req.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	ctx, callInfo := connect.NewClientContext(context.Background())
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = projectClient.UpdateProjectLimits(context.Background(), req)
+	_, err = projectClient.UpdateProjectLimits(ctx, req)
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)

--- a/organization-api/pkg/organization/project_list.go
+++ b/organization-api/pkg/organization/project_list.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) ListProjects(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListProjectsRequest],
-) (*connect.Response[organizationv1.ListProjectsResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
+	req *organizationv1.ListProjectsRequest,
+) (*organizationv1.ListProjectsResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
 
 	if err := s.checkPermission(ctx, authz.CanListProjects(), authz.Cluster(clusterID)); err != nil {
 		return nil, err
@@ -33,9 +33,9 @@ func (s *Server) ListProjects(
 		result = append(result, projectFromListRow(&projects[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListProjectsResponse_builder{
+	return organizationv1.ListProjectsResponse_builder{
 		Projects: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func projectFromListRow(row *db.ProjectListByClusterIDRow) *organizationv1.Project {

--- a/organization-api/pkg/organization/project_member_add.go
+++ b/organization-api/pkg/organization/project_member_add.go
@@ -18,12 +18,12 @@ import (
 
 func (s *Server) AddProjectMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.AddProjectMemberRequest],
-) (*connect.Response[organizationv1.AddProjectMemberResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
-	userID := uuid.MustParse(req.Msg.GetUserId())
+	req *organizationv1.AddProjectMemberRequest,
+) (*organizationv1.AddProjectMemberResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
+	userID := uuid.MustParse(req.GetUserId())
 
-	role := projectMemberRoleToDB(req.Msg.GetRole())
+	role := projectMemberRoleToDB(req.GetRole())
 	if role == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid role"))
 	}
@@ -55,7 +55,7 @@ func (s *Server) AddProjectMember(
 		"role", role,
 	)
 
-	return connect.NewResponse(organizationv1.AddProjectMemberResponse_builder{
+	return organizationv1.AddProjectMemberResponse_builder{
 		MemberId: memberID.String(),
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_member_add_test.go
+++ b/organization-api/pkg/organization/project_member_add_test.go
@@ -18,11 +18,11 @@ func Test_ProjectMember_Add_Unauthenticated(t *testing.T) {
 	env := newTestAPI(t)
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.AddProjectMember(context.Background(), connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
+	_, err := client.AddProjectMember(context.Background(), organizationv1.AddProjectMemberRequest_builder{
 		ProjectId: uuid.New().String(),
 		UserId:    uuid.New().String(),
 		Role:      organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_VIEWER,
-	}.Build()))
+	}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -53,58 +53,62 @@ func Test_ProjectMember_Add(t *testing.T) {
 	token := env.createAuthnToken(t, callerUserID)
 
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createClusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	createClusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: createClusterRes.Msg.GetClusterId(),
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: createClusterRes.GetClusterId(),
 		Name:      "test-project",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createProjectRes, err := client.CreateProject(context.Background(), createProjectReq)
+	createProjectRes, err := client.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
 
-	projectID := createProjectRes.Msg.GetProjectId()
+	projectID := createProjectRes.GetProjectId()
 
-	addReq := connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
+	addReq := organizationv1.AddProjectMemberRequest_builder{
 		ProjectId: projectID,
 		UserId:    newMemberUserID.String(),
 		Role:      organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_VIEWER,
-	}.Build())
-	addReq.Header().Set("Authorization", "Bearer "+token)
-	addReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	addCtx, addCallInfo := connect.NewClientContext(context.Background())
+	addCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	addCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	res, err := client.AddProjectMember(context.Background(), addReq)
+	res, err := client.AddProjectMember(addCtx, addReq)
 	require.NoError(t, err)
-	assert.NotEmpty(t, res.Msg.GetMemberId())
+	assert.NotEmpty(t, res.GetMemberId())
 
 	// Adding the same user a second time must fail.
-	_, err = client.AddProjectMember(context.Background(), addReq)
+	_, err = client.AddProjectMember(addCtx, addReq)
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeAlreadyExists, connectErr.Code())
 
-	invalidRoleReq := connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
+	invalidRoleReq := organizationv1.AddProjectMemberRequest_builder{
 		ProjectId: projectID,
 		UserId:    uuid.New().String(),
 		Role:      organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_UNSPECIFIED,
-	}.Build())
-	invalidRoleReq.Header().Set("Authorization", "Bearer "+token)
-	invalidRoleReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	invalidRoleCtx, invalidRoleCallInfo := connect.NewClientContext(context.Background())
+	invalidRoleCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	invalidRoleCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	_, err = client.AddProjectMember(context.Background(), invalidRoleReq)
+	_, err = client.AddProjectMember(invalidRoleCtx, invalidRoleReq)
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
 }

--- a/organization-api/pkg/organization/project_member_get.go
+++ b/organization-api/pkg/organization/project_member_get.go
@@ -17,9 +17,9 @@ import (
 
 func (s *Server) GetProjectMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.GetProjectMemberRequest],
-) (*connect.Response[organizationv1.GetProjectMemberResponse], error) {
-	memberID := uuid.MustParse(req.Msg.GetMemberId())
+	req *organizationv1.GetProjectMemberRequest,
+) (*organizationv1.GetProjectMemberResponse, error) {
+	memberID := uuid.MustParse(req.GetMemberId())
 
 	if err := s.checkPermission(ctx, authz.CanView(), authz.ProjectMember(memberID)); err != nil {
 		return nil, err
@@ -33,9 +33,9 @@ func (s *Server) GetProjectMember(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get project member: %w", err))
 	}
 
-	return connect.NewResponse(organizationv1.GetProjectMemberResponse_builder{
+	return organizationv1.GetProjectMemberResponse_builder{
 		Member: projectMemberFromGetRow(&member),
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func projectMemberFromGetRow(row *db.ProjectMemberGetByIDRow) *organizationv1.ProjectMember {

--- a/organization-api/pkg/organization/project_member_get_test.go
+++ b/organization-api/pkg/organization/project_member_get_test.go
@@ -19,7 +19,7 @@ func Test_ProjectMember_Get_Unauthenticated(t *testing.T) {
 
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	_, err := client.GetProjectMember(context.Background(), connect.NewRequest(organizationv1.GetProjectMemberRequest_builder{}.Build()))
+	_, err := client.GetProjectMember(context.Background(), organizationv1.GetProjectMemberRequest_builder{}.Build())
 
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
@@ -51,38 +51,41 @@ func Test_ProjectMember_Get(t *testing.T) {
 
 	clusterClient := organizationv1connect.NewClusterServiceClient(env.server.Client(), env.server.URL)
 
-	createClusterReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createClusterReq := organizationv1.CreateClusterRequest_builder{
 		Name:              "test-cluster",
 		Region:            "eu-west-1",
 		KubernetesVersion: "1.28",
-	}.Build())
-	createClusterReq.Header().Set("Authorization", "Bearer "+token)
-	createClusterReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createClusterCtx, createClusterCallInfo := connect.NewClientContext(context.Background())
+	createClusterCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createClusterCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createClusterRes, err := clusterClient.CreateCluster(context.Background(), createClusterReq)
+	createClusterRes, err := clusterClient.CreateCluster(createClusterCtx, createClusterReq)
 	require.NoError(t, err)
 
 	client := organizationv1connect.NewProjectServiceClient(env.server.Client(), env.server.URL)
 
-	createProjectReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
-		ClusterId: createClusterRes.Msg.GetClusterId(),
+	createProjectReq := organizationv1.CreateProjectRequest_builder{
+		ClusterId: createClusterRes.GetClusterId(),
 		Name:      "arbitrary",
-	}.Build())
-	createProjectReq.Header().Set("Authorization", "Bearer "+token)
-	createProjectReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	createProjectCtx, createProjectCallInfo := connect.NewClientContext(context.Background())
+	createProjectCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	createProjectCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	createProjectRes, err := client.CreateProject(context.Background(), createProjectReq)
+	createProjectRes, err := client.CreateProject(createProjectCtx, createProjectReq)
 	require.NoError(t, err)
 
-	addProjectMemberReq := connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
-		ProjectId: createProjectRes.Msg.GetProjectId(),
+	addProjectMemberReq := organizationv1.AddProjectMemberRequest_builder{
+		ProjectId: createProjectRes.GetProjectId(),
 		UserId:    projectMemberUserID.String(),
 		Role:      organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_VIEWER,
-	}.Build())
-	addProjectMemberReq.Header().Set("Authorization", "Bearer "+token)
-	addProjectMemberReq.Header().Set("Fun-Organization", orgID.String())
+	}.Build()
+	addProjectMemberCtx, addProjectMemberCallInfo := connect.NewClientContext(context.Background())
+	addProjectMemberCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+	addProjectMemberCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-	addMemberRes, err := client.AddProjectMember(context.Background(), addProjectMemberReq)
+	addMemberRes, err := client.AddProjectMember(addProjectMemberCtx, addProjectMemberReq)
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -99,12 +102,12 @@ func Test_ProjectMember_Get(t *testing.T) {
 		},
 		"happy_flow": {
 			Request: organizationv1.GetProjectMemberRequest_builder{
-				MemberId: addMemberRes.Msg.GetMemberId(),
+				MemberId: addMemberRes.GetMemberId(),
 			}.Build(),
 			ExpectedResponse: organizationv1.GetProjectMemberResponse_builder{
 				Member: organizationv1.ProjectMember_builder{
-					Id:        addMemberRes.Msg.GetMemberId(),
-					ProjectId: createProjectRes.Msg.GetProjectId(),
+					Id:        addMemberRes.GetMemberId(),
+					ProjectId: createProjectRes.GetProjectId(),
 					UserId:    projectMemberUserID.String(),
 					UserName:  "project-member-name",
 					Role:      organizationv1.ProjectMemberRole_PROJECT_MEMBER_ROLE_VIEWER,
@@ -117,23 +120,24 @@ func Test_ProjectMember_Get(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			getProjectMemberReq := connect.NewRequest(tc.Request)
-			getProjectMemberReq.Header().Set("Authorization", "Bearer "+token)
-			getProjectMemberReq.Header().Set("Fun-Organization", orgID.String())
+			getProjectMemberReq := tc.Request
+			getProjectMemberCtx, getProjectMemberCallInfo := connect.NewClientContext(context.Background())
+			getProjectMemberCallInfo.RequestHeader().Set("Authorization", "Bearer "+token)
+			getProjectMemberCallInfo.RequestHeader().Set("Fun-Organization", orgID.String())
 
-			res, err := client.GetProjectMember(context.Background(), getProjectMemberReq)
+			res, err := client.GetProjectMember(getProjectMemberCtx, getProjectMemberReq)
 
 			if tc.ExpectedErrorCode != 0 {
 				var connectErr *connect.Error
 				require.ErrorAs(t, err, &connectErr)
 				assert.Equal(t, tc.ExpectedErrorCode, connectErr.Code())
 			} else {
-				assert.True(t, res.Msg.HasMember())
-				assert.Equal(t, tc.ExpectedResponse.GetMember().GetProjectId(), res.Msg.GetMember().GetProjectId())
-				assert.Equal(t, tc.ExpectedResponse.GetMember().GetId(), res.Msg.GetMember().GetId())
-				assert.Equal(t, tc.ExpectedResponse.GetMember().GetUserId(), res.Msg.GetMember().GetUserId())
-				assert.Equal(t, tc.ExpectedResponse.GetMember().GetRole().String(), res.Msg.GetMember().GetRole().String())
-				assert.Equal(t, tc.ExpectedResponse.GetMember().GetUserName(), res.Msg.GetMember().GetUserName())
+				assert.True(t, res.HasMember())
+				assert.Equal(t, tc.ExpectedResponse.GetMember().GetProjectId(), res.GetMember().GetProjectId())
+				assert.Equal(t, tc.ExpectedResponse.GetMember().GetId(), res.GetMember().GetId())
+				assert.Equal(t, tc.ExpectedResponse.GetMember().GetUserId(), res.GetMember().GetUserId())
+				assert.Equal(t, tc.ExpectedResponse.GetMember().GetRole().String(), res.GetMember().GetRole().String())
+				assert.Equal(t, tc.ExpectedResponse.GetMember().GetUserName(), res.GetMember().GetUserName())
 			}
 		})
 	}

--- a/organization-api/pkg/organization/project_member_list.go
+++ b/organization-api/pkg/organization/project_member_list.go
@@ -15,9 +15,9 @@ import (
 
 func (s *Server) ListProjectMembers(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListProjectMembersRequest],
-) (*connect.Response[organizationv1.ListProjectMembersResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.ListProjectMembersRequest,
+) (*organizationv1.ListProjectMembersResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanListMembers(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -33,9 +33,9 @@ func (s *Server) ListProjectMembers(
 		result = append(result, projectMemberFromListRow(&members[i]))
 	}
 
-	return connect.NewResponse(organizationv1.ListProjectMembersResponse_builder{
+	return organizationv1.ListProjectMembersResponse_builder{
 		Members: result,
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func projectMemberFromListRow(row *db.ProjectMemberListRow) *organizationv1.ProjectMember {

--- a/organization-api/pkg/organization/project_member_remove.go
+++ b/organization-api/pkg/organization/project_member_remove.go
@@ -18,9 +18,9 @@ import (
 
 func (s *Server) RemoveProjectMember(
 	ctx context.Context,
-	req *connect.Request[organizationv1.RemoveProjectMemberRequest],
-) (*connect.Response[organizationv1.RemoveProjectMemberResponse], error) {
-	memberID := uuid.MustParse(req.Msg.GetMemberId())
+	req *organizationv1.RemoveProjectMemberRequest,
+) (*organizationv1.RemoveProjectMemberResponse, error) {
+	memberID := uuid.MustParse(req.GetMemberId())
 
 	if err := s.checkPermission(ctx, authz.CanDelete(), authz.ProjectMember(memberID)); err != nil {
 		return nil, err
@@ -47,5 +47,5 @@ func (s *Server) RemoveProjectMember(
 		"member_id", memberID,
 	)
 
-	return connect.NewResponse(organizationv1.RemoveProjectMemberResponse_builder{}.Build()), nil
+	return organizationv1.RemoveProjectMemberResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_member_update.go
+++ b/organization-api/pkg/organization/project_member_update.go
@@ -18,11 +18,11 @@ import (
 
 func (s *Server) UpdateProjectMemberRole(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateProjectMemberRoleRequest],
-) (*connect.Response[organizationv1.UpdateProjectMemberRoleResponse], error) {
-	memberID := uuid.MustParse(req.Msg.GetMemberId())
+	req *organizationv1.UpdateProjectMemberRoleRequest,
+) (*organizationv1.UpdateProjectMemberRoleResponse, error) {
+	memberID := uuid.MustParse(req.GetMemberId())
 
-	role := projectMemberRoleToDB(req.Msg.GetRole())
+	role := projectMemberRoleToDB(req.GetRole())
 	if role == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid role"))
 	}
@@ -54,5 +54,5 @@ func (s *Server) UpdateProjectMemberRole(
 		"role", role,
 	)
 
-	return connect.NewResponse(organizationv1.UpdateProjectMemberRoleResponse_builder{}.Build()), nil
+	return organizationv1.UpdateProjectMemberRoleResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/project_update.go
+++ b/organization-api/pkg/organization/project_update.go
@@ -19,9 +19,9 @@ import (
 
 func (s *Server) UpdateProject(
 	ctx context.Context,
-	req *connect.Request[organizationv1.UpdateProjectRequest],
-) (*connect.Response[organizationv1.UpdateProjectResponse], error) {
-	projectID := uuid.MustParse(req.Msg.GetProjectId())
+	req *organizationv1.UpdateProjectRequest,
+) (*organizationv1.UpdateProjectResponse, error) {
+	projectID := uuid.MustParse(req.GetProjectId())
 
 	if err := s.checkPermission(ctx, authz.CanEdit(), authz.Project(projectID)); err != nil {
 		return nil, err
@@ -31,8 +31,8 @@ func (s *Server) UpdateProject(
 		ID: projectID,
 	}
 
-	if req.Msg.HasAlias() {
-		params.Alias = pgtype.Text{String: req.Msg.GetAlias(), Valid: true}
+	if req.HasAlias() {
+		params.Alias = pgtype.Text{String: req.GetAlias(), Valid: true}
 	}
 
 	rowsAffected, err := s.queries.ProjectUpdate(ctx, params)
@@ -51,5 +51,5 @@ func (s *Server) UpdateProject(
 
 	s.logger.InfoContext(ctx, "project updated", "project_id", projectID)
 
-	return connect.NewResponse(organizationv1.UpdateProjectResponse_builder{}.Build()), nil
+	return organizationv1.UpdateProjectResponse_builder{}.Build(), nil
 }

--- a/organization-api/pkg/organization/region_list.go
+++ b/organization-api/pkg/organization/region_list.go
@@ -16,8 +16,8 @@ import (
 // permission check or org filter (same pattern as ListPresets).
 func (s *Server) ListRegions(
 	ctx context.Context,
-	req *connect.Request[organizationv1.ListRegionsRequest],
-) (*connect.Response[organizationv1.ListRegionsResponse], error) {
+	req *organizationv1.ListRegionsRequest,
+) (*organizationv1.ListRegionsResponse, error) {
 	regions, err := s.queries.RegionList(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list regions: %w", err))
@@ -56,7 +56,7 @@ func (s *Server) ListRegions(
 		}.Build())
 	}
 
-	return connect.NewResponse(organizationv1.ListRegionsResponse_builder{
+	return organizationv1.ListRegionsResponse_builder{
 		Regions: result,
-	}.Build()), nil
+	}.Build(), nil
 }

--- a/organization-api/pkg/proto/buf.gen.yaml
+++ b/organization-api/pkg/proto/buf.gen.yaml
@@ -5,4 +5,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/apikey.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/apikey.connect.go
@@ -52,15 +52,15 @@ const (
 // APIKeyServiceClient is a client for the organization.v1.APIKeyService service.
 type APIKeyServiceClient interface {
 	// Create a new API key
-	CreateAPIKey(context.Context, *connect.Request[v1.CreateAPIKeyRequest]) (*connect.Response[v1.CreateAPIKeyResponse], error)
+	CreateAPIKey(context.Context, *v1.CreateAPIKeyRequest) (*v1.CreateAPIKeyResponse, error)
 	// List all API keys for the current organization
-	ListAPIKeys(context.Context, *connect.Request[v1.ListAPIKeysRequest]) (*connect.Response[v1.ListAPIKeysResponse], error)
+	ListAPIKeys(context.Context, *v1.ListAPIKeysRequest) (*v1.ListAPIKeysResponse, error)
 	// Get a specific API key by ID
-	GetAPIKey(context.Context, *connect.Request[v1.GetAPIKeyRequest]) (*connect.Response[v1.GetAPIKeyResponse], error)
+	GetAPIKey(context.Context, *v1.GetAPIKeyRequest) (*v1.GetAPIKeyResponse, error)
 	// Revoke an API key
-	RevokeAPIKey(context.Context, *connect.Request[v1.RevokeAPIKeyRequest]) (*connect.Response[v1.RevokeAPIKeyResponse], error)
+	RevokeAPIKey(context.Context, *v1.RevokeAPIKeyRequest) (*v1.RevokeAPIKeyResponse, error)
 	// Delete an API key
-	DeleteAPIKey(context.Context, *connect.Request[v1.DeleteAPIKeyRequest]) (*connect.Response[v1.DeleteAPIKeyResponse], error)
+	DeleteAPIKey(context.Context, *v1.DeleteAPIKeyRequest) (*v1.DeleteAPIKeyResponse, error)
 }
 
 // NewAPIKeyServiceClient constructs a client for the organization.v1.APIKeyService service. By
@@ -117,42 +117,62 @@ type aPIKeyServiceClient struct {
 }
 
 // CreateAPIKey calls organization.v1.APIKeyService.CreateAPIKey.
-func (c *aPIKeyServiceClient) CreateAPIKey(ctx context.Context, req *connect.Request[v1.CreateAPIKeyRequest]) (*connect.Response[v1.CreateAPIKeyResponse], error) {
-	return c.createAPIKey.CallUnary(ctx, req)
+func (c *aPIKeyServiceClient) CreateAPIKey(ctx context.Context, req *v1.CreateAPIKeyRequest) (*v1.CreateAPIKeyResponse, error) {
+	response, err := c.createAPIKey.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListAPIKeys calls organization.v1.APIKeyService.ListAPIKeys.
-func (c *aPIKeyServiceClient) ListAPIKeys(ctx context.Context, req *connect.Request[v1.ListAPIKeysRequest]) (*connect.Response[v1.ListAPIKeysResponse], error) {
-	return c.listAPIKeys.CallUnary(ctx, req)
+func (c *aPIKeyServiceClient) ListAPIKeys(ctx context.Context, req *v1.ListAPIKeysRequest) (*v1.ListAPIKeysResponse, error) {
+	response, err := c.listAPIKeys.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetAPIKey calls organization.v1.APIKeyService.GetAPIKey.
-func (c *aPIKeyServiceClient) GetAPIKey(ctx context.Context, req *connect.Request[v1.GetAPIKeyRequest]) (*connect.Response[v1.GetAPIKeyResponse], error) {
-	return c.getAPIKey.CallUnary(ctx, req)
+func (c *aPIKeyServiceClient) GetAPIKey(ctx context.Context, req *v1.GetAPIKeyRequest) (*v1.GetAPIKeyResponse, error) {
+	response, err := c.getAPIKey.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RevokeAPIKey calls organization.v1.APIKeyService.RevokeAPIKey.
-func (c *aPIKeyServiceClient) RevokeAPIKey(ctx context.Context, req *connect.Request[v1.RevokeAPIKeyRequest]) (*connect.Response[v1.RevokeAPIKeyResponse], error) {
-	return c.revokeAPIKey.CallUnary(ctx, req)
+func (c *aPIKeyServiceClient) RevokeAPIKey(ctx context.Context, req *v1.RevokeAPIKeyRequest) (*v1.RevokeAPIKeyResponse, error) {
+	response, err := c.revokeAPIKey.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteAPIKey calls organization.v1.APIKeyService.DeleteAPIKey.
-func (c *aPIKeyServiceClient) DeleteAPIKey(ctx context.Context, req *connect.Request[v1.DeleteAPIKeyRequest]) (*connect.Response[v1.DeleteAPIKeyResponse], error) {
-	return c.deleteAPIKey.CallUnary(ctx, req)
+func (c *aPIKeyServiceClient) DeleteAPIKey(ctx context.Context, req *v1.DeleteAPIKeyRequest) (*v1.DeleteAPIKeyResponse, error) {
+	response, err := c.deleteAPIKey.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // APIKeyServiceHandler is an implementation of the organization.v1.APIKeyService service.
 type APIKeyServiceHandler interface {
 	// Create a new API key
-	CreateAPIKey(context.Context, *connect.Request[v1.CreateAPIKeyRequest]) (*connect.Response[v1.CreateAPIKeyResponse], error)
+	CreateAPIKey(context.Context, *v1.CreateAPIKeyRequest) (*v1.CreateAPIKeyResponse, error)
 	// List all API keys for the current organization
-	ListAPIKeys(context.Context, *connect.Request[v1.ListAPIKeysRequest]) (*connect.Response[v1.ListAPIKeysResponse], error)
+	ListAPIKeys(context.Context, *v1.ListAPIKeysRequest) (*v1.ListAPIKeysResponse, error)
 	// Get a specific API key by ID
-	GetAPIKey(context.Context, *connect.Request[v1.GetAPIKeyRequest]) (*connect.Response[v1.GetAPIKeyResponse], error)
+	GetAPIKey(context.Context, *v1.GetAPIKeyRequest) (*v1.GetAPIKeyResponse, error)
 	// Revoke an API key
-	RevokeAPIKey(context.Context, *connect.Request[v1.RevokeAPIKeyRequest]) (*connect.Response[v1.RevokeAPIKeyResponse], error)
+	RevokeAPIKey(context.Context, *v1.RevokeAPIKeyRequest) (*v1.RevokeAPIKeyResponse, error)
 	// Delete an API key
-	DeleteAPIKey(context.Context, *connect.Request[v1.DeleteAPIKeyRequest]) (*connect.Response[v1.DeleteAPIKeyResponse], error)
+	DeleteAPIKey(context.Context, *v1.DeleteAPIKeyRequest) (*v1.DeleteAPIKeyResponse, error)
 }
 
 // NewAPIKeyServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -162,31 +182,31 @@ type APIKeyServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewAPIKeyServiceHandler(svc APIKeyServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	aPIKeyServiceMethods := v1.File_v1_apikey_proto.Services().ByName("APIKeyService").Methods()
-	aPIKeyServiceCreateAPIKeyHandler := connect.NewUnaryHandler(
+	aPIKeyServiceCreateAPIKeyHandler := connect.NewUnaryHandlerSimple(
 		APIKeyServiceCreateAPIKeyProcedure,
 		svc.CreateAPIKey,
 		connect.WithSchema(aPIKeyServiceMethods.ByName("CreateAPIKey")),
 		connect.WithHandlerOptions(opts...),
 	)
-	aPIKeyServiceListAPIKeysHandler := connect.NewUnaryHandler(
+	aPIKeyServiceListAPIKeysHandler := connect.NewUnaryHandlerSimple(
 		APIKeyServiceListAPIKeysProcedure,
 		svc.ListAPIKeys,
 		connect.WithSchema(aPIKeyServiceMethods.ByName("ListAPIKeys")),
 		connect.WithHandlerOptions(opts...),
 	)
-	aPIKeyServiceGetAPIKeyHandler := connect.NewUnaryHandler(
+	aPIKeyServiceGetAPIKeyHandler := connect.NewUnaryHandlerSimple(
 		APIKeyServiceGetAPIKeyProcedure,
 		svc.GetAPIKey,
 		connect.WithSchema(aPIKeyServiceMethods.ByName("GetAPIKey")),
 		connect.WithHandlerOptions(opts...),
 	)
-	aPIKeyServiceRevokeAPIKeyHandler := connect.NewUnaryHandler(
+	aPIKeyServiceRevokeAPIKeyHandler := connect.NewUnaryHandlerSimple(
 		APIKeyServiceRevokeAPIKeyProcedure,
 		svc.RevokeAPIKey,
 		connect.WithSchema(aPIKeyServiceMethods.ByName("RevokeAPIKey")),
 		connect.WithHandlerOptions(opts...),
 	)
-	aPIKeyServiceDeleteAPIKeyHandler := connect.NewUnaryHandler(
+	aPIKeyServiceDeleteAPIKeyHandler := connect.NewUnaryHandlerSimple(
 		APIKeyServiceDeleteAPIKeyProcedure,
 		svc.DeleteAPIKey,
 		connect.WithSchema(aPIKeyServiceMethods.ByName("DeleteAPIKey")),
@@ -213,22 +233,22 @@ func NewAPIKeyServiceHandler(svc APIKeyServiceHandler, opts ...connect.HandlerOp
 // UnimplementedAPIKeyServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedAPIKeyServiceHandler struct{}
 
-func (UnimplementedAPIKeyServiceHandler) CreateAPIKey(context.Context, *connect.Request[v1.CreateAPIKeyRequest]) (*connect.Response[v1.CreateAPIKeyResponse], error) {
+func (UnimplementedAPIKeyServiceHandler) CreateAPIKey(context.Context, *v1.CreateAPIKeyRequest) (*v1.CreateAPIKeyResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.APIKeyService.CreateAPIKey is not implemented"))
 }
 
-func (UnimplementedAPIKeyServiceHandler) ListAPIKeys(context.Context, *connect.Request[v1.ListAPIKeysRequest]) (*connect.Response[v1.ListAPIKeysResponse], error) {
+func (UnimplementedAPIKeyServiceHandler) ListAPIKeys(context.Context, *v1.ListAPIKeysRequest) (*v1.ListAPIKeysResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.APIKeyService.ListAPIKeys is not implemented"))
 }
 
-func (UnimplementedAPIKeyServiceHandler) GetAPIKey(context.Context, *connect.Request[v1.GetAPIKeyRequest]) (*connect.Response[v1.GetAPIKeyResponse], error) {
+func (UnimplementedAPIKeyServiceHandler) GetAPIKey(context.Context, *v1.GetAPIKeyRequest) (*v1.GetAPIKeyResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.APIKeyService.GetAPIKey is not implemented"))
 }
 
-func (UnimplementedAPIKeyServiceHandler) RevokeAPIKey(context.Context, *connect.Request[v1.RevokeAPIKeyRequest]) (*connect.Response[v1.RevokeAPIKeyResponse], error) {
+func (UnimplementedAPIKeyServiceHandler) RevokeAPIKey(context.Context, *v1.RevokeAPIKeyRequest) (*v1.RevokeAPIKeyResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.APIKeyService.RevokeAPIKey is not implemented"))
 }
 
-func (UnimplementedAPIKeyServiceHandler) DeleteAPIKey(context.Context, *connect.Request[v1.DeleteAPIKeyRequest]) (*connect.Response[v1.DeleteAPIKeyResponse], error) {
+func (UnimplementedAPIKeyServiceHandler) DeleteAPIKey(context.Context, *v1.DeleteAPIKeyRequest) (*v1.DeleteAPIKeyResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.APIKeyService.DeleteAPIKey is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/cluster.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/cluster.connect.go
@@ -84,35 +84,35 @@ const (
 type ClusterServiceClient interface {
 	// List the region catalog: every region with the kubernetes versions and
 	// machine types it offers (drives the create-cluster cascade).
-	ListRegions(context.Context, *connect.Request[v1.ListRegionsRequest]) (*connect.Response[v1.ListRegionsResponse], error)
+	ListRegions(context.Context, *v1.ListRegionsRequest) (*v1.ListRegionsResponse, error)
 	// List all clusters for the current organization
-	ListClusters(context.Context, *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error)
+	ListClusters(context.Context, *v1.ListClustersRequest) (*v1.ListClustersResponse, error)
 	// Get detailed information about a specific cluster
-	GetCluster(context.Context, *connect.Request[v1.GetClusterRequest]) (*connect.Response[v1.GetClusterResponse], error)
+	GetCluster(context.Context, *v1.GetClusterRequest) (*v1.GetClusterResponse, error)
 	// Get a cluster by name
-	GetClusterByName(context.Context, *connect.Request[v1.GetClusterByNameRequest]) (*connect.Response[v1.GetClusterResponse], error)
+	GetClusterByName(context.Context, *v1.GetClusterByNameRequest) (*v1.GetClusterResponse, error)
 	// Create a new cluster
-	CreateCluster(context.Context, *connect.Request[v1.CreateClusterRequest]) (*connect.Response[v1.CreateClusterResponse], error)
+	CreateCluster(context.Context, *v1.CreateClusterRequest) (*v1.CreateClusterResponse, error)
 	// Update cluster configuration
-	UpdateCluster(context.Context, *connect.Request[v1.UpdateClusterRequest]) (*connect.Response[v1.UpdateClusterResponse], error)
+	UpdateCluster(context.Context, *v1.UpdateClusterRequest) (*v1.UpdateClusterResponse, error)
 	// Delete a cluster
-	DeleteCluster(context.Context, *connect.Request[v1.DeleteClusterRequest]) (*connect.Response[v1.DeleteClusterResponse], error)
+	DeleteCluster(context.Context, *v1.DeleteClusterRequest) (*v1.DeleteClusterResponse, error)
 	// Get cluster activity log
-	GetClusterActivity(context.Context, *connect.Request[v1.GetClusterActivityRequest]) (*connect.Response[v1.GetClusterActivityResponse], error)
+	GetClusterActivity(context.Context, *v1.GetClusterActivityRequest) (*v1.GetClusterActivityResponse, error)
 	// Download kubeconfig for a cluster
-	GetKubeconfig(context.Context, *connect.Request[v1.GetKubeconfigRequest]) (*connect.Response[v1.GetKubeconfigResponse], error)
+	GetKubeconfig(context.Context, *v1.GetKubeconfigRequest) (*v1.GetKubeconfigResponse, error)
 	// Fetch the basic-auth credentials for a cluster's metrics dashboard.
-	GetClusterMetricsCredentials(context.Context, *connect.Request[v1.GetClusterMetricsCredentialsRequest]) (*connect.Response[v1.GetClusterMetricsCredentialsResponse], error)
+	GetClusterMetricsCredentials(context.Context, *v1.GetClusterMetricsCredentialsRequest) (*v1.GetClusterMetricsCredentialsResponse, error)
 	// List node pools for a cluster
-	ListNodePools(context.Context, *connect.Request[v1.ListNodePoolsRequest]) (*connect.Response[v1.ListNodePoolsResponse], error)
+	ListNodePools(context.Context, *v1.ListNodePoolsRequest) (*v1.ListNodePoolsResponse, error)
 	// Get a node pool by ID
-	GetNodePool(context.Context, *connect.Request[v1.GetNodePoolRequest]) (*connect.Response[v1.GetNodePoolResponse], error)
+	GetNodePool(context.Context, *v1.GetNodePoolRequest) (*v1.GetNodePoolResponse, error)
 	// Create a node pool in a cluster
-	CreateNodePool(context.Context, *connect.Request[v1.CreateNodePoolRequest]) (*connect.Response[v1.CreateNodePoolResponse], error)
+	CreateNodePool(context.Context, *v1.CreateNodePoolRequest) (*v1.CreateNodePoolResponse, error)
 	// Update a node pool
-	UpdateNodePool(context.Context, *connect.Request[v1.UpdateNodePoolRequest]) (*connect.Response[v1.UpdateNodePoolResponse], error)
+	UpdateNodePool(context.Context, *v1.UpdateNodePoolRequest) (*v1.UpdateNodePoolResponse, error)
 	// Delete a node pool
-	DeleteNodePool(context.Context, *connect.Request[v1.DeleteNodePoolRequest]) (*connect.Response[v1.DeleteNodePoolResponse], error)
+	DeleteNodePool(context.Context, *v1.DeleteNodePoolRequest) (*v1.DeleteNodePoolResponse, error)
 }
 
 // NewClusterServiceClient constructs a client for the organization.v1.ClusterService service. By
@@ -239,113 +239,173 @@ type clusterServiceClient struct {
 }
 
 // ListRegions calls organization.v1.ClusterService.ListRegions.
-func (c *clusterServiceClient) ListRegions(ctx context.Context, req *connect.Request[v1.ListRegionsRequest]) (*connect.Response[v1.ListRegionsResponse], error) {
-	return c.listRegions.CallUnary(ctx, req)
+func (c *clusterServiceClient) ListRegions(ctx context.Context, req *v1.ListRegionsRequest) (*v1.ListRegionsResponse, error) {
+	response, err := c.listRegions.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListClusters calls organization.v1.ClusterService.ListClusters.
-func (c *clusterServiceClient) ListClusters(ctx context.Context, req *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error) {
-	return c.listClusters.CallUnary(ctx, req)
+func (c *clusterServiceClient) ListClusters(ctx context.Context, req *v1.ListClustersRequest) (*v1.ListClustersResponse, error) {
+	response, err := c.listClusters.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetCluster calls organization.v1.ClusterService.GetCluster.
-func (c *clusterServiceClient) GetCluster(ctx context.Context, req *connect.Request[v1.GetClusterRequest]) (*connect.Response[v1.GetClusterResponse], error) {
-	return c.getCluster.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetCluster(ctx context.Context, req *v1.GetClusterRequest) (*v1.GetClusterResponse, error) {
+	response, err := c.getCluster.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetClusterByName calls organization.v1.ClusterService.GetClusterByName.
-func (c *clusterServiceClient) GetClusterByName(ctx context.Context, req *connect.Request[v1.GetClusterByNameRequest]) (*connect.Response[v1.GetClusterResponse], error) {
-	return c.getClusterByName.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetClusterByName(ctx context.Context, req *v1.GetClusterByNameRequest) (*v1.GetClusterResponse, error) {
+	response, err := c.getClusterByName.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateCluster calls organization.v1.ClusterService.CreateCluster.
-func (c *clusterServiceClient) CreateCluster(ctx context.Context, req *connect.Request[v1.CreateClusterRequest]) (*connect.Response[v1.CreateClusterResponse], error) {
-	return c.createCluster.CallUnary(ctx, req)
+func (c *clusterServiceClient) CreateCluster(ctx context.Context, req *v1.CreateClusterRequest) (*v1.CreateClusterResponse, error) {
+	response, err := c.createCluster.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateCluster calls organization.v1.ClusterService.UpdateCluster.
-func (c *clusterServiceClient) UpdateCluster(ctx context.Context, req *connect.Request[v1.UpdateClusterRequest]) (*connect.Response[v1.UpdateClusterResponse], error) {
-	return c.updateCluster.CallUnary(ctx, req)
+func (c *clusterServiceClient) UpdateCluster(ctx context.Context, req *v1.UpdateClusterRequest) (*v1.UpdateClusterResponse, error) {
+	response, err := c.updateCluster.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteCluster calls organization.v1.ClusterService.DeleteCluster.
-func (c *clusterServiceClient) DeleteCluster(ctx context.Context, req *connect.Request[v1.DeleteClusterRequest]) (*connect.Response[v1.DeleteClusterResponse], error) {
-	return c.deleteCluster.CallUnary(ctx, req)
+func (c *clusterServiceClient) DeleteCluster(ctx context.Context, req *v1.DeleteClusterRequest) (*v1.DeleteClusterResponse, error) {
+	response, err := c.deleteCluster.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetClusterActivity calls organization.v1.ClusterService.GetClusterActivity.
-func (c *clusterServiceClient) GetClusterActivity(ctx context.Context, req *connect.Request[v1.GetClusterActivityRequest]) (*connect.Response[v1.GetClusterActivityResponse], error) {
-	return c.getClusterActivity.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetClusterActivity(ctx context.Context, req *v1.GetClusterActivityRequest) (*v1.GetClusterActivityResponse, error) {
+	response, err := c.getClusterActivity.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetKubeconfig calls organization.v1.ClusterService.GetKubeconfig.
-func (c *clusterServiceClient) GetKubeconfig(ctx context.Context, req *connect.Request[v1.GetKubeconfigRequest]) (*connect.Response[v1.GetKubeconfigResponse], error) {
-	return c.getKubeconfig.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetKubeconfig(ctx context.Context, req *v1.GetKubeconfigRequest) (*v1.GetKubeconfigResponse, error) {
+	response, err := c.getKubeconfig.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetClusterMetricsCredentials calls organization.v1.ClusterService.GetClusterMetricsCredentials.
-func (c *clusterServiceClient) GetClusterMetricsCredentials(ctx context.Context, req *connect.Request[v1.GetClusterMetricsCredentialsRequest]) (*connect.Response[v1.GetClusterMetricsCredentialsResponse], error) {
-	return c.getClusterMetricsCredentials.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetClusterMetricsCredentials(ctx context.Context, req *v1.GetClusterMetricsCredentialsRequest) (*v1.GetClusterMetricsCredentialsResponse, error) {
+	response, err := c.getClusterMetricsCredentials.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListNodePools calls organization.v1.ClusterService.ListNodePools.
-func (c *clusterServiceClient) ListNodePools(ctx context.Context, req *connect.Request[v1.ListNodePoolsRequest]) (*connect.Response[v1.ListNodePoolsResponse], error) {
-	return c.listNodePools.CallUnary(ctx, req)
+func (c *clusterServiceClient) ListNodePools(ctx context.Context, req *v1.ListNodePoolsRequest) (*v1.ListNodePoolsResponse, error) {
+	response, err := c.listNodePools.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetNodePool calls organization.v1.ClusterService.GetNodePool.
-func (c *clusterServiceClient) GetNodePool(ctx context.Context, req *connect.Request[v1.GetNodePoolRequest]) (*connect.Response[v1.GetNodePoolResponse], error) {
-	return c.getNodePool.CallUnary(ctx, req)
+func (c *clusterServiceClient) GetNodePool(ctx context.Context, req *v1.GetNodePoolRequest) (*v1.GetNodePoolResponse, error) {
+	response, err := c.getNodePool.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateNodePool calls organization.v1.ClusterService.CreateNodePool.
-func (c *clusterServiceClient) CreateNodePool(ctx context.Context, req *connect.Request[v1.CreateNodePoolRequest]) (*connect.Response[v1.CreateNodePoolResponse], error) {
-	return c.createNodePool.CallUnary(ctx, req)
+func (c *clusterServiceClient) CreateNodePool(ctx context.Context, req *v1.CreateNodePoolRequest) (*v1.CreateNodePoolResponse, error) {
+	response, err := c.createNodePool.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateNodePool calls organization.v1.ClusterService.UpdateNodePool.
-func (c *clusterServiceClient) UpdateNodePool(ctx context.Context, req *connect.Request[v1.UpdateNodePoolRequest]) (*connect.Response[v1.UpdateNodePoolResponse], error) {
-	return c.updateNodePool.CallUnary(ctx, req)
+func (c *clusterServiceClient) UpdateNodePool(ctx context.Context, req *v1.UpdateNodePoolRequest) (*v1.UpdateNodePoolResponse, error) {
+	response, err := c.updateNodePool.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteNodePool calls organization.v1.ClusterService.DeleteNodePool.
-func (c *clusterServiceClient) DeleteNodePool(ctx context.Context, req *connect.Request[v1.DeleteNodePoolRequest]) (*connect.Response[v1.DeleteNodePoolResponse], error) {
-	return c.deleteNodePool.CallUnary(ctx, req)
+func (c *clusterServiceClient) DeleteNodePool(ctx context.Context, req *v1.DeleteNodePoolRequest) (*v1.DeleteNodePoolResponse, error) {
+	response, err := c.deleteNodePool.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ClusterServiceHandler is an implementation of the organization.v1.ClusterService service.
 type ClusterServiceHandler interface {
 	// List the region catalog: every region with the kubernetes versions and
 	// machine types it offers (drives the create-cluster cascade).
-	ListRegions(context.Context, *connect.Request[v1.ListRegionsRequest]) (*connect.Response[v1.ListRegionsResponse], error)
+	ListRegions(context.Context, *v1.ListRegionsRequest) (*v1.ListRegionsResponse, error)
 	// List all clusters for the current organization
-	ListClusters(context.Context, *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error)
+	ListClusters(context.Context, *v1.ListClustersRequest) (*v1.ListClustersResponse, error)
 	// Get detailed information about a specific cluster
-	GetCluster(context.Context, *connect.Request[v1.GetClusterRequest]) (*connect.Response[v1.GetClusterResponse], error)
+	GetCluster(context.Context, *v1.GetClusterRequest) (*v1.GetClusterResponse, error)
 	// Get a cluster by name
-	GetClusterByName(context.Context, *connect.Request[v1.GetClusterByNameRequest]) (*connect.Response[v1.GetClusterResponse], error)
+	GetClusterByName(context.Context, *v1.GetClusterByNameRequest) (*v1.GetClusterResponse, error)
 	// Create a new cluster
-	CreateCluster(context.Context, *connect.Request[v1.CreateClusterRequest]) (*connect.Response[v1.CreateClusterResponse], error)
+	CreateCluster(context.Context, *v1.CreateClusterRequest) (*v1.CreateClusterResponse, error)
 	// Update cluster configuration
-	UpdateCluster(context.Context, *connect.Request[v1.UpdateClusterRequest]) (*connect.Response[v1.UpdateClusterResponse], error)
+	UpdateCluster(context.Context, *v1.UpdateClusterRequest) (*v1.UpdateClusterResponse, error)
 	// Delete a cluster
-	DeleteCluster(context.Context, *connect.Request[v1.DeleteClusterRequest]) (*connect.Response[v1.DeleteClusterResponse], error)
+	DeleteCluster(context.Context, *v1.DeleteClusterRequest) (*v1.DeleteClusterResponse, error)
 	// Get cluster activity log
-	GetClusterActivity(context.Context, *connect.Request[v1.GetClusterActivityRequest]) (*connect.Response[v1.GetClusterActivityResponse], error)
+	GetClusterActivity(context.Context, *v1.GetClusterActivityRequest) (*v1.GetClusterActivityResponse, error)
 	// Download kubeconfig for a cluster
-	GetKubeconfig(context.Context, *connect.Request[v1.GetKubeconfigRequest]) (*connect.Response[v1.GetKubeconfigResponse], error)
+	GetKubeconfig(context.Context, *v1.GetKubeconfigRequest) (*v1.GetKubeconfigResponse, error)
 	// Fetch the basic-auth credentials for a cluster's metrics dashboard.
-	GetClusterMetricsCredentials(context.Context, *connect.Request[v1.GetClusterMetricsCredentialsRequest]) (*connect.Response[v1.GetClusterMetricsCredentialsResponse], error)
+	GetClusterMetricsCredentials(context.Context, *v1.GetClusterMetricsCredentialsRequest) (*v1.GetClusterMetricsCredentialsResponse, error)
 	// List node pools for a cluster
-	ListNodePools(context.Context, *connect.Request[v1.ListNodePoolsRequest]) (*connect.Response[v1.ListNodePoolsResponse], error)
+	ListNodePools(context.Context, *v1.ListNodePoolsRequest) (*v1.ListNodePoolsResponse, error)
 	// Get a node pool by ID
-	GetNodePool(context.Context, *connect.Request[v1.GetNodePoolRequest]) (*connect.Response[v1.GetNodePoolResponse], error)
+	GetNodePool(context.Context, *v1.GetNodePoolRequest) (*v1.GetNodePoolResponse, error)
 	// Create a node pool in a cluster
-	CreateNodePool(context.Context, *connect.Request[v1.CreateNodePoolRequest]) (*connect.Response[v1.CreateNodePoolResponse], error)
+	CreateNodePool(context.Context, *v1.CreateNodePoolRequest) (*v1.CreateNodePoolResponse, error)
 	// Update a node pool
-	UpdateNodePool(context.Context, *connect.Request[v1.UpdateNodePoolRequest]) (*connect.Response[v1.UpdateNodePoolResponse], error)
+	UpdateNodePool(context.Context, *v1.UpdateNodePoolRequest) (*v1.UpdateNodePoolResponse, error)
 	// Delete a node pool
-	DeleteNodePool(context.Context, *connect.Request[v1.DeleteNodePoolRequest]) (*connect.Response[v1.DeleteNodePoolResponse], error)
+	DeleteNodePool(context.Context, *v1.DeleteNodePoolRequest) (*v1.DeleteNodePoolResponse, error)
 }
 
 // NewClusterServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -355,91 +415,91 @@ type ClusterServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	clusterServiceMethods := v1.File_v1_cluster_proto.Services().ByName("ClusterService").Methods()
-	clusterServiceListRegionsHandler := connect.NewUnaryHandler(
+	clusterServiceListRegionsHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceListRegionsProcedure,
 		svc.ListRegions,
 		connect.WithSchema(clusterServiceMethods.ByName("ListRegions")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceListClustersHandler := connect.NewUnaryHandler(
+	clusterServiceListClustersHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceListClustersProcedure,
 		svc.ListClusters,
 		connect.WithSchema(clusterServiceMethods.ByName("ListClusters")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetClusterHandler := connect.NewUnaryHandler(
+	clusterServiceGetClusterHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetClusterProcedure,
 		svc.GetCluster,
 		connect.WithSchema(clusterServiceMethods.ByName("GetCluster")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetClusterByNameHandler := connect.NewUnaryHandler(
+	clusterServiceGetClusterByNameHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetClusterByNameProcedure,
 		svc.GetClusterByName,
 		connect.WithSchema(clusterServiceMethods.ByName("GetClusterByName")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceCreateClusterHandler := connect.NewUnaryHandler(
+	clusterServiceCreateClusterHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceCreateClusterProcedure,
 		svc.CreateCluster,
 		connect.WithSchema(clusterServiceMethods.ByName("CreateCluster")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceUpdateClusterHandler := connect.NewUnaryHandler(
+	clusterServiceUpdateClusterHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceUpdateClusterProcedure,
 		svc.UpdateCluster,
 		connect.WithSchema(clusterServiceMethods.ByName("UpdateCluster")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceDeleteClusterHandler := connect.NewUnaryHandler(
+	clusterServiceDeleteClusterHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceDeleteClusterProcedure,
 		svc.DeleteCluster,
 		connect.WithSchema(clusterServiceMethods.ByName("DeleteCluster")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetClusterActivityHandler := connect.NewUnaryHandler(
+	clusterServiceGetClusterActivityHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetClusterActivityProcedure,
 		svc.GetClusterActivity,
 		connect.WithSchema(clusterServiceMethods.ByName("GetClusterActivity")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetKubeconfigHandler := connect.NewUnaryHandler(
+	clusterServiceGetKubeconfigHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetKubeconfigProcedure,
 		svc.GetKubeconfig,
 		connect.WithSchema(clusterServiceMethods.ByName("GetKubeconfig")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetClusterMetricsCredentialsHandler := connect.NewUnaryHandler(
+	clusterServiceGetClusterMetricsCredentialsHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetClusterMetricsCredentialsProcedure,
 		svc.GetClusterMetricsCredentials,
 		connect.WithSchema(clusterServiceMethods.ByName("GetClusterMetricsCredentials")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceListNodePoolsHandler := connect.NewUnaryHandler(
+	clusterServiceListNodePoolsHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceListNodePoolsProcedure,
 		svc.ListNodePools,
 		connect.WithSchema(clusterServiceMethods.ByName("ListNodePools")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceGetNodePoolHandler := connect.NewUnaryHandler(
+	clusterServiceGetNodePoolHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceGetNodePoolProcedure,
 		svc.GetNodePool,
 		connect.WithSchema(clusterServiceMethods.ByName("GetNodePool")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceCreateNodePoolHandler := connect.NewUnaryHandler(
+	clusterServiceCreateNodePoolHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceCreateNodePoolProcedure,
 		svc.CreateNodePool,
 		connect.WithSchema(clusterServiceMethods.ByName("CreateNodePool")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceUpdateNodePoolHandler := connect.NewUnaryHandler(
+	clusterServiceUpdateNodePoolHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceUpdateNodePoolProcedure,
 		svc.UpdateNodePool,
 		connect.WithSchema(clusterServiceMethods.ByName("UpdateNodePool")),
 		connect.WithHandlerOptions(opts...),
 	)
-	clusterServiceDeleteNodePoolHandler := connect.NewUnaryHandler(
+	clusterServiceDeleteNodePoolHandler := connect.NewUnaryHandlerSimple(
 		ClusterServiceDeleteNodePoolProcedure,
 		svc.DeleteNodePool,
 		connect.WithSchema(clusterServiceMethods.ByName("DeleteNodePool")),
@@ -486,62 +546,62 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 // UnimplementedClusterServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedClusterServiceHandler struct{}
 
-func (UnimplementedClusterServiceHandler) ListRegions(context.Context, *connect.Request[v1.ListRegionsRequest]) (*connect.Response[v1.ListRegionsResponse], error) {
+func (UnimplementedClusterServiceHandler) ListRegions(context.Context, *v1.ListRegionsRequest) (*v1.ListRegionsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.ListRegions is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) ListClusters(context.Context, *connect.Request[v1.ListClustersRequest]) (*connect.Response[v1.ListClustersResponse], error) {
+func (UnimplementedClusterServiceHandler) ListClusters(context.Context, *v1.ListClustersRequest) (*v1.ListClustersResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.ListClusters is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetCluster(context.Context, *connect.Request[v1.GetClusterRequest]) (*connect.Response[v1.GetClusterResponse], error) {
+func (UnimplementedClusterServiceHandler) GetCluster(context.Context, *v1.GetClusterRequest) (*v1.GetClusterResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetCluster is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetClusterByName(context.Context, *connect.Request[v1.GetClusterByNameRequest]) (*connect.Response[v1.GetClusterResponse], error) {
+func (UnimplementedClusterServiceHandler) GetClusterByName(context.Context, *v1.GetClusterByNameRequest) (*v1.GetClusterResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetClusterByName is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) CreateCluster(context.Context, *connect.Request[v1.CreateClusterRequest]) (*connect.Response[v1.CreateClusterResponse], error) {
+func (UnimplementedClusterServiceHandler) CreateCluster(context.Context, *v1.CreateClusterRequest) (*v1.CreateClusterResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.CreateCluster is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) UpdateCluster(context.Context, *connect.Request[v1.UpdateClusterRequest]) (*connect.Response[v1.UpdateClusterResponse], error) {
+func (UnimplementedClusterServiceHandler) UpdateCluster(context.Context, *v1.UpdateClusterRequest) (*v1.UpdateClusterResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.UpdateCluster is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) DeleteCluster(context.Context, *connect.Request[v1.DeleteClusterRequest]) (*connect.Response[v1.DeleteClusterResponse], error) {
+func (UnimplementedClusterServiceHandler) DeleteCluster(context.Context, *v1.DeleteClusterRequest) (*v1.DeleteClusterResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.DeleteCluster is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetClusterActivity(context.Context, *connect.Request[v1.GetClusterActivityRequest]) (*connect.Response[v1.GetClusterActivityResponse], error) {
+func (UnimplementedClusterServiceHandler) GetClusterActivity(context.Context, *v1.GetClusterActivityRequest) (*v1.GetClusterActivityResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetClusterActivity is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetKubeconfig(context.Context, *connect.Request[v1.GetKubeconfigRequest]) (*connect.Response[v1.GetKubeconfigResponse], error) {
+func (UnimplementedClusterServiceHandler) GetKubeconfig(context.Context, *v1.GetKubeconfigRequest) (*v1.GetKubeconfigResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetKubeconfig is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetClusterMetricsCredentials(context.Context, *connect.Request[v1.GetClusterMetricsCredentialsRequest]) (*connect.Response[v1.GetClusterMetricsCredentialsResponse], error) {
+func (UnimplementedClusterServiceHandler) GetClusterMetricsCredentials(context.Context, *v1.GetClusterMetricsCredentialsRequest) (*v1.GetClusterMetricsCredentialsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetClusterMetricsCredentials is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) ListNodePools(context.Context, *connect.Request[v1.ListNodePoolsRequest]) (*connect.Response[v1.ListNodePoolsResponse], error) {
+func (UnimplementedClusterServiceHandler) ListNodePools(context.Context, *v1.ListNodePoolsRequest) (*v1.ListNodePoolsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.ListNodePools is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) GetNodePool(context.Context, *connect.Request[v1.GetNodePoolRequest]) (*connect.Response[v1.GetNodePoolResponse], error) {
+func (UnimplementedClusterServiceHandler) GetNodePool(context.Context, *v1.GetNodePoolRequest) (*v1.GetNodePoolResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.GetNodePool is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) CreateNodePool(context.Context, *connect.Request[v1.CreateNodePoolRequest]) (*connect.Response[v1.CreateNodePoolResponse], error) {
+func (UnimplementedClusterServiceHandler) CreateNodePool(context.Context, *v1.CreateNodePoolRequest) (*v1.CreateNodePoolResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.CreateNodePool is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) UpdateNodePool(context.Context, *connect.Request[v1.UpdateNodePoolRequest]) (*connect.Response[v1.UpdateNodePoolResponse], error) {
+func (UnimplementedClusterServiceHandler) UpdateNodePool(context.Context, *v1.UpdateNodePoolRequest) (*v1.UpdateNodePoolResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.UpdateNodePool is not implemented"))
 }
 
-func (UnimplementedClusterServiceHandler) DeleteNodePool(context.Context, *connect.Request[v1.DeleteNodePoolRequest]) (*connect.Response[v1.DeleteNodePoolResponse], error) {
+func (UnimplementedClusterServiceHandler) DeleteNodePool(context.Context, *v1.DeleteNodePoolRequest) (*v1.DeleteNodePoolResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ClusterService.DeleteNodePool is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/invite.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/invite.connect.go
@@ -50,13 +50,13 @@ const (
 // InviteServiceClient is a client for the organization.v1.InviteService service.
 type InviteServiceClient interface {
 	// Invite a new member by email (org-scoped)
-	InviteMember(context.Context, *connect.Request[v1.InviteMemberRequest]) (*connect.Response[v1.InviteMemberResponse], error)
+	InviteMember(context.Context, *v1.InviteMemberRequest) (*v1.InviteMemberResponse, error)
 	// List pending invitations for the current user (user-scoped, no org header needed)
-	ListInvitations(context.Context, *connect.Request[v1.ListInvitationsRequest]) (*connect.Response[v1.ListInvitationsResponse], error)
+	ListInvitations(context.Context, *v1.ListInvitationsRequest) (*v1.ListInvitationsResponse, error)
 	// Accept a pending invitation (user-scoped, no org header needed)
-	AcceptInvitation(context.Context, *connect.Request[v1.AcceptInvitationRequest]) (*connect.Response[v1.AcceptInvitationResponse], error)
+	AcceptInvitation(context.Context, *v1.AcceptInvitationRequest) (*v1.AcceptInvitationResponse, error)
 	// Decline a pending invitation (user-scoped, no org header needed)
-	DeclineInvitation(context.Context, *connect.Request[v1.DeclineInvitationRequest]) (*connect.Response[v1.DeclineInvitationResponse], error)
+	DeclineInvitation(context.Context, *v1.DeclineInvitationRequest) (*v1.DeclineInvitationResponse, error)
 }
 
 // NewInviteServiceClient constructs a client for the organization.v1.InviteService service. By
@@ -106,35 +106,51 @@ type inviteServiceClient struct {
 }
 
 // InviteMember calls organization.v1.InviteService.InviteMember.
-func (c *inviteServiceClient) InviteMember(ctx context.Context, req *connect.Request[v1.InviteMemberRequest]) (*connect.Response[v1.InviteMemberResponse], error) {
-	return c.inviteMember.CallUnary(ctx, req)
+func (c *inviteServiceClient) InviteMember(ctx context.Context, req *v1.InviteMemberRequest) (*v1.InviteMemberResponse, error) {
+	response, err := c.inviteMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListInvitations calls organization.v1.InviteService.ListInvitations.
-func (c *inviteServiceClient) ListInvitations(ctx context.Context, req *connect.Request[v1.ListInvitationsRequest]) (*connect.Response[v1.ListInvitationsResponse], error) {
-	return c.listInvitations.CallUnary(ctx, req)
+func (c *inviteServiceClient) ListInvitations(ctx context.Context, req *v1.ListInvitationsRequest) (*v1.ListInvitationsResponse, error) {
+	response, err := c.listInvitations.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // AcceptInvitation calls organization.v1.InviteService.AcceptInvitation.
-func (c *inviteServiceClient) AcceptInvitation(ctx context.Context, req *connect.Request[v1.AcceptInvitationRequest]) (*connect.Response[v1.AcceptInvitationResponse], error) {
-	return c.acceptInvitation.CallUnary(ctx, req)
+func (c *inviteServiceClient) AcceptInvitation(ctx context.Context, req *v1.AcceptInvitationRequest) (*v1.AcceptInvitationResponse, error) {
+	response, err := c.acceptInvitation.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeclineInvitation calls organization.v1.InviteService.DeclineInvitation.
-func (c *inviteServiceClient) DeclineInvitation(ctx context.Context, req *connect.Request[v1.DeclineInvitationRequest]) (*connect.Response[v1.DeclineInvitationResponse], error) {
-	return c.declineInvitation.CallUnary(ctx, req)
+func (c *inviteServiceClient) DeclineInvitation(ctx context.Context, req *v1.DeclineInvitationRequest) (*v1.DeclineInvitationResponse, error) {
+	response, err := c.declineInvitation.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // InviteServiceHandler is an implementation of the organization.v1.InviteService service.
 type InviteServiceHandler interface {
 	// Invite a new member by email (org-scoped)
-	InviteMember(context.Context, *connect.Request[v1.InviteMemberRequest]) (*connect.Response[v1.InviteMemberResponse], error)
+	InviteMember(context.Context, *v1.InviteMemberRequest) (*v1.InviteMemberResponse, error)
 	// List pending invitations for the current user (user-scoped, no org header needed)
-	ListInvitations(context.Context, *connect.Request[v1.ListInvitationsRequest]) (*connect.Response[v1.ListInvitationsResponse], error)
+	ListInvitations(context.Context, *v1.ListInvitationsRequest) (*v1.ListInvitationsResponse, error)
 	// Accept a pending invitation (user-scoped, no org header needed)
-	AcceptInvitation(context.Context, *connect.Request[v1.AcceptInvitationRequest]) (*connect.Response[v1.AcceptInvitationResponse], error)
+	AcceptInvitation(context.Context, *v1.AcceptInvitationRequest) (*v1.AcceptInvitationResponse, error)
 	// Decline a pending invitation (user-scoped, no org header needed)
-	DeclineInvitation(context.Context, *connect.Request[v1.DeclineInvitationRequest]) (*connect.Response[v1.DeclineInvitationResponse], error)
+	DeclineInvitation(context.Context, *v1.DeclineInvitationRequest) (*v1.DeclineInvitationResponse, error)
 }
 
 // NewInviteServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -144,25 +160,25 @@ type InviteServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewInviteServiceHandler(svc InviteServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	inviteServiceMethods := v1.File_v1_invite_proto.Services().ByName("InviteService").Methods()
-	inviteServiceInviteMemberHandler := connect.NewUnaryHandler(
+	inviteServiceInviteMemberHandler := connect.NewUnaryHandlerSimple(
 		InviteServiceInviteMemberProcedure,
 		svc.InviteMember,
 		connect.WithSchema(inviteServiceMethods.ByName("InviteMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	inviteServiceListInvitationsHandler := connect.NewUnaryHandler(
+	inviteServiceListInvitationsHandler := connect.NewUnaryHandlerSimple(
 		InviteServiceListInvitationsProcedure,
 		svc.ListInvitations,
 		connect.WithSchema(inviteServiceMethods.ByName("ListInvitations")),
 		connect.WithHandlerOptions(opts...),
 	)
-	inviteServiceAcceptInvitationHandler := connect.NewUnaryHandler(
+	inviteServiceAcceptInvitationHandler := connect.NewUnaryHandlerSimple(
 		InviteServiceAcceptInvitationProcedure,
 		svc.AcceptInvitation,
 		connect.WithSchema(inviteServiceMethods.ByName("AcceptInvitation")),
 		connect.WithHandlerOptions(opts...),
 	)
-	inviteServiceDeclineInvitationHandler := connect.NewUnaryHandler(
+	inviteServiceDeclineInvitationHandler := connect.NewUnaryHandlerSimple(
 		InviteServiceDeclineInvitationProcedure,
 		svc.DeclineInvitation,
 		connect.WithSchema(inviteServiceMethods.ByName("DeclineInvitation")),
@@ -187,18 +203,18 @@ func NewInviteServiceHandler(svc InviteServiceHandler, opts ...connect.HandlerOp
 // UnimplementedInviteServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedInviteServiceHandler struct{}
 
-func (UnimplementedInviteServiceHandler) InviteMember(context.Context, *connect.Request[v1.InviteMemberRequest]) (*connect.Response[v1.InviteMemberResponse], error) {
+func (UnimplementedInviteServiceHandler) InviteMember(context.Context, *v1.InviteMemberRequest) (*v1.InviteMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.InviteService.InviteMember is not implemented"))
 }
 
-func (UnimplementedInviteServiceHandler) ListInvitations(context.Context, *connect.Request[v1.ListInvitationsRequest]) (*connect.Response[v1.ListInvitationsResponse], error) {
+func (UnimplementedInviteServiceHandler) ListInvitations(context.Context, *v1.ListInvitationsRequest) (*v1.ListInvitationsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.InviteService.ListInvitations is not implemented"))
 }
 
-func (UnimplementedInviteServiceHandler) AcceptInvitation(context.Context, *connect.Request[v1.AcceptInvitationRequest]) (*connect.Response[v1.AcceptInvitationResponse], error) {
+func (UnimplementedInviteServiceHandler) AcceptInvitation(context.Context, *v1.AcceptInvitationRequest) (*v1.AcceptInvitationResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.InviteService.AcceptInvitation is not implemented"))
 }
 
-func (UnimplementedInviteServiceHandler) DeclineInvitation(context.Context, *connect.Request[v1.DeclineInvitationRequest]) (*connect.Response[v1.DeclineInvitationResponse], error) {
+func (UnimplementedInviteServiceHandler) DeclineInvitation(context.Context, *v1.DeclineInvitationRequest) (*v1.DeclineInvitationResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.InviteService.DeclineInvitation is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/member.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/member.connect.go
@@ -49,13 +49,13 @@ const (
 // MemberServiceClient is a client for the organization.v1.MemberService service.
 type MemberServiceClient interface {
 	// List all members of the current organization
-	ListMembers(context.Context, *connect.Request[v1.ListMembersRequest]) (*connect.Response[v1.ListMembersResponse], error)
+	ListMembers(context.Context, *v1.ListMembersRequest) (*v1.ListMembersResponse, error)
 	// Get a member by membership ID or user ID
-	GetMember(context.Context, *connect.Request[v1.GetMemberRequest]) (*connect.Response[v1.GetMemberResponse], error)
+	GetMember(context.Context, *v1.GetMemberRequest) (*v1.GetMemberResponse, error)
 	// Delete a member from the organization
-	DeleteMember(context.Context, *connect.Request[v1.DeleteMemberRequest]) (*connect.Response[v1.DeleteMemberResponse], error)
+	DeleteMember(context.Context, *v1.DeleteMemberRequest) (*v1.DeleteMemberResponse, error)
 	// Update a member's permission
-	UpdateMemberPermission(context.Context, *connect.Request[v1.UpdateMemberPermissionRequest]) (*connect.Response[v1.UpdateMemberPermissionResponse], error)
+	UpdateMemberPermission(context.Context, *v1.UpdateMemberPermissionRequest) (*v1.UpdateMemberPermissionResponse, error)
 }
 
 // NewMemberServiceClient constructs a client for the organization.v1.MemberService service. By
@@ -105,35 +105,51 @@ type memberServiceClient struct {
 }
 
 // ListMembers calls organization.v1.MemberService.ListMembers.
-func (c *memberServiceClient) ListMembers(ctx context.Context, req *connect.Request[v1.ListMembersRequest]) (*connect.Response[v1.ListMembersResponse], error) {
-	return c.listMembers.CallUnary(ctx, req)
+func (c *memberServiceClient) ListMembers(ctx context.Context, req *v1.ListMembersRequest) (*v1.ListMembersResponse, error) {
+	response, err := c.listMembers.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetMember calls organization.v1.MemberService.GetMember.
-func (c *memberServiceClient) GetMember(ctx context.Context, req *connect.Request[v1.GetMemberRequest]) (*connect.Response[v1.GetMemberResponse], error) {
-	return c.getMember.CallUnary(ctx, req)
+func (c *memberServiceClient) GetMember(ctx context.Context, req *v1.GetMemberRequest) (*v1.GetMemberResponse, error) {
+	response, err := c.getMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteMember calls organization.v1.MemberService.DeleteMember.
-func (c *memberServiceClient) DeleteMember(ctx context.Context, req *connect.Request[v1.DeleteMemberRequest]) (*connect.Response[v1.DeleteMemberResponse], error) {
-	return c.deleteMember.CallUnary(ctx, req)
+func (c *memberServiceClient) DeleteMember(ctx context.Context, req *v1.DeleteMemberRequest) (*v1.DeleteMemberResponse, error) {
+	response, err := c.deleteMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateMemberPermission calls organization.v1.MemberService.UpdateMemberPermission.
-func (c *memberServiceClient) UpdateMemberPermission(ctx context.Context, req *connect.Request[v1.UpdateMemberPermissionRequest]) (*connect.Response[v1.UpdateMemberPermissionResponse], error) {
-	return c.updateMemberPermission.CallUnary(ctx, req)
+func (c *memberServiceClient) UpdateMemberPermission(ctx context.Context, req *v1.UpdateMemberPermissionRequest) (*v1.UpdateMemberPermissionResponse, error) {
+	response, err := c.updateMemberPermission.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // MemberServiceHandler is an implementation of the organization.v1.MemberService service.
 type MemberServiceHandler interface {
 	// List all members of the current organization
-	ListMembers(context.Context, *connect.Request[v1.ListMembersRequest]) (*connect.Response[v1.ListMembersResponse], error)
+	ListMembers(context.Context, *v1.ListMembersRequest) (*v1.ListMembersResponse, error)
 	// Get a member by membership ID or user ID
-	GetMember(context.Context, *connect.Request[v1.GetMemberRequest]) (*connect.Response[v1.GetMemberResponse], error)
+	GetMember(context.Context, *v1.GetMemberRequest) (*v1.GetMemberResponse, error)
 	// Delete a member from the organization
-	DeleteMember(context.Context, *connect.Request[v1.DeleteMemberRequest]) (*connect.Response[v1.DeleteMemberResponse], error)
+	DeleteMember(context.Context, *v1.DeleteMemberRequest) (*v1.DeleteMemberResponse, error)
 	// Update a member's permission
-	UpdateMemberPermission(context.Context, *connect.Request[v1.UpdateMemberPermissionRequest]) (*connect.Response[v1.UpdateMemberPermissionResponse], error)
+	UpdateMemberPermission(context.Context, *v1.UpdateMemberPermissionRequest) (*v1.UpdateMemberPermissionResponse, error)
 }
 
 // NewMemberServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -143,25 +159,25 @@ type MemberServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewMemberServiceHandler(svc MemberServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	memberServiceMethods := v1.File_v1_member_proto.Services().ByName("MemberService").Methods()
-	memberServiceListMembersHandler := connect.NewUnaryHandler(
+	memberServiceListMembersHandler := connect.NewUnaryHandlerSimple(
 		MemberServiceListMembersProcedure,
 		svc.ListMembers,
 		connect.WithSchema(memberServiceMethods.ByName("ListMembers")),
 		connect.WithHandlerOptions(opts...),
 	)
-	memberServiceGetMemberHandler := connect.NewUnaryHandler(
+	memberServiceGetMemberHandler := connect.NewUnaryHandlerSimple(
 		MemberServiceGetMemberProcedure,
 		svc.GetMember,
 		connect.WithSchema(memberServiceMethods.ByName("GetMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	memberServiceDeleteMemberHandler := connect.NewUnaryHandler(
+	memberServiceDeleteMemberHandler := connect.NewUnaryHandlerSimple(
 		MemberServiceDeleteMemberProcedure,
 		svc.DeleteMember,
 		connect.WithSchema(memberServiceMethods.ByName("DeleteMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	memberServiceUpdateMemberPermissionHandler := connect.NewUnaryHandler(
+	memberServiceUpdateMemberPermissionHandler := connect.NewUnaryHandlerSimple(
 		MemberServiceUpdateMemberPermissionProcedure,
 		svc.UpdateMemberPermission,
 		connect.WithSchema(memberServiceMethods.ByName("UpdateMemberPermission")),
@@ -186,18 +202,18 @@ func NewMemberServiceHandler(svc MemberServiceHandler, opts ...connect.HandlerOp
 // UnimplementedMemberServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedMemberServiceHandler struct{}
 
-func (UnimplementedMemberServiceHandler) ListMembers(context.Context, *connect.Request[v1.ListMembersRequest]) (*connect.Response[v1.ListMembersResponse], error) {
+func (UnimplementedMemberServiceHandler) ListMembers(context.Context, *v1.ListMembersRequest) (*v1.ListMembersResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MemberService.ListMembers is not implemented"))
 }
 
-func (UnimplementedMemberServiceHandler) GetMember(context.Context, *connect.Request[v1.GetMemberRequest]) (*connect.Response[v1.GetMemberResponse], error) {
+func (UnimplementedMemberServiceHandler) GetMember(context.Context, *v1.GetMemberRequest) (*v1.GetMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MemberService.GetMember is not implemented"))
 }
 
-func (UnimplementedMemberServiceHandler) DeleteMember(context.Context, *connect.Request[v1.DeleteMemberRequest]) (*connect.Response[v1.DeleteMemberResponse], error) {
+func (UnimplementedMemberServiceHandler) DeleteMember(context.Context, *v1.DeleteMemberRequest) (*v1.DeleteMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MemberService.DeleteMember is not implemented"))
 }
 
-func (UnimplementedMemberServiceHandler) UpdateMemberPermission(context.Context, *connect.Request[v1.UpdateMemberPermissionRequest]) (*connect.Response[v1.UpdateMemberPermissionResponse], error) {
+func (UnimplementedMemberServiceHandler) UpdateMemberPermission(context.Context, *v1.UpdateMemberPermissionRequest) (*v1.UpdateMemberPermissionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MemberService.UpdateMemberPermission is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/metrics.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/metrics.connect.go
@@ -65,23 +65,23 @@ const (
 // MetricsServiceClient is a client for the organization.v1.MetricsService service.
 type MetricsServiceClient interface {
 	// Cluster-level workload metrics (CPU, memory, pods) for a specific cluster
-	GetClusterWorkloadMetrics(context.Context, *connect.Request[v1.GetClusterWorkloadMetricsRequest]) (*connect.Response[v1.GetClusterWorkloadMetricsResponse], error)
+	GetClusterWorkloadMetrics(context.Context, *v1.GetClusterWorkloadMetricsRequest) (*v1.GetClusterWorkloadMetricsResponse, error)
 	// Time-series workload metrics for a specific cluster
-	GetClusterWorkloadTimeSeries(context.Context, *connect.Request[v1.GetClusterWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetClusterWorkloadTimeSeries(context.Context, *v1.GetClusterWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Org-level workload metrics aggregated across all clusters
-	GetOrgWorkloadMetrics(context.Context, *connect.Request[v1.GetOrgWorkloadMetricsRequest]) (*connect.Response[v1.GetOrgWorkloadMetricsResponse], error)
+	GetOrgWorkloadMetrics(context.Context, *v1.GetOrgWorkloadMetricsRequest) (*v1.GetOrgWorkloadMetricsResponse, error)
 	// Org-level time-series workload metrics aggregated across all clusters
-	GetOrgWorkloadTimeSeries(context.Context, *connect.Request[v1.GetOrgWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetOrgWorkloadTimeSeries(context.Context, *v1.GetOrgWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Project-level workload metrics filtered to the project's namespaces
-	GetProjectWorkloadMetrics(context.Context, *connect.Request[v1.GetProjectWorkloadMetricsRequest]) (*connect.Response[v1.GetProjectWorkloadMetricsResponse], error)
+	GetProjectWorkloadMetrics(context.Context, *v1.GetProjectWorkloadMetricsRequest) (*v1.GetProjectWorkloadMetricsResponse, error)
 	// Project-level time-series workload metrics filtered to the project's namespaces
-	GetProjectWorkloadTimeSeries(context.Context, *connect.Request[v1.GetProjectWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetProjectWorkloadTimeSeries(context.Context, *v1.GetProjectWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Live streaming of org-wide workload metrics, pushed every 15 seconds.
-	StreamOrgWorkloadMetrics(context.Context, *connect.Request[v1.StreamOrgWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
+	StreamOrgWorkloadMetrics(context.Context, *v1.StreamOrgWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
 	// Live streaming of cluster workload metrics, pushed every 15 seconds.
-	StreamClusterWorkloadMetrics(context.Context, *connect.Request[v1.StreamClusterWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
+	StreamClusterWorkloadMetrics(context.Context, *v1.StreamClusterWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
 	// Live streaming of project workload metrics, pushed every 15 seconds.
-	StreamProjectWorkloadMetrics(context.Context, *connect.Request[v1.StreamProjectWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
+	StreamProjectWorkloadMetrics(context.Context, *v1.StreamProjectWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error)
 }
 
 // NewMetricsServiceClient constructs a client for the organization.v1.MetricsService service. By
@@ -166,70 +166,94 @@ type metricsServiceClient struct {
 }
 
 // GetClusterWorkloadMetrics calls organization.v1.MetricsService.GetClusterWorkloadMetrics.
-func (c *metricsServiceClient) GetClusterWorkloadMetrics(ctx context.Context, req *connect.Request[v1.GetClusterWorkloadMetricsRequest]) (*connect.Response[v1.GetClusterWorkloadMetricsResponse], error) {
-	return c.getClusterWorkloadMetrics.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetClusterWorkloadMetrics(ctx context.Context, req *v1.GetClusterWorkloadMetricsRequest) (*v1.GetClusterWorkloadMetricsResponse, error) {
+	response, err := c.getClusterWorkloadMetrics.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetClusterWorkloadTimeSeries calls organization.v1.MetricsService.GetClusterWorkloadTimeSeries.
-func (c *metricsServiceClient) GetClusterWorkloadTimeSeries(ctx context.Context, req *connect.Request[v1.GetClusterWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
-	return c.getClusterWorkloadTimeSeries.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetClusterWorkloadTimeSeries(ctx context.Context, req *v1.GetClusterWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
+	response, err := c.getClusterWorkloadTimeSeries.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetOrgWorkloadMetrics calls organization.v1.MetricsService.GetOrgWorkloadMetrics.
-func (c *metricsServiceClient) GetOrgWorkloadMetrics(ctx context.Context, req *connect.Request[v1.GetOrgWorkloadMetricsRequest]) (*connect.Response[v1.GetOrgWorkloadMetricsResponse], error) {
-	return c.getOrgWorkloadMetrics.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetOrgWorkloadMetrics(ctx context.Context, req *v1.GetOrgWorkloadMetricsRequest) (*v1.GetOrgWorkloadMetricsResponse, error) {
+	response, err := c.getOrgWorkloadMetrics.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetOrgWorkloadTimeSeries calls organization.v1.MetricsService.GetOrgWorkloadTimeSeries.
-func (c *metricsServiceClient) GetOrgWorkloadTimeSeries(ctx context.Context, req *connect.Request[v1.GetOrgWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
-	return c.getOrgWorkloadTimeSeries.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetOrgWorkloadTimeSeries(ctx context.Context, req *v1.GetOrgWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
+	response, err := c.getOrgWorkloadTimeSeries.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProjectWorkloadMetrics calls organization.v1.MetricsService.GetProjectWorkloadMetrics.
-func (c *metricsServiceClient) GetProjectWorkloadMetrics(ctx context.Context, req *connect.Request[v1.GetProjectWorkloadMetricsRequest]) (*connect.Response[v1.GetProjectWorkloadMetricsResponse], error) {
-	return c.getProjectWorkloadMetrics.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetProjectWorkloadMetrics(ctx context.Context, req *v1.GetProjectWorkloadMetricsRequest) (*v1.GetProjectWorkloadMetricsResponse, error) {
+	response, err := c.getProjectWorkloadMetrics.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProjectWorkloadTimeSeries calls organization.v1.MetricsService.GetProjectWorkloadTimeSeries.
-func (c *metricsServiceClient) GetProjectWorkloadTimeSeries(ctx context.Context, req *connect.Request[v1.GetProjectWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
-	return c.getProjectWorkloadTimeSeries.CallUnary(ctx, req)
+func (c *metricsServiceClient) GetProjectWorkloadTimeSeries(ctx context.Context, req *v1.GetProjectWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
+	response, err := c.getProjectWorkloadTimeSeries.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // StreamOrgWorkloadMetrics calls organization.v1.MetricsService.StreamOrgWorkloadMetrics.
-func (c *metricsServiceClient) StreamOrgWorkloadMetrics(ctx context.Context, req *connect.Request[v1.StreamOrgWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
-	return c.streamOrgWorkloadMetrics.CallServerStream(ctx, req)
+func (c *metricsServiceClient) StreamOrgWorkloadMetrics(ctx context.Context, req *v1.StreamOrgWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
+	return c.streamOrgWorkloadMetrics.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // StreamClusterWorkloadMetrics calls organization.v1.MetricsService.StreamClusterWorkloadMetrics.
-func (c *metricsServiceClient) StreamClusterWorkloadMetrics(ctx context.Context, req *connect.Request[v1.StreamClusterWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
-	return c.streamClusterWorkloadMetrics.CallServerStream(ctx, req)
+func (c *metricsServiceClient) StreamClusterWorkloadMetrics(ctx context.Context, req *v1.StreamClusterWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
+	return c.streamClusterWorkloadMetrics.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // StreamProjectWorkloadMetrics calls organization.v1.MetricsService.StreamProjectWorkloadMetrics.
-func (c *metricsServiceClient) StreamProjectWorkloadMetrics(ctx context.Context, req *connect.Request[v1.StreamProjectWorkloadMetricsRequest]) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
-	return c.streamProjectWorkloadMetrics.CallServerStream(ctx, req)
+func (c *metricsServiceClient) StreamProjectWorkloadMetrics(ctx context.Context, req *v1.StreamProjectWorkloadMetricsRequest) (*connect.ServerStreamForClient[v1.StreamWorkloadMetricsResponse], error) {
+	return c.streamProjectWorkloadMetrics.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // MetricsServiceHandler is an implementation of the organization.v1.MetricsService service.
 type MetricsServiceHandler interface {
 	// Cluster-level workload metrics (CPU, memory, pods) for a specific cluster
-	GetClusterWorkloadMetrics(context.Context, *connect.Request[v1.GetClusterWorkloadMetricsRequest]) (*connect.Response[v1.GetClusterWorkloadMetricsResponse], error)
+	GetClusterWorkloadMetrics(context.Context, *v1.GetClusterWorkloadMetricsRequest) (*v1.GetClusterWorkloadMetricsResponse, error)
 	// Time-series workload metrics for a specific cluster
-	GetClusterWorkloadTimeSeries(context.Context, *connect.Request[v1.GetClusterWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetClusterWorkloadTimeSeries(context.Context, *v1.GetClusterWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Org-level workload metrics aggregated across all clusters
-	GetOrgWorkloadMetrics(context.Context, *connect.Request[v1.GetOrgWorkloadMetricsRequest]) (*connect.Response[v1.GetOrgWorkloadMetricsResponse], error)
+	GetOrgWorkloadMetrics(context.Context, *v1.GetOrgWorkloadMetricsRequest) (*v1.GetOrgWorkloadMetricsResponse, error)
 	// Org-level time-series workload metrics aggregated across all clusters
-	GetOrgWorkloadTimeSeries(context.Context, *connect.Request[v1.GetOrgWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetOrgWorkloadTimeSeries(context.Context, *v1.GetOrgWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Project-level workload metrics filtered to the project's namespaces
-	GetProjectWorkloadMetrics(context.Context, *connect.Request[v1.GetProjectWorkloadMetricsRequest]) (*connect.Response[v1.GetProjectWorkloadMetricsResponse], error)
+	GetProjectWorkloadMetrics(context.Context, *v1.GetProjectWorkloadMetricsRequest) (*v1.GetProjectWorkloadMetricsResponse, error)
 	// Project-level time-series workload metrics filtered to the project's namespaces
-	GetProjectWorkloadTimeSeries(context.Context, *connect.Request[v1.GetProjectWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error)
+	GetProjectWorkloadTimeSeries(context.Context, *v1.GetProjectWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error)
 	// Live streaming of org-wide workload metrics, pushed every 15 seconds.
-	StreamOrgWorkloadMetrics(context.Context, *connect.Request[v1.StreamOrgWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
+	StreamOrgWorkloadMetrics(context.Context, *v1.StreamOrgWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
 	// Live streaming of cluster workload metrics, pushed every 15 seconds.
-	StreamClusterWorkloadMetrics(context.Context, *connect.Request[v1.StreamClusterWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
+	StreamClusterWorkloadMetrics(context.Context, *v1.StreamClusterWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
 	// Live streaming of project workload metrics, pushed every 15 seconds.
-	StreamProjectWorkloadMetrics(context.Context, *connect.Request[v1.StreamProjectWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
+	StreamProjectWorkloadMetrics(context.Context, *v1.StreamProjectWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error
 }
 
 // NewMetricsServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -239,55 +263,55 @@ type MetricsServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewMetricsServiceHandler(svc MetricsServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	metricsServiceMethods := v1.File_v1_metrics_proto.Services().ByName("MetricsService").Methods()
-	metricsServiceGetClusterWorkloadMetricsHandler := connect.NewUnaryHandler(
+	metricsServiceGetClusterWorkloadMetricsHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetClusterWorkloadMetricsProcedure,
 		svc.GetClusterWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("GetClusterWorkloadMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceGetClusterWorkloadTimeSeriesHandler := connect.NewUnaryHandler(
+	metricsServiceGetClusterWorkloadTimeSeriesHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetClusterWorkloadTimeSeriesProcedure,
 		svc.GetClusterWorkloadTimeSeries,
 		connect.WithSchema(metricsServiceMethods.ByName("GetClusterWorkloadTimeSeries")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceGetOrgWorkloadMetricsHandler := connect.NewUnaryHandler(
+	metricsServiceGetOrgWorkloadMetricsHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetOrgWorkloadMetricsProcedure,
 		svc.GetOrgWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("GetOrgWorkloadMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceGetOrgWorkloadTimeSeriesHandler := connect.NewUnaryHandler(
+	metricsServiceGetOrgWorkloadTimeSeriesHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetOrgWorkloadTimeSeriesProcedure,
 		svc.GetOrgWorkloadTimeSeries,
 		connect.WithSchema(metricsServiceMethods.ByName("GetOrgWorkloadTimeSeries")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceGetProjectWorkloadMetricsHandler := connect.NewUnaryHandler(
+	metricsServiceGetProjectWorkloadMetricsHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetProjectWorkloadMetricsProcedure,
 		svc.GetProjectWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("GetProjectWorkloadMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceGetProjectWorkloadTimeSeriesHandler := connect.NewUnaryHandler(
+	metricsServiceGetProjectWorkloadTimeSeriesHandler := connect.NewUnaryHandlerSimple(
 		MetricsServiceGetProjectWorkloadTimeSeriesProcedure,
 		svc.GetProjectWorkloadTimeSeries,
 		connect.WithSchema(metricsServiceMethods.ByName("GetProjectWorkloadTimeSeries")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceStreamOrgWorkloadMetricsHandler := connect.NewServerStreamHandler(
+	metricsServiceStreamOrgWorkloadMetricsHandler := connect.NewServerStreamHandlerSimple(
 		MetricsServiceStreamOrgWorkloadMetricsProcedure,
 		svc.StreamOrgWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("StreamOrgWorkloadMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceStreamClusterWorkloadMetricsHandler := connect.NewServerStreamHandler(
+	metricsServiceStreamClusterWorkloadMetricsHandler := connect.NewServerStreamHandlerSimple(
 		MetricsServiceStreamClusterWorkloadMetricsProcedure,
 		svc.StreamClusterWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("StreamClusterWorkloadMetrics")),
 		connect.WithHandlerOptions(opts...),
 	)
-	metricsServiceStreamProjectWorkloadMetricsHandler := connect.NewServerStreamHandler(
+	metricsServiceStreamProjectWorkloadMetricsHandler := connect.NewServerStreamHandlerSimple(
 		MetricsServiceStreamProjectWorkloadMetricsProcedure,
 		svc.StreamProjectWorkloadMetrics,
 		connect.WithSchema(metricsServiceMethods.ByName("StreamProjectWorkloadMetrics")),
@@ -322,38 +346,38 @@ func NewMetricsServiceHandler(svc MetricsServiceHandler, opts ...connect.Handler
 // UnimplementedMetricsServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedMetricsServiceHandler struct{}
 
-func (UnimplementedMetricsServiceHandler) GetClusterWorkloadMetrics(context.Context, *connect.Request[v1.GetClusterWorkloadMetricsRequest]) (*connect.Response[v1.GetClusterWorkloadMetricsResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetClusterWorkloadMetrics(context.Context, *v1.GetClusterWorkloadMetricsRequest) (*v1.GetClusterWorkloadMetricsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetClusterWorkloadMetrics is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) GetClusterWorkloadTimeSeries(context.Context, *connect.Request[v1.GetClusterWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetClusterWorkloadTimeSeries(context.Context, *v1.GetClusterWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetClusterWorkloadTimeSeries is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) GetOrgWorkloadMetrics(context.Context, *connect.Request[v1.GetOrgWorkloadMetricsRequest]) (*connect.Response[v1.GetOrgWorkloadMetricsResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetOrgWorkloadMetrics(context.Context, *v1.GetOrgWorkloadMetricsRequest) (*v1.GetOrgWorkloadMetricsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetOrgWorkloadMetrics is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) GetOrgWorkloadTimeSeries(context.Context, *connect.Request[v1.GetOrgWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetOrgWorkloadTimeSeries(context.Context, *v1.GetOrgWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetOrgWorkloadTimeSeries is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) GetProjectWorkloadMetrics(context.Context, *connect.Request[v1.GetProjectWorkloadMetricsRequest]) (*connect.Response[v1.GetProjectWorkloadMetricsResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetProjectWorkloadMetrics(context.Context, *v1.GetProjectWorkloadMetricsRequest) (*v1.GetProjectWorkloadMetricsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetProjectWorkloadMetrics is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) GetProjectWorkloadTimeSeries(context.Context, *connect.Request[v1.GetProjectWorkloadTimeSeriesRequest]) (*connect.Response[v1.GetWorkloadTimeSeriesResponse], error) {
+func (UnimplementedMetricsServiceHandler) GetProjectWorkloadTimeSeries(context.Context, *v1.GetProjectWorkloadTimeSeriesRequest) (*v1.GetWorkloadTimeSeriesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.GetProjectWorkloadTimeSeries is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) StreamOrgWorkloadMetrics(context.Context, *connect.Request[v1.StreamOrgWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
+func (UnimplementedMetricsServiceHandler) StreamOrgWorkloadMetrics(context.Context, *v1.StreamOrgWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.StreamOrgWorkloadMetrics is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) StreamClusterWorkloadMetrics(context.Context, *connect.Request[v1.StreamClusterWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
+func (UnimplementedMetricsServiceHandler) StreamClusterWorkloadMetrics(context.Context, *v1.StreamClusterWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.StreamClusterWorkloadMetrics is not implemented"))
 }
 
-func (UnimplementedMetricsServiceHandler) StreamProjectWorkloadMetrics(context.Context, *connect.Request[v1.StreamProjectWorkloadMetricsRequest], *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
+func (UnimplementedMetricsServiceHandler) StreamProjectWorkloadMetrics(context.Context, *v1.StreamProjectWorkloadMetricsRequest, *connect.ServerStream[v1.StreamWorkloadMetricsResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.MetricsService.StreamProjectWorkloadMetrics is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/namespace.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/namespace.connect.go
@@ -56,17 +56,17 @@ const (
 // NamespaceServiceClient is a client for the organization.v1.NamespaceService service.
 type NamespaceServiceClient interface {
 	// List namespaces for a cluster
-	ListClusterNamespaces(context.Context, *connect.Request[v1.ListClusterNamespacesRequest]) (*connect.Response[v1.ListClusterNamespacesResponse], error)
+	ListClusterNamespaces(context.Context, *v1.ListClusterNamespacesRequest) (*v1.ListClusterNamespacesResponse, error)
 	// List all namespaces belonging to a project
-	ListProjectNamespaces(context.Context, *connect.Request[v1.ListProjectNamespacesRequest]) (*connect.Response[v1.ListProjectNamespacesResponse], error)
+	ListProjectNamespaces(context.Context, *v1.ListProjectNamespacesRequest) (*v1.ListProjectNamespacesResponse, error)
 	// Get a namespace by ID
-	GetNamespace(context.Context, *connect.Request[v1.GetNamespaceRequest]) (*connect.Response[v1.GetNamespaceResponse], error)
+	GetNamespace(context.Context, *v1.GetNamespaceRequest) (*v1.GetNamespaceResponse, error)
 	// Get a namespace by project name and namespace name
-	GetNamespaceByProjectAndName(context.Context, *connect.Request[v1.GetNamespaceByProjectAndNameRequest]) (*connect.Response[v1.GetNamespaceByProjectAndNameResponse], error)
+	GetNamespaceByProjectAndName(context.Context, *v1.GetNamespaceByProjectAndNameRequest) (*v1.GetNamespaceByProjectAndNameResponse, error)
 	// Create a namespace in a project
-	CreateNamespace(context.Context, *connect.Request[v1.CreateNamespaceRequest]) (*connect.Response[v1.CreateNamespaceResponse], error)
+	CreateNamespace(context.Context, *v1.CreateNamespaceRequest) (*v1.CreateNamespaceResponse, error)
 	// Delete a namespace
-	DeleteNamespace(context.Context, *connect.Request[v1.DeleteNamespaceRequest]) (*connect.Response[v1.DeleteNamespaceResponse], error)
+	DeleteNamespace(context.Context, *v1.DeleteNamespaceRequest) (*v1.DeleteNamespaceResponse, error)
 }
 
 // NewNamespaceServiceClient constructs a client for the organization.v1.NamespaceService service.
@@ -130,49 +130,73 @@ type namespaceServiceClient struct {
 }
 
 // ListClusterNamespaces calls organization.v1.NamespaceService.ListClusterNamespaces.
-func (c *namespaceServiceClient) ListClusterNamespaces(ctx context.Context, req *connect.Request[v1.ListClusterNamespacesRequest]) (*connect.Response[v1.ListClusterNamespacesResponse], error) {
-	return c.listClusterNamespaces.CallUnary(ctx, req)
+func (c *namespaceServiceClient) ListClusterNamespaces(ctx context.Context, req *v1.ListClusterNamespacesRequest) (*v1.ListClusterNamespacesResponse, error) {
+	response, err := c.listClusterNamespaces.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListProjectNamespaces calls organization.v1.NamespaceService.ListProjectNamespaces.
-func (c *namespaceServiceClient) ListProjectNamespaces(ctx context.Context, req *connect.Request[v1.ListProjectNamespacesRequest]) (*connect.Response[v1.ListProjectNamespacesResponse], error) {
-	return c.listProjectNamespaces.CallUnary(ctx, req)
+func (c *namespaceServiceClient) ListProjectNamespaces(ctx context.Context, req *v1.ListProjectNamespacesRequest) (*v1.ListProjectNamespacesResponse, error) {
+	response, err := c.listProjectNamespaces.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetNamespace calls organization.v1.NamespaceService.GetNamespace.
-func (c *namespaceServiceClient) GetNamespace(ctx context.Context, req *connect.Request[v1.GetNamespaceRequest]) (*connect.Response[v1.GetNamespaceResponse], error) {
-	return c.getNamespace.CallUnary(ctx, req)
+func (c *namespaceServiceClient) GetNamespace(ctx context.Context, req *v1.GetNamespaceRequest) (*v1.GetNamespaceResponse, error) {
+	response, err := c.getNamespace.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetNamespaceByProjectAndName calls organization.v1.NamespaceService.GetNamespaceByProjectAndName.
-func (c *namespaceServiceClient) GetNamespaceByProjectAndName(ctx context.Context, req *connect.Request[v1.GetNamespaceByProjectAndNameRequest]) (*connect.Response[v1.GetNamespaceByProjectAndNameResponse], error) {
-	return c.getNamespaceByProjectAndName.CallUnary(ctx, req)
+func (c *namespaceServiceClient) GetNamespaceByProjectAndName(ctx context.Context, req *v1.GetNamespaceByProjectAndNameRequest) (*v1.GetNamespaceByProjectAndNameResponse, error) {
+	response, err := c.getNamespaceByProjectAndName.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateNamespace calls organization.v1.NamespaceService.CreateNamespace.
-func (c *namespaceServiceClient) CreateNamespace(ctx context.Context, req *connect.Request[v1.CreateNamespaceRequest]) (*connect.Response[v1.CreateNamespaceResponse], error) {
-	return c.createNamespace.CallUnary(ctx, req)
+func (c *namespaceServiceClient) CreateNamespace(ctx context.Context, req *v1.CreateNamespaceRequest) (*v1.CreateNamespaceResponse, error) {
+	response, err := c.createNamespace.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteNamespace calls organization.v1.NamespaceService.DeleteNamespace.
-func (c *namespaceServiceClient) DeleteNamespace(ctx context.Context, req *connect.Request[v1.DeleteNamespaceRequest]) (*connect.Response[v1.DeleteNamespaceResponse], error) {
-	return c.deleteNamespace.CallUnary(ctx, req)
+func (c *namespaceServiceClient) DeleteNamespace(ctx context.Context, req *v1.DeleteNamespaceRequest) (*v1.DeleteNamespaceResponse, error) {
+	response, err := c.deleteNamespace.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // NamespaceServiceHandler is an implementation of the organization.v1.NamespaceService service.
 type NamespaceServiceHandler interface {
 	// List namespaces for a cluster
-	ListClusterNamespaces(context.Context, *connect.Request[v1.ListClusterNamespacesRequest]) (*connect.Response[v1.ListClusterNamespacesResponse], error)
+	ListClusterNamespaces(context.Context, *v1.ListClusterNamespacesRequest) (*v1.ListClusterNamespacesResponse, error)
 	// List all namespaces belonging to a project
-	ListProjectNamespaces(context.Context, *connect.Request[v1.ListProjectNamespacesRequest]) (*connect.Response[v1.ListProjectNamespacesResponse], error)
+	ListProjectNamespaces(context.Context, *v1.ListProjectNamespacesRequest) (*v1.ListProjectNamespacesResponse, error)
 	// Get a namespace by ID
-	GetNamespace(context.Context, *connect.Request[v1.GetNamespaceRequest]) (*connect.Response[v1.GetNamespaceResponse], error)
+	GetNamespace(context.Context, *v1.GetNamespaceRequest) (*v1.GetNamespaceResponse, error)
 	// Get a namespace by project name and namespace name
-	GetNamespaceByProjectAndName(context.Context, *connect.Request[v1.GetNamespaceByProjectAndNameRequest]) (*connect.Response[v1.GetNamespaceByProjectAndNameResponse], error)
+	GetNamespaceByProjectAndName(context.Context, *v1.GetNamespaceByProjectAndNameRequest) (*v1.GetNamespaceByProjectAndNameResponse, error)
 	// Create a namespace in a project
-	CreateNamespace(context.Context, *connect.Request[v1.CreateNamespaceRequest]) (*connect.Response[v1.CreateNamespaceResponse], error)
+	CreateNamespace(context.Context, *v1.CreateNamespaceRequest) (*v1.CreateNamespaceResponse, error)
 	// Delete a namespace
-	DeleteNamespace(context.Context, *connect.Request[v1.DeleteNamespaceRequest]) (*connect.Response[v1.DeleteNamespaceResponse], error)
+	DeleteNamespace(context.Context, *v1.DeleteNamespaceRequest) (*v1.DeleteNamespaceResponse, error)
 }
 
 // NewNamespaceServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -182,37 +206,37 @@ type NamespaceServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewNamespaceServiceHandler(svc NamespaceServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	namespaceServiceMethods := v1.File_v1_namespace_proto.Services().ByName("NamespaceService").Methods()
-	namespaceServiceListClusterNamespacesHandler := connect.NewUnaryHandler(
+	namespaceServiceListClusterNamespacesHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceListClusterNamespacesProcedure,
 		svc.ListClusterNamespaces,
 		connect.WithSchema(namespaceServiceMethods.ByName("ListClusterNamespaces")),
 		connect.WithHandlerOptions(opts...),
 	)
-	namespaceServiceListProjectNamespacesHandler := connect.NewUnaryHandler(
+	namespaceServiceListProjectNamespacesHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceListProjectNamespacesProcedure,
 		svc.ListProjectNamespaces,
 		connect.WithSchema(namespaceServiceMethods.ByName("ListProjectNamespaces")),
 		connect.WithHandlerOptions(opts...),
 	)
-	namespaceServiceGetNamespaceHandler := connect.NewUnaryHandler(
+	namespaceServiceGetNamespaceHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceGetNamespaceProcedure,
 		svc.GetNamespace,
 		connect.WithSchema(namespaceServiceMethods.ByName("GetNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
-	namespaceServiceGetNamespaceByProjectAndNameHandler := connect.NewUnaryHandler(
+	namespaceServiceGetNamespaceByProjectAndNameHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceGetNamespaceByProjectAndNameProcedure,
 		svc.GetNamespaceByProjectAndName,
 		connect.WithSchema(namespaceServiceMethods.ByName("GetNamespaceByProjectAndName")),
 		connect.WithHandlerOptions(opts...),
 	)
-	namespaceServiceCreateNamespaceHandler := connect.NewUnaryHandler(
+	namespaceServiceCreateNamespaceHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceCreateNamespaceProcedure,
 		svc.CreateNamespace,
 		connect.WithSchema(namespaceServiceMethods.ByName("CreateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
-	namespaceServiceDeleteNamespaceHandler := connect.NewUnaryHandler(
+	namespaceServiceDeleteNamespaceHandler := connect.NewUnaryHandlerSimple(
 		NamespaceServiceDeleteNamespaceProcedure,
 		svc.DeleteNamespace,
 		connect.WithSchema(namespaceServiceMethods.ByName("DeleteNamespace")),
@@ -241,26 +265,26 @@ func NewNamespaceServiceHandler(svc NamespaceServiceHandler, opts ...connect.Han
 // UnimplementedNamespaceServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedNamespaceServiceHandler struct{}
 
-func (UnimplementedNamespaceServiceHandler) ListClusterNamespaces(context.Context, *connect.Request[v1.ListClusterNamespacesRequest]) (*connect.Response[v1.ListClusterNamespacesResponse], error) {
+func (UnimplementedNamespaceServiceHandler) ListClusterNamespaces(context.Context, *v1.ListClusterNamespacesRequest) (*v1.ListClusterNamespacesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.ListClusterNamespaces is not implemented"))
 }
 
-func (UnimplementedNamespaceServiceHandler) ListProjectNamespaces(context.Context, *connect.Request[v1.ListProjectNamespacesRequest]) (*connect.Response[v1.ListProjectNamespacesResponse], error) {
+func (UnimplementedNamespaceServiceHandler) ListProjectNamespaces(context.Context, *v1.ListProjectNamespacesRequest) (*v1.ListProjectNamespacesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.ListProjectNamespaces is not implemented"))
 }
 
-func (UnimplementedNamespaceServiceHandler) GetNamespace(context.Context, *connect.Request[v1.GetNamespaceRequest]) (*connect.Response[v1.GetNamespaceResponse], error) {
+func (UnimplementedNamespaceServiceHandler) GetNamespace(context.Context, *v1.GetNamespaceRequest) (*v1.GetNamespaceResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.GetNamespace is not implemented"))
 }
 
-func (UnimplementedNamespaceServiceHandler) GetNamespaceByProjectAndName(context.Context, *connect.Request[v1.GetNamespaceByProjectAndNameRequest]) (*connect.Response[v1.GetNamespaceByProjectAndNameResponse], error) {
+func (UnimplementedNamespaceServiceHandler) GetNamespaceByProjectAndName(context.Context, *v1.GetNamespaceByProjectAndNameRequest) (*v1.GetNamespaceByProjectAndNameResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.GetNamespaceByProjectAndName is not implemented"))
 }
 
-func (UnimplementedNamespaceServiceHandler) CreateNamespace(context.Context, *connect.Request[v1.CreateNamespaceRequest]) (*connect.Response[v1.CreateNamespaceResponse], error) {
+func (UnimplementedNamespaceServiceHandler) CreateNamespace(context.Context, *v1.CreateNamespaceRequest) (*v1.CreateNamespaceResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.CreateNamespace is not implemented"))
 }
 
-func (UnimplementedNamespaceServiceHandler) DeleteNamespace(context.Context, *connect.Request[v1.DeleteNamespaceRequest]) (*connect.Response[v1.DeleteNamespaceResponse], error) {
+func (UnimplementedNamespaceServiceHandler) DeleteNamespace(context.Context, *v1.DeleteNamespaceRequest) (*v1.DeleteNamespaceResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.NamespaceService.DeleteNamespace is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/organization.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/organization.connect.go
@@ -53,15 +53,15 @@ const (
 // OrganizationServiceClient is a client for the organization.v1.OrganizationService service.
 type OrganizationServiceClient interface {
 	// ListOrganizations lists all organizations the current user belongs to
-	ListOrganizations(context.Context, *connect.Request[v1.ListOrganizationsRequest]) (*connect.Response[v1.ListOrganizationsResponse], error)
+	ListOrganizations(context.Context, *v1.ListOrganizationsRequest) (*v1.ListOrganizationsResponse, error)
 	// GetOrganization retrieves the user's organization by ID
-	GetOrganization(context.Context, *connect.Request[v1.GetOrganizationRequest]) (*connect.Response[v1.GetOrganizationResponse], error)
+	GetOrganization(context.Context, *v1.GetOrganizationRequest) (*v1.GetOrganizationResponse, error)
 	// UpdateOrganization updates the user's organization
-	UpdateOrganization(context.Context, *connect.Request[v1.UpdateOrganizationRequest]) (*connect.Response[v1.UpdateOrganizationResponse], error)
+	UpdateOrganization(context.Context, *v1.UpdateOrganizationRequest) (*v1.UpdateOrganizationResponse, error)
 	// GetOrganizationLimits retrieves the resource limits for an organization
-	GetOrganizationLimits(context.Context, *connect.Request[v1.GetOrganizationLimitsRequest]) (*connect.Response[v1.GetOrganizationLimitsResponse], error)
+	GetOrganizationLimits(context.Context, *v1.GetOrganizationLimitsRequest) (*v1.GetOrganizationLimitsResponse, error)
 	// UpdateOrganizationLimits sets the resource limits for an organization
-	UpdateOrganizationLimits(context.Context, *connect.Request[v1.UpdateOrganizationLimitsRequest]) (*connect.Response[v1.UpdateOrganizationLimitsResponse], error)
+	UpdateOrganizationLimits(context.Context, *v1.UpdateOrganizationLimitsRequest) (*v1.UpdateOrganizationLimitsResponse, error)
 }
 
 // NewOrganizationServiceClient constructs a client for the organization.v1.OrganizationService
@@ -118,43 +118,63 @@ type organizationServiceClient struct {
 }
 
 // ListOrganizations calls organization.v1.OrganizationService.ListOrganizations.
-func (c *organizationServiceClient) ListOrganizations(ctx context.Context, req *connect.Request[v1.ListOrganizationsRequest]) (*connect.Response[v1.ListOrganizationsResponse], error) {
-	return c.listOrganizations.CallUnary(ctx, req)
+func (c *organizationServiceClient) ListOrganizations(ctx context.Context, req *v1.ListOrganizationsRequest) (*v1.ListOrganizationsResponse, error) {
+	response, err := c.listOrganizations.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetOrganization calls organization.v1.OrganizationService.GetOrganization.
-func (c *organizationServiceClient) GetOrganization(ctx context.Context, req *connect.Request[v1.GetOrganizationRequest]) (*connect.Response[v1.GetOrganizationResponse], error) {
-	return c.getOrganization.CallUnary(ctx, req)
+func (c *organizationServiceClient) GetOrganization(ctx context.Context, req *v1.GetOrganizationRequest) (*v1.GetOrganizationResponse, error) {
+	response, err := c.getOrganization.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateOrganization calls organization.v1.OrganizationService.UpdateOrganization.
-func (c *organizationServiceClient) UpdateOrganization(ctx context.Context, req *connect.Request[v1.UpdateOrganizationRequest]) (*connect.Response[v1.UpdateOrganizationResponse], error) {
-	return c.updateOrganization.CallUnary(ctx, req)
+func (c *organizationServiceClient) UpdateOrganization(ctx context.Context, req *v1.UpdateOrganizationRequest) (*v1.UpdateOrganizationResponse, error) {
+	response, err := c.updateOrganization.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetOrganizationLimits calls organization.v1.OrganizationService.GetOrganizationLimits.
-func (c *organizationServiceClient) GetOrganizationLimits(ctx context.Context, req *connect.Request[v1.GetOrganizationLimitsRequest]) (*connect.Response[v1.GetOrganizationLimitsResponse], error) {
-	return c.getOrganizationLimits.CallUnary(ctx, req)
+func (c *organizationServiceClient) GetOrganizationLimits(ctx context.Context, req *v1.GetOrganizationLimitsRequest) (*v1.GetOrganizationLimitsResponse, error) {
+	response, err := c.getOrganizationLimits.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateOrganizationLimits calls organization.v1.OrganizationService.UpdateOrganizationLimits.
-func (c *organizationServiceClient) UpdateOrganizationLimits(ctx context.Context, req *connect.Request[v1.UpdateOrganizationLimitsRequest]) (*connect.Response[v1.UpdateOrganizationLimitsResponse], error) {
-	return c.updateOrganizationLimits.CallUnary(ctx, req)
+func (c *organizationServiceClient) UpdateOrganizationLimits(ctx context.Context, req *v1.UpdateOrganizationLimitsRequest) (*v1.UpdateOrganizationLimitsResponse, error) {
+	response, err := c.updateOrganizationLimits.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // OrganizationServiceHandler is an implementation of the organization.v1.OrganizationService
 // service.
 type OrganizationServiceHandler interface {
 	// ListOrganizations lists all organizations the current user belongs to
-	ListOrganizations(context.Context, *connect.Request[v1.ListOrganizationsRequest]) (*connect.Response[v1.ListOrganizationsResponse], error)
+	ListOrganizations(context.Context, *v1.ListOrganizationsRequest) (*v1.ListOrganizationsResponse, error)
 	// GetOrganization retrieves the user's organization by ID
-	GetOrganization(context.Context, *connect.Request[v1.GetOrganizationRequest]) (*connect.Response[v1.GetOrganizationResponse], error)
+	GetOrganization(context.Context, *v1.GetOrganizationRequest) (*v1.GetOrganizationResponse, error)
 	// UpdateOrganization updates the user's organization
-	UpdateOrganization(context.Context, *connect.Request[v1.UpdateOrganizationRequest]) (*connect.Response[v1.UpdateOrganizationResponse], error)
+	UpdateOrganization(context.Context, *v1.UpdateOrganizationRequest) (*v1.UpdateOrganizationResponse, error)
 	// GetOrganizationLimits retrieves the resource limits for an organization
-	GetOrganizationLimits(context.Context, *connect.Request[v1.GetOrganizationLimitsRequest]) (*connect.Response[v1.GetOrganizationLimitsResponse], error)
+	GetOrganizationLimits(context.Context, *v1.GetOrganizationLimitsRequest) (*v1.GetOrganizationLimitsResponse, error)
 	// UpdateOrganizationLimits sets the resource limits for an organization
-	UpdateOrganizationLimits(context.Context, *connect.Request[v1.UpdateOrganizationLimitsRequest]) (*connect.Response[v1.UpdateOrganizationLimitsResponse], error)
+	UpdateOrganizationLimits(context.Context, *v1.UpdateOrganizationLimitsRequest) (*v1.UpdateOrganizationLimitsResponse, error)
 }
 
 // NewOrganizationServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -164,31 +184,31 @@ type OrganizationServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewOrganizationServiceHandler(svc OrganizationServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	organizationServiceMethods := v1.File_v1_organization_proto.Services().ByName("OrganizationService").Methods()
-	organizationServiceListOrganizationsHandler := connect.NewUnaryHandler(
+	organizationServiceListOrganizationsHandler := connect.NewUnaryHandlerSimple(
 		OrganizationServiceListOrganizationsProcedure,
 		svc.ListOrganizations,
 		connect.WithSchema(organizationServiceMethods.ByName("ListOrganizations")),
 		connect.WithHandlerOptions(opts...),
 	)
-	organizationServiceGetOrganizationHandler := connect.NewUnaryHandler(
+	organizationServiceGetOrganizationHandler := connect.NewUnaryHandlerSimple(
 		OrganizationServiceGetOrganizationProcedure,
 		svc.GetOrganization,
 		connect.WithSchema(organizationServiceMethods.ByName("GetOrganization")),
 		connect.WithHandlerOptions(opts...),
 	)
-	organizationServiceUpdateOrganizationHandler := connect.NewUnaryHandler(
+	organizationServiceUpdateOrganizationHandler := connect.NewUnaryHandlerSimple(
 		OrganizationServiceUpdateOrganizationProcedure,
 		svc.UpdateOrganization,
 		connect.WithSchema(organizationServiceMethods.ByName("UpdateOrganization")),
 		connect.WithHandlerOptions(opts...),
 	)
-	organizationServiceGetOrganizationLimitsHandler := connect.NewUnaryHandler(
+	organizationServiceGetOrganizationLimitsHandler := connect.NewUnaryHandlerSimple(
 		OrganizationServiceGetOrganizationLimitsProcedure,
 		svc.GetOrganizationLimits,
 		connect.WithSchema(organizationServiceMethods.ByName("GetOrganizationLimits")),
 		connect.WithHandlerOptions(opts...),
 	)
-	organizationServiceUpdateOrganizationLimitsHandler := connect.NewUnaryHandler(
+	organizationServiceUpdateOrganizationLimitsHandler := connect.NewUnaryHandlerSimple(
 		OrganizationServiceUpdateOrganizationLimitsProcedure,
 		svc.UpdateOrganizationLimits,
 		connect.WithSchema(organizationServiceMethods.ByName("UpdateOrganizationLimits")),
@@ -215,22 +235,22 @@ func NewOrganizationServiceHandler(svc OrganizationServiceHandler, opts ...conne
 // UnimplementedOrganizationServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedOrganizationServiceHandler struct{}
 
-func (UnimplementedOrganizationServiceHandler) ListOrganizations(context.Context, *connect.Request[v1.ListOrganizationsRequest]) (*connect.Response[v1.ListOrganizationsResponse], error) {
+func (UnimplementedOrganizationServiceHandler) ListOrganizations(context.Context, *v1.ListOrganizationsRequest) (*v1.ListOrganizationsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.OrganizationService.ListOrganizations is not implemented"))
 }
 
-func (UnimplementedOrganizationServiceHandler) GetOrganization(context.Context, *connect.Request[v1.GetOrganizationRequest]) (*connect.Response[v1.GetOrganizationResponse], error) {
+func (UnimplementedOrganizationServiceHandler) GetOrganization(context.Context, *v1.GetOrganizationRequest) (*v1.GetOrganizationResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.OrganizationService.GetOrganization is not implemented"))
 }
 
-func (UnimplementedOrganizationServiceHandler) UpdateOrganization(context.Context, *connect.Request[v1.UpdateOrganizationRequest]) (*connect.Response[v1.UpdateOrganizationResponse], error) {
+func (UnimplementedOrganizationServiceHandler) UpdateOrganization(context.Context, *v1.UpdateOrganizationRequest) (*v1.UpdateOrganizationResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.OrganizationService.UpdateOrganization is not implemented"))
 }
 
-func (UnimplementedOrganizationServiceHandler) GetOrganizationLimits(context.Context, *connect.Request[v1.GetOrganizationLimitsRequest]) (*connect.Response[v1.GetOrganizationLimitsResponse], error) {
+func (UnimplementedOrganizationServiceHandler) GetOrganizationLimits(context.Context, *v1.GetOrganizationLimitsRequest) (*v1.GetOrganizationLimitsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.OrganizationService.GetOrganizationLimits is not implemented"))
 }
 
-func (UnimplementedOrganizationServiceHandler) UpdateOrganizationLimits(context.Context, *connect.Request[v1.UpdateOrganizationLimitsRequest]) (*connect.Response[v1.UpdateOrganizationLimitsResponse], error) {
+func (UnimplementedOrganizationServiceHandler) UpdateOrganizationLimits(context.Context, *v1.UpdateOrganizationLimitsRequest) (*v1.UpdateOrganizationLimitsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.OrganizationService.UpdateOrganizationLimits is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/plugin.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/plugin.connect.go
@@ -56,25 +56,25 @@ const (
 // PluginServiceClient is a client for the organization.v1.PluginService service.
 type PluginServiceClient interface {
 	// List all available plugins
-	ListPlugins(context.Context, *connect.Request[v1.ListPluginsRequest]) (*connect.Response[v1.ListPluginsResponse], error)
+	ListPlugins(context.Context, *v1.ListPluginsRequest) (*v1.ListPluginsResponse, error)
 	// Get detailed information about a specific plugin
-	GetPluginDetail(context.Context, *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error)
+	GetPluginDetail(context.Context, *v1.GetPluginDetailRequest) (*v1.GetPluginDetailResponse, error)
 	// List all available presets
-	ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error)
+	ListPresets(context.Context, *v1.ListPresetsRequest) (*v1.ListPresetsResponse, error)
 	// List the published definitions (version + hash) for a plugin, latest first.
 	// Used by the console to offer a version to pin on install.
-	ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error)
+	ListPluginDefinitions(context.Context, *v1.ListPluginDefinitionsRequest) (*v1.ListPluginDefinitionsResponse, error)
 	// Idempotent upsert of a plugin definition. Server computes the hash from the
 	// manifest bytes. Same (plugin_id, version, hash) → returns the existing row;
 	// same (plugin_id, version) with a different hash → FAILED_PRECONDITION unless
 	// replace=true, which soft-deletes the existing row and stores the new one.
 	// Requires the catalog plugin to exist — FAILED_PRECONDITION otherwise.
 	// Requires an authenticated user.
-	PutPluginDefinition(context.Context, *connect.Request[v1.PutPluginDefinitionRequest]) (*connect.Response[v1.PutPluginDefinitionResponse], error)
+	PutPluginDefinition(context.Context, *v1.PutPluginDefinitionRequest) (*v1.PutPluginDefinitionResponse, error)
 	// Fetch a plugin definition by (plugin_name, plugin_version). The plugin is
 	// resolved via the plugin catalog by name. Returns the verbatim manifest
 	// bytes, the sha256 hash, and a parsed PluginDefinition.
-	GetPluginDefinition(context.Context, *connect.Request[v1.GetPluginDefinitionRequest]) (*connect.Response[v1.GetPluginDefinitionResponse], error)
+	GetPluginDefinition(context.Context, *v1.GetPluginDefinitionRequest) (*v1.GetPluginDefinitionResponse, error)
 }
 
 // NewPluginServiceClient constructs a client for the organization.v1.PluginService service. By
@@ -138,57 +138,81 @@ type pluginServiceClient struct {
 }
 
 // ListPlugins calls organization.v1.PluginService.ListPlugins.
-func (c *pluginServiceClient) ListPlugins(ctx context.Context, req *connect.Request[v1.ListPluginsRequest]) (*connect.Response[v1.ListPluginsResponse], error) {
-	return c.listPlugins.CallUnary(ctx, req)
+func (c *pluginServiceClient) ListPlugins(ctx context.Context, req *v1.ListPluginsRequest) (*v1.ListPluginsResponse, error) {
+	response, err := c.listPlugins.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPluginDetail calls organization.v1.PluginService.GetPluginDetail.
-func (c *pluginServiceClient) GetPluginDetail(ctx context.Context, req *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error) {
-	return c.getPluginDetail.CallUnary(ctx, req)
+func (c *pluginServiceClient) GetPluginDetail(ctx context.Context, req *v1.GetPluginDetailRequest) (*v1.GetPluginDetailResponse, error) {
+	response, err := c.getPluginDetail.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListPresets calls organization.v1.PluginService.ListPresets.
-func (c *pluginServiceClient) ListPresets(ctx context.Context, req *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error) {
-	return c.listPresets.CallUnary(ctx, req)
+func (c *pluginServiceClient) ListPresets(ctx context.Context, req *v1.ListPresetsRequest) (*v1.ListPresetsResponse, error) {
+	response, err := c.listPresets.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListPluginDefinitions calls organization.v1.PluginService.ListPluginDefinitions.
-func (c *pluginServiceClient) ListPluginDefinitions(ctx context.Context, req *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error) {
-	return c.listPluginDefinitions.CallUnary(ctx, req)
+func (c *pluginServiceClient) ListPluginDefinitions(ctx context.Context, req *v1.ListPluginDefinitionsRequest) (*v1.ListPluginDefinitionsResponse, error) {
+	response, err := c.listPluginDefinitions.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PutPluginDefinition calls organization.v1.PluginService.PutPluginDefinition.
-func (c *pluginServiceClient) PutPluginDefinition(ctx context.Context, req *connect.Request[v1.PutPluginDefinitionRequest]) (*connect.Response[v1.PutPluginDefinitionResponse], error) {
-	return c.putPluginDefinition.CallUnary(ctx, req)
+func (c *pluginServiceClient) PutPluginDefinition(ctx context.Context, req *v1.PutPluginDefinitionRequest) (*v1.PutPluginDefinitionResponse, error) {
+	response, err := c.putPluginDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetPluginDefinition calls organization.v1.PluginService.GetPluginDefinition.
-func (c *pluginServiceClient) GetPluginDefinition(ctx context.Context, req *connect.Request[v1.GetPluginDefinitionRequest]) (*connect.Response[v1.GetPluginDefinitionResponse], error) {
-	return c.getPluginDefinition.CallUnary(ctx, req)
+func (c *pluginServiceClient) GetPluginDefinition(ctx context.Context, req *v1.GetPluginDefinitionRequest) (*v1.GetPluginDefinitionResponse, error) {
+	response, err := c.getPluginDefinition.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PluginServiceHandler is an implementation of the organization.v1.PluginService service.
 type PluginServiceHandler interface {
 	// List all available plugins
-	ListPlugins(context.Context, *connect.Request[v1.ListPluginsRequest]) (*connect.Response[v1.ListPluginsResponse], error)
+	ListPlugins(context.Context, *v1.ListPluginsRequest) (*v1.ListPluginsResponse, error)
 	// Get detailed information about a specific plugin
-	GetPluginDetail(context.Context, *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error)
+	GetPluginDetail(context.Context, *v1.GetPluginDetailRequest) (*v1.GetPluginDetailResponse, error)
 	// List all available presets
-	ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error)
+	ListPresets(context.Context, *v1.ListPresetsRequest) (*v1.ListPresetsResponse, error)
 	// List the published definitions (version + hash) for a plugin, latest first.
 	// Used by the console to offer a version to pin on install.
-	ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error)
+	ListPluginDefinitions(context.Context, *v1.ListPluginDefinitionsRequest) (*v1.ListPluginDefinitionsResponse, error)
 	// Idempotent upsert of a plugin definition. Server computes the hash from the
 	// manifest bytes. Same (plugin_id, version, hash) → returns the existing row;
 	// same (plugin_id, version) with a different hash → FAILED_PRECONDITION unless
 	// replace=true, which soft-deletes the existing row and stores the new one.
 	// Requires the catalog plugin to exist — FAILED_PRECONDITION otherwise.
 	// Requires an authenticated user.
-	PutPluginDefinition(context.Context, *connect.Request[v1.PutPluginDefinitionRequest]) (*connect.Response[v1.PutPluginDefinitionResponse], error)
+	PutPluginDefinition(context.Context, *v1.PutPluginDefinitionRequest) (*v1.PutPluginDefinitionResponse, error)
 	// Fetch a plugin definition by (plugin_name, plugin_version). The plugin is
 	// resolved via the plugin catalog by name. Returns the verbatim manifest
 	// bytes, the sha256 hash, and a parsed PluginDefinition.
-	GetPluginDefinition(context.Context, *connect.Request[v1.GetPluginDefinitionRequest]) (*connect.Response[v1.GetPluginDefinitionResponse], error)
+	GetPluginDefinition(context.Context, *v1.GetPluginDefinitionRequest) (*v1.GetPluginDefinitionResponse, error)
 }
 
 // NewPluginServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -198,37 +222,37 @@ type PluginServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	pluginServiceMethods := v1.File_v1_plugin_proto.Services().ByName("PluginService").Methods()
-	pluginServiceListPluginsHandler := connect.NewUnaryHandler(
+	pluginServiceListPluginsHandler := connect.NewUnaryHandlerSimple(
 		PluginServiceListPluginsProcedure,
 		svc.ListPlugins,
 		connect.WithSchema(pluginServiceMethods.ByName("ListPlugins")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginServiceGetPluginDetailHandler := connect.NewUnaryHandler(
+	pluginServiceGetPluginDetailHandler := connect.NewUnaryHandlerSimple(
 		PluginServiceGetPluginDetailProcedure,
 		svc.GetPluginDetail,
 		connect.WithSchema(pluginServiceMethods.ByName("GetPluginDetail")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginServiceListPresetsHandler := connect.NewUnaryHandler(
+	pluginServiceListPresetsHandler := connect.NewUnaryHandlerSimple(
 		PluginServiceListPresetsProcedure,
 		svc.ListPresets,
 		connect.WithSchema(pluginServiceMethods.ByName("ListPresets")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginServiceListPluginDefinitionsHandler := connect.NewUnaryHandler(
+	pluginServiceListPluginDefinitionsHandler := connect.NewUnaryHandlerSimple(
 		PluginServiceListPluginDefinitionsProcedure,
 		svc.ListPluginDefinitions,
 		connect.WithSchema(pluginServiceMethods.ByName("ListPluginDefinitions")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginServicePutPluginDefinitionHandler := connect.NewUnaryHandler(
+	pluginServicePutPluginDefinitionHandler := connect.NewUnaryHandlerSimple(
 		PluginServicePutPluginDefinitionProcedure,
 		svc.PutPluginDefinition,
 		connect.WithSchema(pluginServiceMethods.ByName("PutPluginDefinition")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginServiceGetPluginDefinitionHandler := connect.NewUnaryHandler(
+	pluginServiceGetPluginDefinitionHandler := connect.NewUnaryHandlerSimple(
 		PluginServiceGetPluginDefinitionProcedure,
 		svc.GetPluginDefinition,
 		connect.WithSchema(pluginServiceMethods.ByName("GetPluginDefinition")),
@@ -257,26 +281,26 @@ func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOp
 // UnimplementedPluginServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPluginServiceHandler struct{}
 
-func (UnimplementedPluginServiceHandler) ListPlugins(context.Context, *connect.Request[v1.ListPluginsRequest]) (*connect.Response[v1.ListPluginsResponse], error) {
+func (UnimplementedPluginServiceHandler) ListPlugins(context.Context, *v1.ListPluginsRequest) (*v1.ListPluginsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.ListPlugins is not implemented"))
 }
 
-func (UnimplementedPluginServiceHandler) GetPluginDetail(context.Context, *connect.Request[v1.GetPluginDetailRequest]) (*connect.Response[v1.GetPluginDetailResponse], error) {
+func (UnimplementedPluginServiceHandler) GetPluginDetail(context.Context, *v1.GetPluginDetailRequest) (*v1.GetPluginDetailResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.GetPluginDetail is not implemented"))
 }
 
-func (UnimplementedPluginServiceHandler) ListPresets(context.Context, *connect.Request[v1.ListPresetsRequest]) (*connect.Response[v1.ListPresetsResponse], error) {
+func (UnimplementedPluginServiceHandler) ListPresets(context.Context, *v1.ListPresetsRequest) (*v1.ListPresetsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.ListPresets is not implemented"))
 }
 
-func (UnimplementedPluginServiceHandler) ListPluginDefinitions(context.Context, *connect.Request[v1.ListPluginDefinitionsRequest]) (*connect.Response[v1.ListPluginDefinitionsResponse], error) {
+func (UnimplementedPluginServiceHandler) ListPluginDefinitions(context.Context, *v1.ListPluginDefinitionsRequest) (*v1.ListPluginDefinitionsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.ListPluginDefinitions is not implemented"))
 }
 
-func (UnimplementedPluginServiceHandler) PutPluginDefinition(context.Context, *connect.Request[v1.PutPluginDefinitionRequest]) (*connect.Response[v1.PutPluginDefinitionResponse], error) {
+func (UnimplementedPluginServiceHandler) PutPluginDefinition(context.Context, *v1.PutPluginDefinitionRequest) (*v1.PutPluginDefinitionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.PutPluginDefinition is not implemented"))
 }
 
-func (UnimplementedPluginServiceHandler) GetPluginDefinition(context.Context, *connect.Request[v1.GetPluginDefinitionRequest]) (*connect.Response[v1.GetPluginDefinitionResponse], error) {
+func (UnimplementedPluginServiceHandler) GetPluginDefinition(context.Context, *v1.GetPluginDefinitionRequest) (*v1.GetPluginDefinitionResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.PluginService.GetPluginDefinition is not implemented"))
 }

--- a/organization-api/pkg/proto/gen/v1/organizationv1connect/project.connect.go
+++ b/organization-api/pkg/proto/gen/v1/organizationv1connect/project.connect.go
@@ -77,31 +77,31 @@ const (
 // ProjectServiceClient is a client for the organization.v1.ProjectService service.
 type ProjectServiceClient interface {
 	// List all projects for the current organization
-	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
+	ListProjects(context.Context, *v1.ListProjectsRequest) (*v1.ListProjectsResponse, error)
 	// Get detailed information about a specific project
-	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.GetProjectResponse], error)
+	GetProject(context.Context, *v1.GetProjectRequest) (*v1.GetProjectResponse, error)
 	// Get a project by name
-	GetProjectByName(context.Context, *connect.Request[v1.GetProjectByNameRequest]) (*connect.Response[v1.GetProjectResponse], error)
+	GetProjectByName(context.Context, *v1.GetProjectByNameRequest) (*v1.GetProjectResponse, error)
 	// Create a new project
-	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.CreateProjectResponse], error)
+	CreateProject(context.Context, *v1.CreateProjectRequest) (*v1.CreateProjectResponse, error)
 	// Update project configuration
-	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.UpdateProjectResponse], error)
+	UpdateProject(context.Context, *v1.UpdateProjectRequest) (*v1.UpdateProjectResponse, error)
 	// Delete a project
-	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[v1.DeleteProjectResponse], error)
+	DeleteProject(context.Context, *v1.DeleteProjectRequest) (*v1.DeleteProjectResponse, error)
 	// List all members of a project
-	ListProjectMembers(context.Context, *connect.Request[v1.ListProjectMembersRequest]) (*connect.Response[v1.ListProjectMembersResponse], error)
+	ListProjectMembers(context.Context, *v1.ListProjectMembersRequest) (*v1.ListProjectMembersResponse, error)
 	// Get a single project member by ID
-	GetProjectMember(context.Context, *connect.Request[v1.GetProjectMemberRequest]) (*connect.Response[v1.GetProjectMemberResponse], error)
+	GetProjectMember(context.Context, *v1.GetProjectMemberRequest) (*v1.GetProjectMemberResponse, error)
 	// Add a member to a project (requires admin role)
-	AddProjectMember(context.Context, *connect.Request[v1.AddProjectMemberRequest]) (*connect.Response[v1.AddProjectMemberResponse], error)
+	AddProjectMember(context.Context, *v1.AddProjectMemberRequest) (*v1.AddProjectMemberResponse, error)
 	// Update a member's role (requires admin role)
-	UpdateProjectMemberRole(context.Context, *connect.Request[v1.UpdateProjectMemberRoleRequest]) (*connect.Response[v1.UpdateProjectMemberRoleResponse], error)
+	UpdateProjectMemberRole(context.Context, *v1.UpdateProjectMemberRoleRequest) (*v1.UpdateProjectMemberRoleResponse, error)
 	// Remove a member from a project (requires admin role)
-	RemoveProjectMember(context.Context, *connect.Request[v1.RemoveProjectMemberRequest]) (*connect.Response[v1.RemoveProjectMemberResponse], error)
+	RemoveProjectMember(context.Context, *v1.RemoveProjectMemberRequest) (*v1.RemoveProjectMemberResponse, error)
 	// GetProjectLimits retrieves the namespace resource defaults for a project
-	GetProjectLimits(context.Context, *connect.Request[v1.GetProjectLimitsRequest]) (*connect.Response[v1.GetProjectLimitsResponse], error)
+	GetProjectLimits(context.Context, *v1.GetProjectLimitsRequest) (*v1.GetProjectLimitsResponse, error)
 	// UpdateProjectLimits sets the namespace resource defaults for a project
-	UpdateProjectLimits(context.Context, *connect.Request[v1.UpdateProjectLimitsRequest]) (*connect.Response[v1.UpdateProjectLimitsResponse], error)
+	UpdateProjectLimits(context.Context, *v1.UpdateProjectLimitsRequest) (*v1.UpdateProjectLimitsResponse, error)
 }
 
 // NewProjectServiceClient constructs a client for the organization.v1.ProjectService service. By
@@ -214,98 +214,150 @@ type projectServiceClient struct {
 }
 
 // ListProjects calls organization.v1.ProjectService.ListProjects.
-func (c *projectServiceClient) ListProjects(ctx context.Context, req *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error) {
-	return c.listProjects.CallUnary(ctx, req)
+func (c *projectServiceClient) ListProjects(ctx context.Context, req *v1.ListProjectsRequest) (*v1.ListProjectsResponse, error) {
+	response, err := c.listProjects.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProject calls organization.v1.ProjectService.GetProject.
-func (c *projectServiceClient) GetProject(ctx context.Context, req *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.GetProjectResponse], error) {
-	return c.getProject.CallUnary(ctx, req)
+func (c *projectServiceClient) GetProject(ctx context.Context, req *v1.GetProjectRequest) (*v1.GetProjectResponse, error) {
+	response, err := c.getProject.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProjectByName calls organization.v1.ProjectService.GetProjectByName.
-func (c *projectServiceClient) GetProjectByName(ctx context.Context, req *connect.Request[v1.GetProjectByNameRequest]) (*connect.Response[v1.GetProjectResponse], error) {
-	return c.getProjectByName.CallUnary(ctx, req)
+func (c *projectServiceClient) GetProjectByName(ctx context.Context, req *v1.GetProjectByNameRequest) (*v1.GetProjectResponse, error) {
+	response, err := c.getProjectByName.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CreateProject calls organization.v1.ProjectService.CreateProject.
-func (c *projectServiceClient) CreateProject(ctx context.Context, req *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.CreateProjectResponse], error) {
-	return c.createProject.CallUnary(ctx, req)
+func (c *projectServiceClient) CreateProject(ctx context.Context, req *v1.CreateProjectRequest) (*v1.CreateProjectResponse, error) {
+	response, err := c.createProject.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateProject calls organization.v1.ProjectService.UpdateProject.
-func (c *projectServiceClient) UpdateProject(ctx context.Context, req *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.UpdateProjectResponse], error) {
-	return c.updateProject.CallUnary(ctx, req)
+func (c *projectServiceClient) UpdateProject(ctx context.Context, req *v1.UpdateProjectRequest) (*v1.UpdateProjectResponse, error) {
+	response, err := c.updateProject.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // DeleteProject calls organization.v1.ProjectService.DeleteProject.
-func (c *projectServiceClient) DeleteProject(ctx context.Context, req *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[v1.DeleteProjectResponse], error) {
-	return c.deleteProject.CallUnary(ctx, req)
+func (c *projectServiceClient) DeleteProject(ctx context.Context, req *v1.DeleteProjectRequest) (*v1.DeleteProjectResponse, error) {
+	response, err := c.deleteProject.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ListProjectMembers calls organization.v1.ProjectService.ListProjectMembers.
-func (c *projectServiceClient) ListProjectMembers(ctx context.Context, req *connect.Request[v1.ListProjectMembersRequest]) (*connect.Response[v1.ListProjectMembersResponse], error) {
-	return c.listProjectMembers.CallUnary(ctx, req)
+func (c *projectServiceClient) ListProjectMembers(ctx context.Context, req *v1.ListProjectMembersRequest) (*v1.ListProjectMembersResponse, error) {
+	response, err := c.listProjectMembers.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProjectMember calls organization.v1.ProjectService.GetProjectMember.
-func (c *projectServiceClient) GetProjectMember(ctx context.Context, req *connect.Request[v1.GetProjectMemberRequest]) (*connect.Response[v1.GetProjectMemberResponse], error) {
-	return c.getProjectMember.CallUnary(ctx, req)
+func (c *projectServiceClient) GetProjectMember(ctx context.Context, req *v1.GetProjectMemberRequest) (*v1.GetProjectMemberResponse, error) {
+	response, err := c.getProjectMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // AddProjectMember calls organization.v1.ProjectService.AddProjectMember.
-func (c *projectServiceClient) AddProjectMember(ctx context.Context, req *connect.Request[v1.AddProjectMemberRequest]) (*connect.Response[v1.AddProjectMemberResponse], error) {
-	return c.addProjectMember.CallUnary(ctx, req)
+func (c *projectServiceClient) AddProjectMember(ctx context.Context, req *v1.AddProjectMemberRequest) (*v1.AddProjectMemberResponse, error) {
+	response, err := c.addProjectMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateProjectMemberRole calls organization.v1.ProjectService.UpdateProjectMemberRole.
-func (c *projectServiceClient) UpdateProjectMemberRole(ctx context.Context, req *connect.Request[v1.UpdateProjectMemberRoleRequest]) (*connect.Response[v1.UpdateProjectMemberRoleResponse], error) {
-	return c.updateProjectMemberRole.CallUnary(ctx, req)
+func (c *projectServiceClient) UpdateProjectMemberRole(ctx context.Context, req *v1.UpdateProjectMemberRoleRequest) (*v1.UpdateProjectMemberRoleResponse, error) {
+	response, err := c.updateProjectMemberRole.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RemoveProjectMember calls organization.v1.ProjectService.RemoveProjectMember.
-func (c *projectServiceClient) RemoveProjectMember(ctx context.Context, req *connect.Request[v1.RemoveProjectMemberRequest]) (*connect.Response[v1.RemoveProjectMemberResponse], error) {
-	return c.removeProjectMember.CallUnary(ctx, req)
+func (c *projectServiceClient) RemoveProjectMember(ctx context.Context, req *v1.RemoveProjectMemberRequest) (*v1.RemoveProjectMemberResponse, error) {
+	response, err := c.removeProjectMember.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // GetProjectLimits calls organization.v1.ProjectService.GetProjectLimits.
-func (c *projectServiceClient) GetProjectLimits(ctx context.Context, req *connect.Request[v1.GetProjectLimitsRequest]) (*connect.Response[v1.GetProjectLimitsResponse], error) {
-	return c.getProjectLimits.CallUnary(ctx, req)
+func (c *projectServiceClient) GetProjectLimits(ctx context.Context, req *v1.GetProjectLimitsRequest) (*v1.GetProjectLimitsResponse, error) {
+	response, err := c.getProjectLimits.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // UpdateProjectLimits calls organization.v1.ProjectService.UpdateProjectLimits.
-func (c *projectServiceClient) UpdateProjectLimits(ctx context.Context, req *connect.Request[v1.UpdateProjectLimitsRequest]) (*connect.Response[v1.UpdateProjectLimitsResponse], error) {
-	return c.updateProjectLimits.CallUnary(ctx, req)
+func (c *projectServiceClient) UpdateProjectLimits(ctx context.Context, req *v1.UpdateProjectLimitsRequest) (*v1.UpdateProjectLimitsResponse, error) {
+	response, err := c.updateProjectLimits.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // ProjectServiceHandler is an implementation of the organization.v1.ProjectService service.
 type ProjectServiceHandler interface {
 	// List all projects for the current organization
-	ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error)
+	ListProjects(context.Context, *v1.ListProjectsRequest) (*v1.ListProjectsResponse, error)
 	// Get detailed information about a specific project
-	GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.GetProjectResponse], error)
+	GetProject(context.Context, *v1.GetProjectRequest) (*v1.GetProjectResponse, error)
 	// Get a project by name
-	GetProjectByName(context.Context, *connect.Request[v1.GetProjectByNameRequest]) (*connect.Response[v1.GetProjectResponse], error)
+	GetProjectByName(context.Context, *v1.GetProjectByNameRequest) (*v1.GetProjectResponse, error)
 	// Create a new project
-	CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.CreateProjectResponse], error)
+	CreateProject(context.Context, *v1.CreateProjectRequest) (*v1.CreateProjectResponse, error)
 	// Update project configuration
-	UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.UpdateProjectResponse], error)
+	UpdateProject(context.Context, *v1.UpdateProjectRequest) (*v1.UpdateProjectResponse, error)
 	// Delete a project
-	DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[v1.DeleteProjectResponse], error)
+	DeleteProject(context.Context, *v1.DeleteProjectRequest) (*v1.DeleteProjectResponse, error)
 	// List all members of a project
-	ListProjectMembers(context.Context, *connect.Request[v1.ListProjectMembersRequest]) (*connect.Response[v1.ListProjectMembersResponse], error)
+	ListProjectMembers(context.Context, *v1.ListProjectMembersRequest) (*v1.ListProjectMembersResponse, error)
 	// Get a single project member by ID
-	GetProjectMember(context.Context, *connect.Request[v1.GetProjectMemberRequest]) (*connect.Response[v1.GetProjectMemberResponse], error)
+	GetProjectMember(context.Context, *v1.GetProjectMemberRequest) (*v1.GetProjectMemberResponse, error)
 	// Add a member to a project (requires admin role)
-	AddProjectMember(context.Context, *connect.Request[v1.AddProjectMemberRequest]) (*connect.Response[v1.AddProjectMemberResponse], error)
+	AddProjectMember(context.Context, *v1.AddProjectMemberRequest) (*v1.AddProjectMemberResponse, error)
 	// Update a member's role (requires admin role)
-	UpdateProjectMemberRole(context.Context, *connect.Request[v1.UpdateProjectMemberRoleRequest]) (*connect.Response[v1.UpdateProjectMemberRoleResponse], error)
+	UpdateProjectMemberRole(context.Context, *v1.UpdateProjectMemberRoleRequest) (*v1.UpdateProjectMemberRoleResponse, error)
 	// Remove a member from a project (requires admin role)
-	RemoveProjectMember(context.Context, *connect.Request[v1.RemoveProjectMemberRequest]) (*connect.Response[v1.RemoveProjectMemberResponse], error)
+	RemoveProjectMember(context.Context, *v1.RemoveProjectMemberRequest) (*v1.RemoveProjectMemberResponse, error)
 	// GetProjectLimits retrieves the namespace resource defaults for a project
-	GetProjectLimits(context.Context, *connect.Request[v1.GetProjectLimitsRequest]) (*connect.Response[v1.GetProjectLimitsResponse], error)
+	GetProjectLimits(context.Context, *v1.GetProjectLimitsRequest) (*v1.GetProjectLimitsResponse, error)
 	// UpdateProjectLimits sets the namespace resource defaults for a project
-	UpdateProjectLimits(context.Context, *connect.Request[v1.UpdateProjectLimitsRequest]) (*connect.Response[v1.UpdateProjectLimitsResponse], error)
+	UpdateProjectLimits(context.Context, *v1.UpdateProjectLimitsRequest) (*v1.UpdateProjectLimitsResponse, error)
 }
 
 // NewProjectServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -315,79 +367,79 @@ type ProjectServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	projectServiceMethods := v1.File_v1_project_proto.Services().ByName("ProjectService").Methods()
-	projectServiceListProjectsHandler := connect.NewUnaryHandler(
+	projectServiceListProjectsHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceListProjectsProcedure,
 		svc.ListProjects,
 		connect.WithSchema(projectServiceMethods.ByName("ListProjects")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceGetProjectHandler := connect.NewUnaryHandler(
+	projectServiceGetProjectHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceGetProjectProcedure,
 		svc.GetProject,
 		connect.WithSchema(projectServiceMethods.ByName("GetProject")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceGetProjectByNameHandler := connect.NewUnaryHandler(
+	projectServiceGetProjectByNameHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceGetProjectByNameProcedure,
 		svc.GetProjectByName,
 		connect.WithSchema(projectServiceMethods.ByName("GetProjectByName")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceCreateProjectHandler := connect.NewUnaryHandler(
+	projectServiceCreateProjectHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceCreateProjectProcedure,
 		svc.CreateProject,
 		connect.WithSchema(projectServiceMethods.ByName("CreateProject")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceUpdateProjectHandler := connect.NewUnaryHandler(
+	projectServiceUpdateProjectHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceUpdateProjectProcedure,
 		svc.UpdateProject,
 		connect.WithSchema(projectServiceMethods.ByName("UpdateProject")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceDeleteProjectHandler := connect.NewUnaryHandler(
+	projectServiceDeleteProjectHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceDeleteProjectProcedure,
 		svc.DeleteProject,
 		connect.WithSchema(projectServiceMethods.ByName("DeleteProject")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceListProjectMembersHandler := connect.NewUnaryHandler(
+	projectServiceListProjectMembersHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceListProjectMembersProcedure,
 		svc.ListProjectMembers,
 		connect.WithSchema(projectServiceMethods.ByName("ListProjectMembers")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceGetProjectMemberHandler := connect.NewUnaryHandler(
+	projectServiceGetProjectMemberHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceGetProjectMemberProcedure,
 		svc.GetProjectMember,
 		connect.WithSchema(projectServiceMethods.ByName("GetProjectMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceAddProjectMemberHandler := connect.NewUnaryHandler(
+	projectServiceAddProjectMemberHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceAddProjectMemberProcedure,
 		svc.AddProjectMember,
 		connect.WithSchema(projectServiceMethods.ByName("AddProjectMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceUpdateProjectMemberRoleHandler := connect.NewUnaryHandler(
+	projectServiceUpdateProjectMemberRoleHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceUpdateProjectMemberRoleProcedure,
 		svc.UpdateProjectMemberRole,
 		connect.WithSchema(projectServiceMethods.ByName("UpdateProjectMemberRole")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceRemoveProjectMemberHandler := connect.NewUnaryHandler(
+	projectServiceRemoveProjectMemberHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceRemoveProjectMemberProcedure,
 		svc.RemoveProjectMember,
 		connect.WithSchema(projectServiceMethods.ByName("RemoveProjectMember")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceGetProjectLimitsHandler := connect.NewUnaryHandler(
+	projectServiceGetProjectLimitsHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceGetProjectLimitsProcedure,
 		svc.GetProjectLimits,
 		connect.WithSchema(projectServiceMethods.ByName("GetProjectLimits")),
 		connect.WithHandlerOptions(opts...),
 	)
-	projectServiceUpdateProjectLimitsHandler := connect.NewUnaryHandler(
+	projectServiceUpdateProjectLimitsHandler := connect.NewUnaryHandlerSimple(
 		ProjectServiceUpdateProjectLimitsProcedure,
 		svc.UpdateProjectLimits,
 		connect.WithSchema(projectServiceMethods.ByName("UpdateProjectLimits")),
@@ -430,54 +482,54 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 // UnimplementedProjectServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedProjectServiceHandler struct{}
 
-func (UnimplementedProjectServiceHandler) ListProjects(context.Context, *connect.Request[v1.ListProjectsRequest]) (*connect.Response[v1.ListProjectsResponse], error) {
+func (UnimplementedProjectServiceHandler) ListProjects(context.Context, *v1.ListProjectsRequest) (*v1.ListProjectsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.ListProjects is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) GetProject(context.Context, *connect.Request[v1.GetProjectRequest]) (*connect.Response[v1.GetProjectResponse], error) {
+func (UnimplementedProjectServiceHandler) GetProject(context.Context, *v1.GetProjectRequest) (*v1.GetProjectResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.GetProject is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) GetProjectByName(context.Context, *connect.Request[v1.GetProjectByNameRequest]) (*connect.Response[v1.GetProjectResponse], error) {
+func (UnimplementedProjectServiceHandler) GetProjectByName(context.Context, *v1.GetProjectByNameRequest) (*v1.GetProjectResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.GetProjectByName is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) CreateProject(context.Context, *connect.Request[v1.CreateProjectRequest]) (*connect.Response[v1.CreateProjectResponse], error) {
+func (UnimplementedProjectServiceHandler) CreateProject(context.Context, *v1.CreateProjectRequest) (*v1.CreateProjectResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.CreateProject is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) UpdateProject(context.Context, *connect.Request[v1.UpdateProjectRequest]) (*connect.Response[v1.UpdateProjectResponse], error) {
+func (UnimplementedProjectServiceHandler) UpdateProject(context.Context, *v1.UpdateProjectRequest) (*v1.UpdateProjectResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.UpdateProject is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) DeleteProject(context.Context, *connect.Request[v1.DeleteProjectRequest]) (*connect.Response[v1.DeleteProjectResponse], error) {
+func (UnimplementedProjectServiceHandler) DeleteProject(context.Context, *v1.DeleteProjectRequest) (*v1.DeleteProjectResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.DeleteProject is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) ListProjectMembers(context.Context, *connect.Request[v1.ListProjectMembersRequest]) (*connect.Response[v1.ListProjectMembersResponse], error) {
+func (UnimplementedProjectServiceHandler) ListProjectMembers(context.Context, *v1.ListProjectMembersRequest) (*v1.ListProjectMembersResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.ListProjectMembers is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) GetProjectMember(context.Context, *connect.Request[v1.GetProjectMemberRequest]) (*connect.Response[v1.GetProjectMemberResponse], error) {
+func (UnimplementedProjectServiceHandler) GetProjectMember(context.Context, *v1.GetProjectMemberRequest) (*v1.GetProjectMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.GetProjectMember is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) AddProjectMember(context.Context, *connect.Request[v1.AddProjectMemberRequest]) (*connect.Response[v1.AddProjectMemberResponse], error) {
+func (UnimplementedProjectServiceHandler) AddProjectMember(context.Context, *v1.AddProjectMemberRequest) (*v1.AddProjectMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.AddProjectMember is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) UpdateProjectMemberRole(context.Context, *connect.Request[v1.UpdateProjectMemberRoleRequest]) (*connect.Response[v1.UpdateProjectMemberRoleResponse], error) {
+func (UnimplementedProjectServiceHandler) UpdateProjectMemberRole(context.Context, *v1.UpdateProjectMemberRoleRequest) (*v1.UpdateProjectMemberRoleResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.UpdateProjectMemberRole is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) RemoveProjectMember(context.Context, *connect.Request[v1.RemoveProjectMemberRequest]) (*connect.Response[v1.RemoveProjectMemberResponse], error) {
+func (UnimplementedProjectServiceHandler) RemoveProjectMember(context.Context, *v1.RemoveProjectMemberRequest) (*v1.RemoveProjectMemberResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.RemoveProjectMember is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) GetProjectLimits(context.Context, *connect.Request[v1.GetProjectLimitsRequest]) (*connect.Response[v1.GetProjectLimitsResponse], error) {
+func (UnimplementedProjectServiceHandler) GetProjectLimits(context.Context, *v1.GetProjectLimitsRequest) (*v1.GetProjectLimitsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.GetProjectLimits is not implemented"))
 }
 
-func (UnimplementedProjectServiceHandler) UpdateProjectLimits(context.Context, *connect.Request[v1.UpdateProjectLimitsRequest]) (*connect.Response[v1.UpdateProjectLimitsResponse], error) {
+func (UnimplementedProjectServiceHandler) UpdateProjectLimits(context.Context, *v1.UpdateProjectLimitsRequest) (*v1.UpdateProjectLimitsResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("organization.v1.ProjectService.UpdateProjectLimits is not implemented"))
 }

--- a/plugin-controller/pkg/controller/reconciler.go
+++ b/plugin-controller/pkg/controller/reconciler.go
@@ -245,7 +245,7 @@ func (r *Reconciler) requestPluginUninstall(ctx context.Context, log *slog.Logge
 	url := pluginServiceURL(cr.Name)
 	rpcClient := pluginmetadatav1connect.NewPluginMetadataServiceClient(r.uninstallHTTPClient, url)
 
-	_, err := rpcClient.RequestUninstall(ctx, connect.NewRequest(&pluginmetadatav1.RequestUninstallRequest{}))
+	_, err := rpcClient.RequestUninstall(ctx, &pluginmetadatav1.RequestUninstallRequest{})
 	if err != nil {
 		// If the plugin is unreachable, proceed with cleanup
 		if connect.CodeOf(err) == connect.CodeUnavailable || connect.CodeOf(err) == connect.CodeUnimplemented {

--- a/plugin-controller/pkg/controller/reconciler_test.go
+++ b/plugin-controller/pkg/controller/reconciler_test.go
@@ -726,7 +726,7 @@ func TestPluginServiceURL(t *testing.T) {
 // stub every method. Unset handlers fall through to the connect-provided
 // "unimplemented" default.
 type mockPluginHandlers struct {
-	requestUninstall func(context.Context, *connect.Request[pb.RequestUninstallRequest]) (*connect.Response[pb.RequestUninstallResponse], error)
+	requestUninstall func(context.Context, *pb.RequestUninstallRequest) (*pb.RequestUninstallResponse, error)
 }
 
 // startMockPluginServer boots an HTTP server that speaks the
@@ -757,7 +757,7 @@ type mockPluginHandler struct {
 	handlers mockPluginHandlers
 }
 
-func (m *mockPluginHandler) RequestUninstall(ctx context.Context, req *connect.Request[pb.RequestUninstallRequest]) (*connect.Response[pb.RequestUninstallResponse], error) {
+func (m *mockPluginHandler) RequestUninstall(ctx context.Context, req *pb.RequestUninstallRequest) (*pb.RequestUninstallResponse, error) {
 	if m.handlers.requestUninstall == nil {
 		return m.UnimplementedPluginMetadataServiceHandler.RequestUninstall(ctx, req)
 	}
@@ -787,9 +787,9 @@ func TestHandleDeletion_CallsUninstall(t *testing.T) {
 
 	uninstallCalled := false
 	httpClient, baseURL := startMockPluginServer(t, mockPluginHandlers{
-		requestUninstall: func(_ context.Context, _ *connect.Request[pb.RequestUninstallRequest]) (*connect.Response[pb.RequestUninstallResponse], error) {
+		requestUninstall: func(_ context.Context, _ *pb.RequestUninstallRequest) (*pb.RequestUninstallResponse, error) {
 			uninstallCalled = true
-			return connect.NewResponse(&pb.RequestUninstallResponse{}), nil
+			return &pb.RequestUninstallResponse{}, nil
 		},
 	})
 
@@ -809,7 +809,7 @@ func TestHandleDeletion_CallsUninstall(t *testing.T) {
 	// We need to call requestPluginUninstall directly since handleDeletion
 	// builds the URL from the CR's pluginName which won't match our server.
 	rpcClient := pluginmetadatav1connect.NewPluginMetadataServiceClient(httpClient, baseURL)
-	_, err := rpcClient.RequestUninstall(context.Background(), connect.NewRequest(&pb.RequestUninstallRequest{}))
+	_, err := rpcClient.RequestUninstall(context.Background(), &pb.RequestUninstallRequest{})
 	require.NoError(t, err)
 	assert.True(t, uninstallCalled, "uninstall RPC should have been called")
 
@@ -859,7 +859,7 @@ func TestHandleDeletion_UninstallError_Requeues(t *testing.T) {
 	cr, ns := deletionTestCR(t)
 
 	httpClient, baseURL := startMockPluginServer(t, mockPluginHandlers{
-		requestUninstall: func(_ context.Context, _ *connect.Request[pb.RequestUninstallRequest]) (*connect.Response[pb.RequestUninstallResponse], error) {
+		requestUninstall: func(_ context.Context, _ *pb.RequestUninstallRequest) (*pb.RequestUninstallResponse, error) {
 			return nil, connect.NewError(connect.CodeInternal, errors.New("helm uninstall failed"))
 		},
 	})

--- a/plugin-controller/pkg/controller/status.go
+++ b/plugin-controller/pkg/controller/status.go
@@ -37,7 +37,7 @@ func (s *statusPoller) poll(ctx context.Context, cr *pluginsv1.PluginInstallatio
 	url := pluginServiceURL(cr.Name)
 	client := pluginmetadatav1connect.NewPluginMetadataServiceClient(s.httpClient, url)
 
-	resp, err := client.GetStatus(ctx, connect.NewRequest(&pluginmetadatav1.GetStatusRequest{}))
+	resp, err := client.GetStatus(ctx, &pluginmetadatav1.GetStatusRequest{})
 	if err != nil {
 		return pluginsv1.PluginInstallationStatus{
 			Phase:              pluginsv1.PluginPhaseDeploying,
@@ -46,7 +46,7 @@ func (s *statusPoller) poll(ctx context.Context, cr *pluginsv1.PluginInstallatio
 		}
 	}
 
-	phase, err := mapPhase(resp.Msg.GetPhase())
+	phase, err := mapPhase(resp.GetPhase())
 	if err != nil {
 		return pluginsv1.PluginInstallationStatus{
 			Phase:              pluginsv1.PluginPhaseDegraded,
@@ -57,7 +57,7 @@ func (s *statusPoller) poll(ctx context.Context, cr *pluginsv1.PluginInstallatio
 
 	return pluginsv1.PluginInstallationStatus{
 		Phase:              phase,
-		Message:            resp.Msg.GetMessage(),
+		Message:            resp.GetMessage(),
 		Ready:              phase == pluginsv1.PluginPhaseRunning,
 		ObservedGeneration: cr.Generation,
 	}

--- a/plugin-controller/pkg/defclient/defclient.go
+++ b/plugin-controller/pkg/defclient/defclient.go
@@ -31,11 +31,11 @@ func New(baseURL string, httpClient connect.HTTPClient) Client {
 }
 
 func (c *connectClient) GetDefinition(ctx context.Context, pluginName, pluginVersion string) (Definition, error) {
-	resp, err := c.rpc.GetPluginDefinition(ctx, connect.NewRequest(organizationv1.GetPluginDefinitionRequest_builder{
+	resp, err := c.rpc.GetPluginDefinition(ctx, organizationv1.GetPluginDefinitionRequest_builder{
 		PluginName: pluginName, PluginVersion: pluginVersion,
-	}.Build()))
+	}.Build())
 	if err != nil {
 		return Definition{}, fmt.Errorf("GetPluginDefinition RPC: %w", err)
 	}
-	return Definition{Manifest: resp.Msg.GetManifest(), Hash: resp.Msg.GetHash()}, nil
+	return Definition{Manifest: resp.GetManifest(), Hash: resp.GetHash()}, nil
 }

--- a/plugin-controller/pkg/defclient/defclient_test.go
+++ b/plugin-controller/pkg/defclient/defclient_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,10 +18,10 @@ type stubPlugin struct {
 	organizationv1connect.UnimplementedPluginServiceHandler
 }
 
-func (stubPlugin) GetPluginDefinition(_ context.Context, req *connect.Request[organizationv1.GetPluginDefinitionRequest]) (*connect.Response[organizationv1.GetPluginDefinitionResponse], error) {
-	return connect.NewResponse(organizationv1.GetPluginDefinitionResponse_builder{
+func (stubPlugin) GetPluginDefinition(_ context.Context, _ *organizationv1.GetPluginDefinitionRequest) (*organizationv1.GetPluginDefinitionResponse, error) {
+	return organizationv1.GetPluginDefinitionResponse_builder{
 		Manifest: []byte("manifest-bytes"), Hash: "sha256:abc",
-	}.Build()), nil
+	}.Build(), nil
 }
 
 func TestGetDefinition(t *testing.T) {

--- a/plugin-proxy/pkg/proto/buf.gen.yaml
+++ b/plugin-proxy/pkg/proto/buf.gen.yaml
@@ -5,4 +5,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple

--- a/plugin-proxy/pkg/proto/gen/plugin_proxy/v1/pluginproxyv1connect/plugin_proxy.connect.go
+++ b/plugin-proxy/pkg/proto/gen/plugin_proxy/v1/pluginproxyv1connect/plugin_proxy.connect.go
@@ -45,7 +45,7 @@ type PluginInstallationServiceClient interface {
 	// GetInstallationManifest resolves a PluginInstallation's identity by
 	// (cluster_id, installation_id). A missing installation is signalled with a
 	// NotFound error.
-	GetInstallationManifest(context.Context, *connect.Request[v1.GetInstallationManifestRequest]) (*connect.Response[v1.GetInstallationManifestResponse], error)
+	GetInstallationManifest(context.Context, *v1.GetInstallationManifestRequest) (*v1.GetInstallationManifestResponse, error)
 }
 
 // NewPluginInstallationServiceClient constructs a client for the
@@ -74,8 +74,12 @@ type pluginInstallationServiceClient struct {
 }
 
 // GetInstallationManifest calls plugin_proxy.v1.PluginInstallationService.GetInstallationManifest.
-func (c *pluginInstallationServiceClient) GetInstallationManifest(ctx context.Context, req *connect.Request[v1.GetInstallationManifestRequest]) (*connect.Response[v1.GetInstallationManifestResponse], error) {
-	return c.getInstallationManifest.CallUnary(ctx, req)
+func (c *pluginInstallationServiceClient) GetInstallationManifest(ctx context.Context, req *v1.GetInstallationManifestRequest) (*v1.GetInstallationManifestResponse, error) {
+	response, err := c.getInstallationManifest.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PluginInstallationServiceHandler is an implementation of the
@@ -84,7 +88,7 @@ type PluginInstallationServiceHandler interface {
 	// GetInstallationManifest resolves a PluginInstallation's identity by
 	// (cluster_id, installation_id). A missing installation is signalled with a
 	// NotFound error.
-	GetInstallationManifest(context.Context, *connect.Request[v1.GetInstallationManifestRequest]) (*connect.Response[v1.GetInstallationManifestResponse], error)
+	GetInstallationManifest(context.Context, *v1.GetInstallationManifestRequest) (*v1.GetInstallationManifestResponse, error)
 }
 
 // NewPluginInstallationServiceHandler builds an HTTP handler from the service implementation. It
@@ -94,7 +98,7 @@ type PluginInstallationServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPluginInstallationServiceHandler(svc PluginInstallationServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	pluginInstallationServiceMethods := v1.File_plugin_proxy_v1_plugin_proxy_proto.Services().ByName("PluginInstallationService").Methods()
-	pluginInstallationServiceGetInstallationManifestHandler := connect.NewUnaryHandler(
+	pluginInstallationServiceGetInstallationManifestHandler := connect.NewUnaryHandlerSimple(
 		PluginInstallationServiceGetInstallationManifestProcedure,
 		svc.GetInstallationManifest,
 		connect.WithSchema(pluginInstallationServiceMethods.ByName("GetInstallationManifest")),
@@ -113,6 +117,6 @@ func NewPluginInstallationServiceHandler(svc PluginInstallationServiceHandler, o
 // UnimplementedPluginInstallationServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPluginInstallationServiceHandler struct{}
 
-func (UnimplementedPluginInstallationServiceHandler) GetInstallationManifest(context.Context, *connect.Request[v1.GetInstallationManifestRequest]) (*connect.Response[v1.GetInstallationManifestResponse], error) {
+func (UnimplementedPluginInstallationServiceHandler) GetInstallationManifest(context.Context, *v1.GetInstallationManifestRequest) (*v1.GetInstallationManifestResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("plugin_proxy.v1.PluginInstallationService.GetInstallationManifest is not implemented"))
 }

--- a/plugin-proxy/pkg/service/service.go
+++ b/plugin-proxy/pkg/service/service.go
@@ -51,10 +51,10 @@ func New(logger *slog.Logger, cluster ClusterAccess) *Service {
 // tokens are also used to read state during teardown.
 func (s *Service) GetInstallationManifest(
 	ctx context.Context,
-	req *connect.Request[pluginproxyv1.GetInstallationManifestRequest],
-) (*connect.Response[pluginproxyv1.GetInstallationManifestResponse], error) {
-	clusterID := uuid.MustParse(req.Msg.GetClusterId())
-	installationID := uuid.MustParse(req.Msg.GetInstallationId())
+	req *pluginproxyv1.GetInstallationManifestRequest,
+) (*pluginproxyv1.GetInstallationManifestResponse, error) {
+	clusterID := uuid.MustParse(req.GetClusterId())
+	installationID := uuid.MustParse(req.GetInstallationId())
 
 	target, err := s.Cluster.ForCluster(ctx, clusterID)
 	if err != nil {
@@ -76,15 +76,14 @@ func (s *Service) GetInstallationManifest(
 		"phase", phase,
 	)
 
-	resp := pluginproxyv1.GetInstallationManifestResponse_builder{
+	return pluginproxyv1.GetInstallationManifestResponse_builder{
 		PluginName:       found.Spec.DefinitionRef.PluginName,
 		PluginVersion:    found.Spec.DefinitionRef.PluginVersion,
 		DefinitionHash:   found.Spec.DefinitionRef.DefinitionHash,
 		OrganizationId:   target.OrganizationID.String(),
 		Status:           phase,
 		InstallationName: found.Name,
-	}.Build()
-	return connect.NewResponse(resp), nil
+	}.Build(), nil
 }
 
 // findInstallation locates a PluginInstallation by UID. A missing

--- a/plugin-proxy/pkg/service/service_test.go
+++ b/plugin-proxy/pkg/service/service_test.go
@@ -70,19 +70,18 @@ func TestGetInstallationManifest_ReturnsIdentity(t *testing.T) {
 	svc := testService(c)
 
 	resp, err := svc.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      MockClusterID.String(),
 			InstallationId: MockInstallationID.String(),
-		}.Build()))
+		}.Build())
 	require.NoError(t, err, "GetInstallationManifest")
 
-	msg := resp.Msg
-	assert.Equal(t, MockPluginName, msg.GetPluginName())
-	assert.Equal(t, MockPluginVersion, msg.GetPluginVersion())
-	assert.Equal(t, MockPluginHash, msg.GetDefinitionHash())
-	assert.Equal(t, MockOrganizationID.String(), msg.GetOrganizationId())
-	assert.Equal(t, "Running", msg.GetStatus())
-	assert.Equal(t, MockPluginName, msg.GetInstallationName(), "installation name is the CR metadata.name")
+	assert.Equal(t, MockPluginName, resp.GetPluginName())
+	assert.Equal(t, MockPluginVersion, resp.GetPluginVersion())
+	assert.Equal(t, MockPluginHash, resp.GetDefinitionHash())
+	assert.Equal(t, MockOrganizationID.String(), resp.GetOrganizationId())
+	assert.Equal(t, "Running", resp.GetStatus())
+	assert.Equal(t, MockPluginName, resp.GetInstallationName(), "installation name is the CR metadata.name")
 }
 
 // Mints keep working through teardown so plugin tokens can read state during
@@ -97,12 +96,12 @@ func TestGetInstallationManifest_DeletingReturnsManifest(t *testing.T) {
 	svc := testService(c)
 
 	resp, err := svc.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      MockClusterID.String(),
 			InstallationId: MockInstallationID.String(),
-		}.Build()))
+		}.Build())
 	require.NoError(t, err, "GetInstallationManifest")
-	assert.Equal(t, MockPluginName, resp.Msg.GetPluginName())
+	assert.Equal(t, MockPluginName, resp.GetPluginName())
 }
 
 func TestGetInstallationManifest_TerminatingPhaseReturnsManifest(t *testing.T) {
@@ -112,12 +111,12 @@ func TestGetInstallationManifest_TerminatingPhaseReturnsManifest(t *testing.T) {
 	svc := testService(c)
 
 	resp, err := svc.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      MockClusterID.String(),
 			InstallationId: MockInstallationID.String(),
-		}.Build()))
+		}.Build())
 	require.NoError(t, err, "GetInstallationManifest")
-	assert.Equal(t, string(pluginsv1.PluginPhaseTerminating), resp.Msg.GetStatus())
+	assert.Equal(t, string(pluginsv1.PluginPhaseTerminating), resp.GetStatus())
 }
 
 // Protovalidate rejects non-UUID inputs at the interceptor; without this
@@ -135,10 +134,10 @@ func TestGetInstallationManifest_MalformedUUID_InvalidArgument(t *testing.T) {
 
 	rpcClient := pluginproxyv1connect.NewPluginInstallationServiceClient(srv.Client(), srv.URL)
 	_, err := rpcClient.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      "not-a-uuid",
 			InstallationId: MockInstallationID.String(),
-		}.Build()))
+		}.Build())
 	require.Error(t, err, "expected error for malformed cluster_id")
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -148,10 +147,10 @@ func TestGetInstallationManifest_NotFound(t *testing.T) {
 	svc := testService(c)
 
 	_, err := svc.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      MockClusterID.String(),
 			InstallationId: "11111111-0000-0000-0000-000000000000",
-		}.Build()))
+		}.Build())
 	require.Error(t, err, "expected error for missing CR")
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
@@ -159,10 +158,10 @@ func TestGetInstallationManifest_NotFound(t *testing.T) {
 func TestMockClusterAccess_UnknownClusterUnavailable(t *testing.T) {
 	svc := service(t)
 	_, err := svc.GetInstallationManifest(context.Background(),
-		connect.NewRequest(pluginproxyv1.GetInstallationManifestRequest_builder{
+		pluginproxyv1.GetInstallationManifestRequest_builder{
 			ClusterId:      "00000000-0000-0000-0000-0000000000ff",
 			InstallationId: MockInstallationID.String(),
-		}.Build()))
+		}.Build())
 	require.Error(t, err, "expected error for unknown cluster")
 	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 }

--- a/plugin-sdk/pluginruntime/metadata/proto/buf.gen.yaml
+++ b/plugin-sdk/pluginruntime/metadata/proto/buf.gen.yaml
@@ -5,4 +5,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple

--- a/plugin-sdk/pluginruntime/metadata/proto/gen/v1/pluginmetadatav1connect/metadata.connect.go
+++ b/plugin-sdk/pluginruntime/metadata/proto/gen/v1/pluginmetadatav1connect/metadata.connect.go
@@ -43,8 +43,8 @@ const (
 
 // PluginMetadataServiceClient is a client for the pluginmetadata.v1.PluginMetadataService service.
 type PluginMetadataServiceClient interface {
-	GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error)
-	RequestUninstall(context.Context, *connect.Request[v1.RequestUninstallRequest]) (*connect.Response[v1.RequestUninstallResponse], error)
+	GetStatus(context.Context, *v1.GetStatusRequest) (*v1.GetStatusResponse, error)
+	RequestUninstall(context.Context, *v1.RequestUninstallRequest) (*v1.RequestUninstallResponse, error)
 }
 
 // NewPluginMetadataServiceClient constructs a client for the
@@ -80,20 +80,28 @@ type pluginMetadataServiceClient struct {
 }
 
 // GetStatus calls pluginmetadata.v1.PluginMetadataService.GetStatus.
-func (c *pluginMetadataServiceClient) GetStatus(ctx context.Context, req *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error) {
-	return c.getStatus.CallUnary(ctx, req)
+func (c *pluginMetadataServiceClient) GetStatus(ctx context.Context, req *v1.GetStatusRequest) (*v1.GetStatusResponse, error) {
+	response, err := c.getStatus.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // RequestUninstall calls pluginmetadata.v1.PluginMetadataService.RequestUninstall.
-func (c *pluginMetadataServiceClient) RequestUninstall(ctx context.Context, req *connect.Request[v1.RequestUninstallRequest]) (*connect.Response[v1.RequestUninstallResponse], error) {
-	return c.requestUninstall.CallUnary(ctx, req)
+func (c *pluginMetadataServiceClient) RequestUninstall(ctx context.Context, req *v1.RequestUninstallRequest) (*v1.RequestUninstallResponse, error) {
+	response, err := c.requestUninstall.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // PluginMetadataServiceHandler is an implementation of the pluginmetadata.v1.PluginMetadataService
 // service.
 type PluginMetadataServiceHandler interface {
-	GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error)
-	RequestUninstall(context.Context, *connect.Request[v1.RequestUninstallRequest]) (*connect.Response[v1.RequestUninstallResponse], error)
+	GetStatus(context.Context, *v1.GetStatusRequest) (*v1.GetStatusResponse, error)
+	RequestUninstall(context.Context, *v1.RequestUninstallRequest) (*v1.RequestUninstallResponse, error)
 }
 
 // NewPluginMetadataServiceHandler builds an HTTP handler from the service implementation. It
@@ -103,13 +111,13 @@ type PluginMetadataServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPluginMetadataServiceHandler(svc PluginMetadataServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	pluginMetadataServiceMethods := v1.File_v1_metadata_proto.Services().ByName("PluginMetadataService").Methods()
-	pluginMetadataServiceGetStatusHandler := connect.NewUnaryHandler(
+	pluginMetadataServiceGetStatusHandler := connect.NewUnaryHandlerSimple(
 		PluginMetadataServiceGetStatusProcedure,
 		svc.GetStatus,
 		connect.WithSchema(pluginMetadataServiceMethods.ByName("GetStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pluginMetadataServiceRequestUninstallHandler := connect.NewUnaryHandler(
+	pluginMetadataServiceRequestUninstallHandler := connect.NewUnaryHandlerSimple(
 		PluginMetadataServiceRequestUninstallProcedure,
 		svc.RequestUninstall,
 		connect.WithSchema(pluginMetadataServiceMethods.ByName("RequestUninstall")),
@@ -130,10 +138,10 @@ func NewPluginMetadataServiceHandler(svc PluginMetadataServiceHandler, opts ...c
 // UnimplementedPluginMetadataServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPluginMetadataServiceHandler struct{}
 
-func (UnimplementedPluginMetadataServiceHandler) GetStatus(context.Context, *connect.Request[v1.GetStatusRequest]) (*connect.Response[v1.GetStatusResponse], error) {
+func (UnimplementedPluginMetadataServiceHandler) GetStatus(context.Context, *v1.GetStatusRequest) (*v1.GetStatusResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pluginmetadata.v1.PluginMetadataService.GetStatus is not implemented"))
 }
 
-func (UnimplementedPluginMetadataServiceHandler) RequestUninstall(context.Context, *connect.Request[v1.RequestUninstallRequest]) (*connect.Response[v1.RequestUninstallResponse], error) {
+func (UnimplementedPluginMetadataServiceHandler) RequestUninstall(context.Context, *v1.RequestUninstallRequest) (*v1.RequestUninstallResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pluginmetadata.v1.PluginMetadataService.RequestUninstall is not implemented"))
 }

--- a/plugin-sdk/pluginruntime/metadata_handler.go
+++ b/plugin-sdk/pluginruntime/metadata_handler.go
@@ -28,17 +28,17 @@ func NewMetadataHandler(statusFn func() PluginStatus, uninstallFn func(context.C
 	}
 }
 
-func (h *metadataHandler) GetStatus(_ context.Context, _ *connect.Request[pb.GetStatusRequest]) (*connect.Response[pb.GetStatusResponse], error) {
+func (h *metadataHandler) GetStatus(_ context.Context, _ *pb.GetStatusRequest) (*pb.GetStatusResponse, error) {
 	status := h.getStatus()
-	return connect.NewResponse(&pb.GetStatusResponse{
+	return &pb.GetStatusResponse{
 		Phase:   ptr(string(status.Phase)),
 		Message: ptr(status.Message),
-	}), nil
+	}, nil
 }
 
-func (h *metadataHandler) RequestUninstall(ctx context.Context, _ *connect.Request[pb.RequestUninstallRequest]) (*connect.Response[pb.RequestUninstallResponse], error) {
+func (h *metadataHandler) RequestUninstall(ctx context.Context, _ *pb.RequestUninstallRequest) (*pb.RequestUninstallResponse, error) {
 	if err := h.uninstall(ctx); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(&pb.RequestUninstallResponse{}), nil
+	return &pb.RequestUninstallResponse{}, nil
 }

--- a/plugin-sdk/pluginruntime/testing/harness_test.go
+++ b/plugin-sdk/pluginruntime/testing/harness_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -60,9 +59,9 @@ func TestRunInProcess(t *testing.T) {
 	}
 
 	// Test GetStatus
-	statusResp, err := ip.MetadataClient.GetStatus(context.Background(), connect.NewRequest(&pb.GetStatusRequest{}))
+	statusResp, err := ip.MetadataClient.GetStatus(context.Background(), &pb.GetStatusRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, string(pluginruntime.PhaseRunning), statusResp.Msg.GetPhase())
+	assert.Equal(t, string(pluginruntime.PhaseRunning), statusResp.GetPhase())
 
 	// Stop
 	require.NoError(t, ip.Stop())

--- a/plugins/cmd/plugin-publish/main.go
+++ b/plugins/cmd/plugin-publish/main.go
@@ -74,26 +74,26 @@ func injectImage(src []byte, image, pullPolicy string) ([]byte, error) {
 	return out, nil
 }
 
-// withAuth attaches the bearer token (FUNDAMENT_TOKEN) and organization context
-// to a Connect request. Every authenticated PluginService call needs these —
-// ListPlugins as much as PutPluginDefinition.
-func withAuth(req interface{ Header() http.Header }, orgID string) {
+// withAuth returns a context that attaches the bearer token (FUNDAMENT_TOKEN)
+// and organization context to the next Connect call. Every authenticated
+// PluginService call needs these — ListPlugins as much as PutPluginDefinition.
+// Call it once per request; the returned context carries call-specific state.
+func withAuth(ctx context.Context, orgID string) context.Context {
+	ctx, callInfo := connect.NewClientContext(ctx)
 	if tok := os.Getenv("FUNDAMENT_TOKEN"); tok != "" {
-		req.Header().Set("Authorization", "Bearer "+tok)
+		callInfo.RequestHeader().Set("Authorization", "Bearer "+tok)
 	}
-	req.Header().Set("Fun-Organization", orgID)
+	callInfo.RequestHeader().Set("Fun-Organization", orgID)
+	return ctx
 }
 
 // resolvePluginID looks up the catalog plugin id by name via ListPlugins.
 func resolvePluginID(ctx context.Context, client organizationv1connect.PluginServiceClient, name, orgID string) (string, error) {
-	req := connect.NewRequest(organizationv1.ListPluginsRequest_builder{}.Build())
-	withAuth(req, orgID)
-
-	resp, err := client.ListPlugins(ctx, req)
+	resp, err := client.ListPlugins(withAuth(ctx, orgID), organizationv1.ListPluginsRequest_builder{}.Build())
 	if err != nil {
 		return "", fmt.Errorf("list plugins: %w", err)
 	}
-	for _, p := range resp.Msg.GetPlugins() {
+	for _, p := range resp.GetPlugins() {
 		if p.GetName() == name {
 			return p.GetId(), nil
 		}
@@ -157,21 +157,17 @@ func main() {
 		}
 	}
 
-	req := connect.NewRequest(organizationv1.PutPluginDefinitionRequest_builder{
+	resp, err := client.PutPluginDefinition(withAuth(ctx, orgID), organizationv1.PutPluginDefinitionRequest_builder{
 		PluginId:      pluginID,
 		PluginVersion: def.Metadata.Version,
 		Manifest:      published,
 		Replace:       replace,
 	}.Build())
-
-	withAuth(req, orgID)
-
-	resp, err := client.PutPluginDefinition(ctx, req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "publish failed: %v\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Printf("published plugin=%s version=%s hash=%s id=%s definition_id=%s\n",
-		def.Metadata.Name, resp.Msg.GetPluginVersion(), resp.Msg.GetHash(), resp.Msg.GetPluginId(), resp.Msg.GetId())
+		def.Metadata.Name, resp.GetPluginVersion(), resp.GetHash(), resp.GetPluginId(), resp.GetId())
 }

--- a/terraform-provider/internal/provider/cluster_data_source.go
+++ b/terraform-provider/internal/provider/cluster_data_source.go
@@ -108,9 +108,9 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		"name": config.Name.ValueString(),
 	})
 
-	getReq := connect.NewRequest(organizationv1.GetClusterByNameRequest_builder{
+	getReq := organizationv1.GetClusterByNameRequest_builder{
 		Name: config.Name.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := d.client.ClusterService.GetClusterByName(ctx, getReq)
 	if err != nil {
@@ -139,7 +139,7 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	cluster := getResp.Msg.GetCluster()
+	cluster := getResp.GetCluster()
 
 	// Map response to state
 	config.ID = types.StringValue(cluster.GetId())

--- a/terraform-provider/internal/provider/cluster_namespaces_data_source.go
+++ b/terraform-provider/internal/provider/cluster_namespaces_data_source.go
@@ -124,9 +124,9 @@ func (d *ClusterNamespacesDataSource) Read(ctx context.Context, req datasource.R
 		"cluster_id": clusterID,
 	})
 
-	rpcReq := connect.NewRequest(organizationv1.ListClusterNamespacesRequest_builder{
+	rpcReq := organizationv1.ListClusterNamespacesRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
+	}.Build()
 
 	// Call the API
 	rpcResp, err := d.client.NamespaceService.ListClusterNamespaces(ctx, rpcReq)
@@ -157,8 +157,8 @@ func (d *ClusterNamespacesDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	// Map response to state
-	state.Namespaces = make([]NamespaceModel, len(rpcResp.Msg.GetNamespaces()))
-	for i, ns := range rpcResp.Msg.GetNamespaces() {
+	state.Namespaces = make([]NamespaceModel, len(rpcResp.GetNamespaces()))
+	for i, ns := range rpcResp.GetNamespaces() {
 		state.Namespaces[i] = NamespaceModel{
 			ID:        types.StringValue(ns.GetId()),
 			Name:      types.StringValue(ns.GetName()),

--- a/terraform-provider/internal/provider/cluster_resource.go
+++ b/terraform-provider/internal/provider/cluster_resource.go
@@ -124,11 +124,11 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	})
 
 	// Create the cluster
-	createReq := connect.NewRequest(organizationv1.CreateClusterRequest_builder{
+	createReq := organizationv1.CreateClusterRequest_builder{
 		Name:              plan.Name.ValueString(),
 		Region:            plan.Region.ValueString(),
 		KubernetesVersion: plan.KubernetesVersion.ValueString(),
-	}.Build())
+	}.Build()
 
 	createResp, err := createIdempotent(ctx, r.client.ClusterService.CreateCluster, createReq)
 	if err != nil {
@@ -140,13 +140,13 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Set the ID from the response
-	plan.ID = types.StringValue(createResp.Msg.GetClusterId())
+	plan.ID = types.StringValue(createResp.GetClusterId())
 
 	// Read the cluster to get the full state including status.
 	// Retry on permission_denied, OpenFGA needs time to sync
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
-		ClusterId: createResp.Msg.GetClusterId(),
-	}.Build())
+	getReq := organizationv1.GetClusterRequest_builder{
+		ClusterId: createResp.GetClusterId(),
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetCluster(ctx, getReq)
 	if err != nil {
@@ -158,7 +158,7 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Map response to state
-	plan.Status = types.StringValue(clusterStatusToString(getResp.Msg.GetCluster().GetStatus()))
+	plan.Status = types.StringValue(clusterStatusToString(getResp.GetCluster().GetStatus()))
 
 	tflog.Info(ctx, "Created cluster", map[string]any{
 		"id":     plan.ID.ValueString(),
@@ -189,9 +189,9 @@ func (r *ClusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		"id": state.ID.ValueString(),
 	})
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetCluster(ctx, getReq)
 	if err != nil {
@@ -212,7 +212,7 @@ func (r *ClusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	cluster := getResp.Msg.GetCluster()
+	cluster := getResp.GetCluster()
 
 	// Map response to state
 	state.ID = types.StringValue(cluster.GetId())
@@ -256,10 +256,10 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Only kubernetes_version can be updated
 	kubernetesVersion := plan.KubernetesVersion.ValueString()
-	updateReq := connect.NewRequest(organizationv1.UpdateClusterRequest_builder{
+	updateReq := organizationv1.UpdateClusterRequest_builder{
 		ClusterId:         state.ID.ValueString(),
 		KubernetesVersion: &kubernetesVersion,
-	}.Build())
+	}.Build()
 
 	_, err := r.client.ClusterService.UpdateCluster(ctx, updateReq)
 	if err != nil {
@@ -290,9 +290,9 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Read the cluster to get the updated state.
 	// Retry on permission_denied, OpenFGA needs time to sync.
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetCluster(ctx, getReq)
 	if err != nil {
@@ -311,7 +311,7 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	cluster := getResp.Msg.GetCluster()
+	cluster := getResp.GetCluster()
 
 	// Update the plan with the server response
 	plan.ID = types.StringValue(cluster.GetId())
@@ -349,9 +349,9 @@ func (r *ClusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 		"id": state.ID.ValueString(),
 	})
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteClusterRequest_builder{
+	deleteReq := organizationv1.DeleteClusterRequest_builder{
 		ClusterId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.ClusterService.DeleteCluster(ctx, deleteReq)
 	if err != nil {

--- a/terraform-provider/internal/provider/cluster_wait.go
+++ b/terraform-provider/internal/provider/cluster_wait.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"connectrpc.com/connect"
 	organizationv1 "github.com/fundament-oss/fundament/organization-api/pkg/proto/gen/v1"
 )
 
@@ -20,16 +19,16 @@ func waitForClusterRunning(ctx context.Context, client *FundamentClient, cluster
 	lastStatus := organizationv1.ClusterStatus_CLUSTER_STATUS_UNSPECIFIED
 
 	err := pollWithBackoff(ctx, 10*time.Second, maxConsecutiveErrors, func(ctx context.Context) (done bool, fatal bool, err error) {
-		req := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+		req := organizationv1.GetClusterRequest_builder{
 			ClusterId: clusterID,
-		}.Build())
+		}.Build()
 
 		resp, err := client.ClusterService.GetCluster(ctx, req)
 		if err != nil {
 			return false, false, fmt.Errorf("polling cluster status: %w", err)
 		}
 
-		lastStatus = resp.Msg.GetCluster().GetStatus()
+		lastStatus = resp.GetCluster().GetStatus()
 		switch lastStatus {
 		case organizationv1.ClusterStatus_CLUSTER_STATUS_RUNNING:
 			return true, false, nil

--- a/terraform-provider/internal/provider/clusters_data_source.go
+++ b/terraform-provider/internal/provider/clusters_data_source.go
@@ -119,7 +119,7 @@ func (d *ClustersDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	tflog.Debug(ctx, "Fetching clusters")
 
-	rpcReq := connect.NewRequest(organizationv1.ListClustersRequest_builder{}.Build())
+	rpcReq := organizationv1.ListClustersRequest_builder{}.Build()
 
 	// Call the API
 	rpcResp, err := d.client.ClusterService.ListClusters(ctx, rpcReq)
@@ -150,8 +150,8 @@ func (d *ClustersDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	// Map response to state
-	state.Clusters = make([]ClusterModel, len(rpcResp.Msg.GetClusters()))
-	for i, cluster := range rpcResp.Msg.GetClusters() {
+	state.Clusters = make([]ClusterModel, len(rpcResp.GetClusters()))
+	for i, cluster := range rpcResp.GetClusters() {
 		state.Clusters[i] = ClusterModel{
 			ID:     types.StringValue(cluster.GetId()),
 			Name:   types.StringValue(cluster.GetName()),

--- a/terraform-provider/internal/provider/idempotent_create.go
+++ b/terraform-provider/internal/provider/idempotent_create.go
@@ -56,32 +56,34 @@ var errIdempotencyFailed = errors.New("server reported idempotent operation fail
 // resource reaches a terminal outbox state.
 func createIdempotent[Req, Resp any](
 	ctx context.Context,
-	call func(ctx context.Context, req *connect.Request[Req]) (*connect.Response[Resp], error),
-	req *connect.Request[Req],
-) (*connect.Response[Resp], error) {
+	call func(ctx context.Context, req *Req) (*Resp, error),
+	req *Req,
+) (*Resp, error) {
 	return createIdempotentWithClock(ctx, defaultClock, call, req)
 }
 
 func createIdempotentWithClock[Req, Resp any](
 	ctx context.Context,
 	clk clock,
-	call func(ctx context.Context, req *connect.Request[Req]) (*connect.Response[Resp], error),
-	req *connect.Request[Req],
-) (*connect.Response[Resp], error) {
+	call func(ctx context.Context, req *Req) (*Resp, error),
+	req *Req,
+) (*Resp, error) {
 	key := uuid.New().String()
-	req.Header().Set(idempotencyHeaderKey, key)
 
 	deadlineCtx, cancel := context.WithTimeout(ctx, idempotencyTotalBudget)
 	defer cancel()
 
 	backoff := idempotencyInitialBackoff
 	for {
-		resp, err := call(deadlineCtx, req)
+		callCtx, callInfo := connect.NewClientContext(deadlineCtx)
+		callInfo.RequestHeader().Set(idempotencyHeaderKey, key)
+
+		resp, err := call(callCtx, req)
 		if err != nil {
 			return nil, err
 		}
 
-		switch resp.Header().Get(idempotencyHeaderStatus) {
+		switch callInfo.ResponseHeader().Get(idempotencyHeaderStatus) {
 		case statusCompleted:
 			return resp, nil
 		case statusFailed:

--- a/terraform-provider/internal/provider/idempotent_create_test.go
+++ b/terraform-provider/internal/provider/idempotent_create_test.go
@@ -2,10 +2,17 @@ package provider
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authnv1 "github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1"
 )
 
 // fakeClock lets tests step time forward deterministically.
@@ -29,34 +36,61 @@ func (c *fakeClock) Sleep(ctx context.Context, d time.Duration) error {
 	return nil
 }
 
-// fakeReq is the unconstrained request message the helper accepts.
-type fakeReq struct{}
-type fakeResp struct{}
-
 // scriptedCall returns a pre-canned sequence of (status, err) pairs.
 type scriptStep struct {
 	status string // value to set in Idempotency-Status response header; "" means unset
 	err    error
 }
 
-func scriptedCall(t *testing.T, steps []scriptStep, gotKeys *[]string) func(context.Context, *connect.Request[fakeReq]) (*connect.Response[fakeResp], error) {
+const scriptedProcedure = "/test.v1.ScriptedService/Create"
+
+// scriptedCall serves the scripted steps from an in-process Connect server and
+// returns a plain client call with the same signature as generated clients, so
+// the idempotency headers travel through the real call-info plumbing. The
+// ExchangeToken message types are arbitrary: the wire needs some generated
+// proto, but only the headers matter here.
+func scriptedCall(t *testing.T, steps []scriptStep, gotKeys *[]string) func(context.Context, *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
 	t.Helper()
+	var mu sync.Mutex
 	i := 0
-	return func(ctx context.Context, req *connect.Request[fakeReq]) (*connect.Response[fakeResp], error) {
-		if i >= len(steps) {
-			t.Fatalf("call invoked %d times, only %d scripted", i+1, len(steps))
+	handler := connect.NewUnaryHandlerSimple(
+		scriptedProcedure,
+		func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if i >= len(steps) {
+				t.Errorf("call invoked %d times, only %d scripted", i+1, len(steps))
+				return nil, connect.NewError(connect.CodeInternal, errorString("call overran script"))
+			}
+			callInfo, ok := connect.CallInfoForHandlerContext(ctx)
+			if !ok {
+				t.Error("expected handler call info in context")
+				return nil, connect.NewError(connect.CodeInternal, errorString("no call info"))
+			}
+			*gotKeys = append(*gotKeys, callInfo.RequestHeader().Get(idempotencyHeaderKey))
+			step := steps[i]
+			i++
+			if step.err != nil {
+				return nil, step.err
+			}
+			if step.status != "" {
+				callInfo.ResponseHeader().Set(idempotencyHeaderStatus, step.status)
+			}
+			return &authnv1.ExchangeTokenResponse{}, nil
+		},
+	)
+	mux := http.NewServeMux()
+	mux.Handle(scriptedProcedure, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := connect.NewClient[authnv1.ExchangeTokenRequest, authnv1.ExchangeTokenResponse](srv.Client(), srv.URL+scriptedProcedure)
+	return func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+		resp, err := client.CallUnary(ctx, connect.NewRequest(req))
+		if resp != nil {
+			return resp.Msg, err //nolint:wrapcheck // tests assert on the raw connect error
 		}
-		*gotKeys = append(*gotKeys, req.Header().Get(idempotencyHeaderKey))
-		step := steps[i]
-		i++
-		if step.err != nil {
-			return nil, step.err
-		}
-		resp := connect.NewResponse(&fakeResp{})
-		if step.status != "" {
-			resp.Header().Set(idempotencyHeaderStatus, step.status)
-		}
-		return resp, nil
+		return nil, err //nolint:wrapcheck // tests assert on the raw connect error
 	}
 }
 
@@ -64,19 +98,11 @@ func TestCreateIdempotent_CompletedOnFirstCall(t *testing.T) {
 	var keys []string
 	call := scriptedCall(t, []scriptStep{{status: statusCompleted}}, &keys)
 
-	resp, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, connect.NewRequest(&fakeReq{}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil {
-		t.Fatal("expected response, got nil")
-	}
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 call, got %d", len(keys))
-	}
-	if keys[0] == "" {
-		t.Fatal("expected Idempotency-Key header to be set")
-	}
+	resp, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, &authnv1.ExchangeTokenRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, keys, 1)
+	assert.NotEmpty(t, keys[0], "expected Idempotency-Key header to be set")
 }
 
 func TestCreateIdempotent_ProcessingThenCompleted(t *testing.T) {
@@ -87,38 +113,22 @@ func TestCreateIdempotent_ProcessingThenCompleted(t *testing.T) {
 	}, &keys)
 
 	clk := newFakeClock()
-	resp, err := createIdempotentWithClock(context.Background(), clk, call, connect.NewRequest(&fakeReq{}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil {
-		t.Fatal("expected response, got nil")
-	}
-	if len(keys) != 2 {
-		t.Fatalf("expected 2 calls, got %d", len(keys))
-	}
-	if keys[0] != keys[1] {
-		t.Fatalf("expected same idempotency key on both calls, got %q and %q", keys[0], keys[1])
-	}
-	if len(clk.sleeps) != 1 || clk.sleeps[0] != idempotencyInitialBackoff {
-		t.Fatalf("expected one 100ms sleep, got %v", clk.sleeps)
-	}
+	resp, err := createIdempotentWithClock(context.Background(), clk, call, &authnv1.ExchangeTokenRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, keys, 2)
+	assert.Equal(t, keys[0], keys[1], "expected same idempotency key on both calls")
+	assert.Equal(t, []time.Duration{idempotencyInitialBackoff}, clk.sleeps, "expected one 100ms sleep")
 }
 
 func TestCreateIdempotent_FailedStatusReturnsError(t *testing.T) {
 	var keys []string
 	call := scriptedCall(t, []scriptStep{{status: statusFailed}}, &keys)
 
-	resp, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, connect.NewRequest(&fakeReq{}))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if resp != nil {
-		t.Fatal("expected nil response on failed status")
-	}
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 call, got %d", len(keys))
-	}
+	resp, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, &authnv1.ExchangeTokenRequest{})
+	require.Error(t, err)
+	assert.Nil(t, resp, "expected nil response on failed status")
+	assert.Len(t, keys, 1)
 }
 
 func TestCreateIdempotent_TransportErrorReturnsImmediately(t *testing.T) {
@@ -126,16 +136,10 @@ func TestCreateIdempotent_TransportErrorReturnsImmediately(t *testing.T) {
 	wantErr := connect.NewError(connect.CodePermissionDenied, errorString("no"))
 	call := scriptedCall(t, []scriptStep{{err: wantErr}}, &keys)
 
-	_, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, connect.NewRequest(&fakeReq{}))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("expected PermissionDenied, got %v", err)
-	}
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 call (no retries), got %d", len(keys))
-	}
+	_, err := createIdempotentWithClock(context.Background(), newFakeClock(), call, &authnv1.ExchangeTokenRequest{})
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	assert.Len(t, keys, 1, "expected 1 call (no retries)")
 }
 
 type errorString string
@@ -156,10 +160,8 @@ func TestCreateIdempotent_BackoffSchedule(t *testing.T) {
 	}
 	var keys []string
 	clk := newFakeClock()
-	_, err := createIdempotentWithClock(context.Background(), clk, scriptedCall(t, steps, &keys), connect.NewRequest(&fakeReq{}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	_, err := createIdempotentWithClock(context.Background(), clk, scriptedCall(t, steps, &keys), &authnv1.ExchangeTokenRequest{})
+	require.NoError(t, err)
 
 	want := []time.Duration{
 		100 * time.Millisecond,
@@ -169,14 +171,7 @@ func TestCreateIdempotent_BackoffSchedule(t *testing.T) {
 		1600 * time.Millisecond,
 		2 * time.Second,
 	}
-	if len(clk.sleeps) != len(want) {
-		t.Fatalf("expected %d sleeps, got %d (%v)", len(want), len(clk.sleeps), clk.sleeps)
-	}
-	for i, d := range want {
-		if clk.sleeps[i] != d {
-			t.Errorf("sleep[%d] = %v, want %v", i, clk.sleeps[i], d)
-		}
-	}
+	assert.Equal(t, want, clk.sleeps)
 }
 
 func TestCreateIdempotent_DeadlineExceeded(t *testing.T) {
@@ -190,11 +185,7 @@ func TestCreateIdempotent_DeadlineExceeded(t *testing.T) {
 	for i := range steps {
 		steps[i] = scriptStep{status: statusProcessing}
 	}
-	_, err := createIdempotent(ctx, scriptedCall(t, steps, &keys), connect.NewRequest(&fakeReq{}))
-	if err == nil {
-		t.Fatal("expected deadline error, got nil")
-	}
-	if ctx.Err() == nil {
-		t.Fatal("expected parent ctx to be done")
-	}
+	_, err := createIdempotent(ctx, scriptedCall(t, steps, &keys), &authnv1.ExchangeTokenRequest{})
+	require.Error(t, err, "expected deadline error")
+	require.Error(t, ctx.Err(), "expected parent ctx to be done")
 }

--- a/terraform-provider/internal/provider/main_test.go
+++ b/terraform-provider/internal/provider/main_test.go
@@ -89,9 +89,9 @@ func TestMain(m *testing.M) {
 
 	ready := false
 	for i := range maxRetries {
-		exchangeReq := connect.NewRequest(&authnv1.ExchangeTokenRequest{})
-		exchangeReq.Header().Set("Authorization", "Bearer "+apiKeyToken)
-		exchangeResp, err := tokenClient.ExchangeToken(ctx, exchangeReq)
+		exchangeCtx, exchangeCallInfo := connect.NewClientContext(ctx)
+		exchangeCallInfo.RequestHeader().Set("Authorization", "Bearer "+apiKeyToken)
+		exchangeResp, err := tokenClient.ExchangeToken(exchangeCtx, &authnv1.ExchangeTokenRequest{})
 		if err != nil {
 			code := connect.CodeOf(err)
 			// For a pre-set key, unauthenticated/internal means the key is
@@ -107,10 +107,10 @@ func TestMain(m *testing.M) {
 			continue
 		}
 
-		listReq := connect.NewRequest(&organizationv1.ListClustersRequest{})
-		listReq.Header().Set("Authorization", "Bearer "+exchangeResp.Msg.GetAccessToken())
-		listReq.Header().Set(organization.OrganizationHeader, orgID)
-		_, err = clusterClient.ListClusters(ctx, listReq)
+		listCtx, listCallInfo := connect.NewClientContext(ctx)
+		listCallInfo.RequestHeader().Set("Authorization", "Bearer "+exchangeResp.GetAccessToken())
+		listCallInfo.RequestHeader().Set(organization.OrganizationHeader, orgID)
+		_, err = clusterClient.ListClusters(listCtx, &organizationv1.ListClustersRequest{})
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodePermissionDenied {
 				fmt.Printf("TestMain: authz not ready yet, attempt %d/%d, retrying...\n", i+1, maxRetries)
@@ -140,12 +140,13 @@ func TestMain(m *testing.M) {
 			// Best-effort: a cleanup failure must not change the test exit code.
 			fmt.Fprintf(os.Stderr, "TestMain: failed to get cleanup JWT (best-effort): %v\n", err)
 		} else {
-			deleteReq := connect.NewRequest(organizationv1.DeleteAPIKeyRequest_builder{
+			deleteCtx, deleteCallInfo := connect.NewClientContext(ctx)
+			deleteCallInfo.RequestHeader().Set("Authorization", "Bearer "+cleanupLogin.accessToken)
+			deleteCallInfo.RequestHeader().Set(organization.OrganizationHeader, orgID)
+			deleteReq := organizationv1.DeleteAPIKeyRequest_builder{
 				ApiKeyId: apiKeyID,
-			}.Build())
-			deleteReq.Header().Set("Authorization", "Bearer "+cleanupLogin.accessToken)
-			deleteReq.Header().Set(organization.OrganizationHeader, orgID)
-			if _, err := apiKeyClient.DeleteAPIKey(ctx, deleteReq); err != nil {
+			}.Build()
+			if _, err := apiKeyClient.DeleteAPIKey(deleteCtx, deleteReq); err != nil {
 				fmt.Fprintf(os.Stderr, "TestMain: failed to delete API key (best-effort): %v\n", err)
 			}
 		}
@@ -163,13 +164,13 @@ func createDynamicAPIKey(ctx context.Context, endpoint, orgID, accessToken strin
 
 	fmt.Println("TestMain: creating dynamic test API key")
 	for i := range maxRetries {
-		createReq := connect.NewRequest(organizationv1.CreateAPIKeyRequest_builder{
+		createCtx, createCallInfo := connect.NewClientContext(ctx)
+		createCallInfo.RequestHeader().Set("Authorization", "Bearer "+accessToken)
+		createCallInfo.RequestHeader().Set(organization.OrganizationHeader, orgID)
+
+		createResp, err := apiKeyClient.CreateAPIKey(createCtx, organizationv1.CreateAPIKeyRequest_builder{
 			Name: "terraform-acc-test-" + acctest.RandString(6),
 		}.Build())
-		createReq.Header().Set("Authorization", "Bearer "+accessToken)
-		createReq.Header().Set(organization.OrganizationHeader, orgID)
-
-		createResp, err := apiKeyClient.CreateAPIKey(ctx, createReq)
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodePermissionDenied {
 				fmt.Printf("TestMain: CreateAPIKey not authorized yet (authz-worker pending), attempt %d/%d, retrying...\n", i+1, maxRetries)
@@ -179,7 +180,7 @@ func createDynamicAPIKey(ctx context.Context, endpoint, orgID, accessToken strin
 			return "", "", fmt.Errorf("CreateAPIKey failed: %w", err)
 		}
 
-		return createResp.Msg.GetToken(), createResp.Msg.GetId(), nil
+		return createResp.GetToken(), createResp.GetId(), nil
 	}
 
 	return "", "", fmt.Errorf("could not create dynamic API key within timeout")

--- a/terraform-provider/internal/provider/namespace_data_source.go
+++ b/terraform-provider/internal/provider/namespace_data_source.go
@@ -113,11 +113,11 @@ func (d *NamespaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 		"namespace_name": namespaceName,
 	})
 
-	rpcReq := connect.NewRequest(organizationv1.GetNamespaceByProjectAndNameRequest_builder{
+	rpcReq := organizationv1.GetNamespaceByProjectAndNameRequest_builder{
 		ClusterName:   clusterName,
 		ProjectName:   projectName,
 		NamespaceName: namespaceName,
-	}.Build())
+	}.Build()
 
 	rpcResp, err := d.client.NamespaceService.GetNamespaceByProjectAndName(ctx, rpcReq)
 	if err != nil {
@@ -146,7 +146,7 @@ func (d *NamespaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	ns := rpcResp.Msg.GetNamespace()
+	ns := rpcResp.GetNamespace()
 	config.ID = types.StringValue(ns.GetId())
 	config.Name = types.StringValue(ns.GetName())
 	config.ProjectID = types.StringValue(ns.GetProjectId())

--- a/terraform-provider/internal/provider/namespace_resource.go
+++ b/terraform-provider/internal/provider/namespace_resource.go
@@ -135,25 +135,25 @@ func (r *NamespaceResource) resolveProjectID(ctx context.Context, state *Namespa
 	}
 
 	// Resolve project_name to project_id
-	getReq := connect.NewRequest(organizationv1.GetProjectByNameRequest_builder{
+	getReq := organizationv1.GetProjectByNameRequest_builder{
 		Name: state.ProjectName.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProjectByName(ctx, getReq)
 	if err != nil {
 		return "", fmt.Errorf("unable to find project with name %q: %s", state.ProjectName.ValueString(), err.Error())
 	}
 
-	return getResp.Msg.GetProject().GetId(), nil
+	return getResp.GetProject().GetId(), nil
 }
 
 // populateClusterFields populates both cluster_id and cluster_name on the state from the given cluster_id.
 func (r *NamespaceResource) populateClusterFields(ctx context.Context, state *NamespaceResourceModel, clusterID string) {
 	state.ClusterID = types.StringValue(clusterID)
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetCluster(ctx, getReq)
 	if err != nil {
@@ -166,16 +166,16 @@ func (r *NamespaceResource) populateClusterFields(ctx context.Context, state *Na
 		return
 	}
 
-	state.ClusterName = types.StringValue(getResp.Msg.GetCluster().GetName())
+	state.ClusterName = types.StringValue(getResp.GetCluster().GetName())
 }
 
 // populateProjectFields populates both project_id and project_name on the state from the given project_id.
 func (r *NamespaceResource) populateProjectFields(ctx context.Context, state *NamespaceResourceModel, projectID string) {
 	state.ProjectID = types.StringValue(projectID)
 
-	getReq := connect.NewRequest(organizationv1.GetProjectRequest_builder{
+	getReq := organizationv1.GetProjectRequest_builder{
 		ProjectId: projectID,
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProject(ctx, getReq)
 	if err != nil {
@@ -188,7 +188,7 @@ func (r *NamespaceResource) populateProjectFields(ctx context.Context, state *Na
 		return
 	}
 
-	state.ProjectName = types.StringValue(getResp.Msg.GetProject().GetName())
+	state.ProjectName = types.StringValue(getResp.GetProject().GetName())
 }
 
 // Create creates a new namespace.
@@ -223,10 +223,10 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 	})
 
 	// Create the namespace
-	createReq := connect.NewRequest(organizationv1.CreateNamespaceRequest_builder{
+	createReq := organizationv1.CreateNamespaceRequest_builder{
 		ProjectId: projectID,
 		Name:      plan.Name.ValueString(),
-	}.Build())
+	}.Build()
 
 	createResp, err := createIdempotent(ctx, r.client.NamespaceService.CreateNamespace, createReq)
 	if err != nil {
@@ -261,13 +261,13 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Set the ID from the response
-	plan.ID = types.StringValue(createResp.Msg.GetNamespaceId())
+	plan.ID = types.StringValue(createResp.GetNamespaceId())
 
 	// Read back the namespace to get created and other computed fields.
 	// Retry on permission_denied, OpenFGA needs time to sync
-	getReq := connect.NewRequest(organizationv1.GetNamespaceRequest_builder{
+	getReq := organizationv1.GetNamespaceRequest_builder{
 		NamespaceId: plan.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.NamespaceService.GetNamespace(ctx, getReq)
 	if err != nil {
@@ -278,9 +278,9 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	plan.Created = types.StringValue(getResp.Msg.GetNamespace().GetCreated().AsTime().Format(time.RFC3339))
-	r.populateClusterFields(ctx, &plan, getResp.Msg.GetNamespace().GetClusterId())
-	r.populateProjectFields(ctx, &plan, getResp.Msg.GetNamespace().GetProjectId())
+	plan.Created = types.StringValue(getResp.GetNamespace().GetCreated().AsTime().Format(time.RFC3339))
+	r.populateClusterFields(ctx, &plan, getResp.GetNamespace().GetClusterId())
+	r.populateProjectFields(ctx, &plan, getResp.GetNamespace().GetProjectId())
 
 	tflog.Info(ctx, "Created namespace", map[string]any{
 		"id":      plan.ID.ValueString(),
@@ -311,9 +311,9 @@ func (r *NamespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		"id": state.ID.ValueString(),
 	})
 
-	getReq := connect.NewRequest(organizationv1.GetNamespaceRequest_builder{
+	getReq := organizationv1.GetNamespaceRequest_builder{
 		NamespaceId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.NamespaceService.GetNamespace(ctx, getReq)
 	if err != nil {
@@ -333,7 +333,7 @@ func (r *NamespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		}
 	}
 
-	ns := getResp.Msg.GetNamespace()
+	ns := getResp.GetNamespace()
 	state.Name = types.StringValue(ns.GetName())
 	state.Created = types.StringValue(ns.GetCreated().AsTime().Format(time.RFC3339))
 	r.populateClusterFields(ctx, &state, ns.GetClusterId())
@@ -376,9 +376,9 @@ func (r *NamespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		"id": state.ID.ValueString(),
 	})
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteNamespaceRequest_builder{
+	deleteReq := organizationv1.DeleteNamespaceRequest_builder{
 		NamespaceId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.NamespaceService.DeleteNamespace(ctx, deleteReq)
 	if err != nil {

--- a/terraform-provider/internal/provider/organization_member_resource.go
+++ b/terraform-provider/internal/provider/organization_member_resource.go
@@ -123,10 +123,10 @@ func (r *OrganizationMemberResource) Create(ctx context.Context, req resource.Cr
 		"permission": plan.Permission.ValueString(),
 	})
 
-	inviteReq := connect.NewRequest(organizationv1.InviteMemberRequest_builder{
+	inviteReq := organizationv1.InviteMemberRequest_builder{
 		Email:      plan.Email.ValueString(),
 		Permission: plan.Permission.ValueString(),
-	}.Build())
+	}.Build()
 
 	inviteResp, err := createIdempotent(ctx, r.client.InviteService.InviteMember, inviteReq)
 	if err != nil {
@@ -150,7 +150,7 @@ func (r *OrganizationMemberResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	invitationID := inviteResp.Msg.GetInvitationId()
+	invitationID := inviteResp.GetInvitationId()
 	plan.ID = types.StringValue(invitationID)
 
 	member, err := r.findMemberByID(ctx, invitationID)
@@ -279,10 +279,10 @@ func (r *OrganizationMemberResource) Update(ctx context.Context, req resource.Up
 		"permission_new": plan.Permission.ValueString(),
 	})
 
-	updateReq := connect.NewRequest(organizationv1.UpdateMemberPermissionRequest_builder{
+	updateReq := organizationv1.UpdateMemberPermissionRequest_builder{
 		Id:         state.ID.ValueString(),
 		Permission: plan.Permission.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.MemberService.UpdateMemberPermission(ctx, updateReq)
 	if err != nil {
@@ -380,9 +380,9 @@ func (r *OrganizationMemberResource) Delete(ctx context.Context, req resource.De
 		"id": state.ID.ValueString(),
 	})
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteMemberRequest_builder{
+	deleteReq := organizationv1.DeleteMemberRequest_builder{
 		Id: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.MemberService.DeleteMember(ctx, deleteReq)
 	if err != nil {
@@ -419,9 +419,9 @@ func (r *OrganizationMemberResource) ImportState(ctx context.Context, req resour
 // findMemberByID fetches a single member by membership ID.
 // Returns the member if found, nil if not found, or an error on API failure.
 func (r *OrganizationMemberResource) findMemberByID(ctx context.Context, id string) (*organizationv1.Member, error) {
-	getReq := connect.NewRequest(organizationv1.GetMemberRequest_builder{
+	getReq := organizationv1.GetMemberRequest_builder{
 		Id: &id,
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.MemberService.GetMember(ctx, getReq)
 	if err != nil {
@@ -431,5 +431,5 @@ func (r *OrganizationMemberResource) findMemberByID(ctx context.Context, id stri
 		return nil, fmt.Errorf("failed to get member: %w", err)
 	}
 
-	return getResp.Msg.GetMember(), nil
+	return getResp.GetMember(), nil
 }

--- a/terraform-provider/internal/provider/organization_members_data_source.go
+++ b/terraform-provider/internal/provider/organization_members_data_source.go
@@ -116,7 +116,7 @@ func (d *OrganizationMembersDataSource) Read(ctx context.Context, req datasource
 
 	tflog.Debug(ctx, "Fetching organization members")
 
-	rpcReq := connect.NewRequest(organizationv1.ListMembersRequest_builder{}.Build())
+	rpcReq := organizationv1.ListMembersRequest_builder{}.Build()
 
 	rpcResp, err := d.client.MemberService.ListMembers(ctx, rpcReq)
 	if err != nil {
@@ -135,8 +135,8 @@ func (d *OrganizationMembersDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	state.Members = make([]OrganizationMemberModel, len(rpcResp.Msg.GetMembers()))
-	for i, member := range rpcResp.Msg.GetMembers() {
+	state.Members = make([]OrganizationMemberModel, len(rpcResp.GetMembers()))
+	for i, member := range rpcResp.GetMembers() {
 		m := OrganizationMemberModel{
 			ID:         types.StringValue(member.GetId()),
 			UserID:     types.StringValue(member.GetUserId()),

--- a/terraform-provider/internal/provider/plugin_installation_resource.go
+++ b/terraform-provider/internal/provider/plugin_installation_resource.go
@@ -327,12 +327,12 @@ func (r *PluginInstallationResource) Create(ctx context.Context, req resource.Cr
 // headers are added by the client transport). It errors when the plugin is not
 // in the catalog or has no published definition to pin.
 func (r *PluginInstallationResource) resolveLatestDefinition(ctx context.Context, pluginName string) (string, string, error) {
-	listReq := connect.NewRequest(organizationv1.ListPluginsRequest_builder{}.Build())
+	listReq := organizationv1.ListPluginsRequest_builder{}.Build()
 	listResp, err := r.client.PluginService.ListPlugins(ctx, listReq)
 	if err != nil {
 		return "", "", fmt.Errorf("list plugins: %w", err)
 	}
-	for _, p := range listResp.Msg.GetPlugins() {
+	for _, p := range listResp.GetPlugins() {
 		if p.GetName() != pluginName {
 			continue
 		}
@@ -370,9 +370,9 @@ func (r *PluginInstallationResource) Read(ctx context.Context, req resource.Read
 	defer cancel()
 
 	// Check whether the cluster's Kubernetes API is reachable before hitting the proxy.
-	getClusterReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getClusterReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
+	}.Build()
 
 	clusterResp, err := r.client.ClusterService.GetCluster(ctx, getClusterReq)
 	if err != nil {
@@ -385,7 +385,7 @@ func (r *PluginInstallationResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	clusterStatus := clusterResp.Msg.GetCluster().GetStatus()
+	clusterStatus := clusterResp.GetCluster().GetStatus()
 	switch clusterStatus {
 	case organizationv1.ClusterStatus_CLUSTER_STATUS_RUNNING,
 		organizationv1.ClusterStatus_CLUSTER_STATUS_UPGRADING:
@@ -479,9 +479,9 @@ func (r *PluginInstallationResource) Delete(ctx context.Context, req resource.De
 	defer cancel()
 
 	// Check whether the cluster is in a state where its Kubernetes API is reachable.
-	getClusterReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getClusterReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
+	}.Build()
 
 	clusterResp, err := r.client.ClusterService.GetCluster(ctx, getClusterReq)
 	if err != nil {
@@ -493,7 +493,7 @@ func (r *PluginInstallationResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	clusterStatus := clusterResp.Msg.GetCluster().GetStatus()
+	clusterStatus := clusterResp.GetCluster().GetStatus()
 	switch clusterStatus {
 	case organizationv1.ClusterStatus_CLUSTER_STATUS_RUNNING,
 		organizationv1.ClusterStatus_CLUSTER_STATUS_UPGRADING:

--- a/terraform-provider/internal/provider/project_data_source.go
+++ b/terraform-provider/internal/provider/project_data_source.go
@@ -103,9 +103,9 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		"name": config.Name.ValueString(),
 	})
 
-	getReq := connect.NewRequest(organizationv1.GetProjectByNameRequest_builder{
+	getReq := organizationv1.GetProjectByNameRequest_builder{
 		Name: config.Name.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := d.client.ProjectService.GetProjectByName(ctx, getReq)
 	if err != nil {
@@ -134,7 +134,7 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	project := getResp.Msg.GetProject()
+	project := getResp.GetProject()
 
 	// Map response to state
 	config.ID = types.StringValue(project.GetId())
@@ -143,9 +143,9 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	config.ClusterID = types.StringValue(project.GetClusterId())
 
 	// Resolve cluster name
-	clusterReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	clusterReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: project.GetClusterId(),
-	}.Build())
+	}.Build()
 
 	clusterResp, err := d.client.ClusterService.GetCluster(ctx, clusterReq)
 	if err != nil {
@@ -155,7 +155,7 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		})
 		return
 	} else {
-		config.ClusterName = types.StringValue(clusterResp.Msg.GetCluster().GetName())
+		config.ClusterName = types.StringValue(clusterResp.GetCluster().GetName())
 	}
 
 	if project.GetCreated().CheckValid() == nil {

--- a/terraform-provider/internal/provider/project_member_resource.go
+++ b/terraform-provider/internal/provider/project_member_resource.go
@@ -146,11 +146,11 @@ func (r *ProjectMemberResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Create the project member
-	createReq := connect.NewRequest(organizationv1.AddProjectMemberRequest_builder{
+	createReq := organizationv1.AddProjectMemberRequest_builder{
 		ProjectId: plan.ProjectID.ValueString(),
 		UserId:    plan.UserID.ValueString(),
 		Role:      protoRole,
-	}.Build())
+	}.Build()
 
 	createResp, err := createIdempotent(ctx, r.client.ProjectService.AddProjectMember, createReq)
 	if err != nil {
@@ -180,13 +180,13 @@ func (r *ProjectMemberResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Set the ID from the response
-	plan.ID = types.StringValue(createResp.Msg.GetMemberId())
+	plan.ID = types.StringValue(createResp.GetMemberId())
 
 	// Read back the created member to get computed fields.
 	// Retry on permission_denied: OpenFGA needs time to sync after the member is added.
-	getReq := connect.NewRequest(organizationv1.GetProjectMemberRequest_builder{
-		MemberId: createResp.Msg.GetMemberId(),
-	}.Build())
+	getReq := organizationv1.GetProjectMemberRequest_builder{
+		MemberId: createResp.GetMemberId(),
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProjectMember(ctx, getReq)
 	if err != nil {
@@ -197,15 +197,15 @@ func (r *ProjectMemberResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	permissionStr, err := projectMemberPermissionFromProto(getResp.Msg.GetMember().GetRole())
+	permissionStr, err := projectMemberPermissionFromProto(getResp.GetMember().GetRole())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Invalid Project Member Permission",
-			fmt.Sprintf("Unable to convert permission for member %q: %s", getResp.Msg.GetMember().GetId(), err.Error()),
+			fmt.Sprintf("Unable to convert permission for member %q: %s", getResp.GetMember().GetId(), err.Error()),
 		)
 		return
 	}
-	m := getResp.Msg.GetMember()
+	m := getResp.GetMember()
 	plan.ProjectID = types.StringValue(m.GetProjectId())
 	plan.UserID = types.StringValue(m.GetUserId())
 	plan.UserName = types.StringValue(m.GetUserName())
@@ -303,10 +303,10 @@ func (r *ProjectMemberResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Update the member role
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectMemberRoleRequest_builder{
+	updateReq := organizationv1.UpdateProjectMemberRoleRequest_builder{
 		MemberId: state.ID.ValueString(),
 		Role:     protoRole,
-	}.Build())
+	}.Build()
 
 	_, err = r.client.ProjectService.UpdateProjectMemberRole(ctx, updateReq)
 	if err != nil {
@@ -382,9 +382,9 @@ func (r *ProjectMemberResource) Delete(ctx context.Context, req resource.DeleteR
 		"id": state.ID.ValueString(),
 	})
 
-	deleteReq := connect.NewRequest(organizationv1.RemoveProjectMemberRequest_builder{
+	deleteReq := organizationv1.RemoveProjectMemberRequest_builder{
 		MemberId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.ProjectService.RemoveProjectMember(ctx, deleteReq)
 	if err != nil {
@@ -456,9 +456,9 @@ func (r *ProjectMemberResource) ImportState(ctx context.Context, req resource.Im
 func readProjectMemberIntoModel(ctx context.Context, client *FundamentClient, model *ProjectMemberModel) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	getReq := connect.NewRequest(organizationv1.GetProjectMemberRequest_builder{
+	getReq := organizationv1.GetProjectMemberRequest_builder{
 		MemberId: model.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := client.ProjectService.GetProjectMember(ctx, getReq)
 	if err != nil {
@@ -472,7 +472,7 @@ func readProjectMemberIntoModel(ctx context.Context, client *FundamentClient, mo
 		return false, diags
 	}
 
-	member := getResp.Msg.GetMember()
+	member := getResp.GetMember()
 	permissionStr, err := projectMemberPermissionFromProto(member.GetRole())
 	if err != nil {
 		diags.AddError(

--- a/terraform-provider/internal/provider/project_members_data_source.go
+++ b/terraform-provider/internal/provider/project_members_data_source.go
@@ -127,9 +127,9 @@ func (d *ProjectMembersDataSource) Read(ctx context.Context, req datasource.Read
 		"project_id": state.ProjectID.ValueString(),
 	})
 
-	rpcReq := connect.NewRequest(organizationv1.ListProjectMembersRequest_builder{
+	rpcReq := organizationv1.ListProjectMembersRequest_builder{
 		ProjectId: state.ProjectID.ValueString(),
-	}.Build())
+	}.Build()
 
 	rpcResp, err := d.client.ProjectService.ListProjectMembers(ctx, rpcReq)
 	if err != nil {
@@ -154,7 +154,7 @@ func (d *ProjectMembersDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	// Map response to state
-	members := rpcResp.Msg.GetMembers()
+	members := rpcResp.GetMembers()
 	state.Members = make([]ProjectMemberModel, len(members))
 	for i, member := range members {
 		var created types.String

--- a/terraform-provider/internal/provider/project_namespaces_data_source.go
+++ b/terraform-provider/internal/provider/project_namespaces_data_source.go
@@ -124,9 +124,9 @@ func (d *ProjectNamespacesDataSource) Read(ctx context.Context, req datasource.R
 		"project_id": projectID,
 	})
 
-	rpcReq := connect.NewRequest(organizationv1.ListProjectNamespacesRequest_builder{
+	rpcReq := organizationv1.ListProjectNamespacesRequest_builder{
 		ProjectId: projectID,
-	}.Build())
+	}.Build()
 
 	// Call the API
 	rpcResp, err := d.client.NamespaceService.ListProjectNamespaces(ctx, rpcReq)
@@ -157,8 +157,8 @@ func (d *ProjectNamespacesDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	// Map response to state
-	state.Namespaces = make([]NamespaceModel, len(rpcResp.Msg.GetNamespaces()))
-	for i, ns := range rpcResp.Msg.GetNamespaces() {
+	state.Namespaces = make([]NamespaceModel, len(rpcResp.GetNamespaces()))
+	for i, ns := range rpcResp.GetNamespaces() {
 		state.Namespaces[i] = NamespaceModel{
 			ID:        types.StringValue(ns.GetId()),
 			Name:      types.StringValue(ns.GetName()),

--- a/terraform-provider/internal/provider/project_resource.go
+++ b/terraform-provider/internal/provider/project_resource.go
@@ -121,25 +121,25 @@ func (r *ProjectResource) resolveClusterID(ctx context.Context, state *ProjectMo
 	}
 
 	// Resolve cluster_name to cluster_id
-	getReq := connect.NewRequest(organizationv1.GetClusterByNameRequest_builder{
+	getReq := organizationv1.GetClusterByNameRequest_builder{
 		Name: state.ClusterName.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetClusterByName(ctx, getReq)
 	if err != nil {
 		return "", fmt.Errorf("unable to find cluster with name %q: %s", state.ClusterName.ValueString(), err.Error())
 	}
 
-	return getResp.Msg.GetCluster().GetId(), nil
+	return getResp.GetCluster().GetId(), nil
 }
 
 // populateClusterFields populates both cluster_id and cluster_name on the state from the given cluster_id.
 func (r *ProjectResource) populateClusterFields(ctx context.Context, state *ProjectModel, clusterID string) {
 	state.ClusterID = types.StringValue(clusterID)
 
-	getReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+	getReq := organizationv1.GetClusterRequest_builder{
 		ClusterId: clusterID,
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ClusterService.GetCluster(ctx, getReq)
 	if err != nil {
@@ -152,7 +152,7 @@ func (r *ProjectResource) populateClusterFields(ctx context.Context, state *Proj
 		return
 	}
 
-	state.ClusterName = types.StringValue(getResp.Msg.GetCluster().GetName())
+	state.ClusterName = types.StringValue(getResp.GetCluster().GetName())
 }
 
 // Create creates a new project.
@@ -194,11 +194,11 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Create the project
-	createReq := connect.NewRequest(organizationv1.CreateProjectRequest_builder{
+	createReq := organizationv1.CreateProjectRequest_builder{
 		ClusterId: clusterID,
 		Name:      state.Name.ValueString(),
 		Alias:     aliasPtr,
-	}.Build())
+	}.Build()
 
 	createResp, err := createIdempotent(ctx, r.client.ProjectService.CreateProject, createReq)
 	if err != nil {
@@ -210,13 +210,13 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Set the ID from the response
-	state.ID = types.StringValue(createResp.Msg.GetProjectId())
+	state.ID = types.StringValue(createResp.GetProjectId())
 
 	// Read the project to get the full state including created.
 	// Retry on permission_denied, OpenFGA needs time to sync
-	getReq := connect.NewRequest(organizationv1.GetProjectRequest_builder{
-		ProjectId: createResp.Msg.GetProjectId(),
-	}.Build())
+	getReq := organizationv1.GetProjectRequest_builder{
+		ProjectId: createResp.GetProjectId(),
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProject(ctx, getReq)
 	if err != nil {
@@ -228,12 +228,12 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Populate cluster fields (both ID and name)
-	r.populateClusterFields(ctx, &state, getResp.Msg.GetProject().GetClusterId())
+	r.populateClusterFields(ctx, &state, getResp.GetProject().GetClusterId())
 
-	state.Alias = types.StringValue(getResp.Msg.GetProject().GetAlias())
+	state.Alias = types.StringValue(getResp.GetProject().GetAlias())
 
-	if getResp.Msg.GetProject().GetCreated().CheckValid() == nil {
-		state.Created = types.StringValue(getResp.Msg.GetProject().GetCreated().String())
+	if getResp.GetProject().GetCreated().CheckValid() == nil {
+		state.Created = types.StringValue(getResp.GetProject().GetCreated().String())
 	}
 
 	tflog.Info(ctx, "Created project", map[string]any{
@@ -264,9 +264,9 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		"id": state.ID.ValueString(),
 	})
 
-	getReq := connect.NewRequest(organizationv1.GetProjectRequest_builder{
+	getReq := organizationv1.GetProjectRequest_builder{
 		ProjectId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProject(ctx, getReq)
 	if err != nil {
@@ -286,7 +286,7 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	project := getResp.Msg.GetProject()
+	project := getResp.GetProject()
 
 	// Map response to state
 	state.ID = types.StringValue(project.GetId())
@@ -338,10 +338,10 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 		a := plan.Alias.ValueString()
 		aliasPtr = &a
 	}
-	updateReq := connect.NewRequest(organizationv1.UpdateProjectRequest_builder{
+	updateReq := organizationv1.UpdateProjectRequest_builder{
 		ProjectId: state.ID.ValueString(),
 		Alias:     aliasPtr,
-	}.Build())
+	}.Build()
 
 	_, err := r.client.ProjectService.UpdateProject(ctx, updateReq)
 	if err != nil {
@@ -371,9 +371,9 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Read the project to get the updated state
-	getReq := connect.NewRequest(organizationv1.GetProjectRequest_builder{
+	getReq := organizationv1.GetProjectRequest_builder{
 		ProjectId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	getResp, err := r.client.ProjectService.GetProject(ctx, getReq)
 	if err != nil {
@@ -392,7 +392,7 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	project := getResp.Msg.GetProject()
+	project := getResp.GetProject()
 
 	// Update the plan with the server response
 	plan.ID = types.StringValue(project.GetId())
@@ -434,9 +434,9 @@ func (r *ProjectResource) Delete(ctx context.Context, req resource.DeleteRequest
 		"id": state.ID.ValueString(),
 	})
 
-	deleteReq := connect.NewRequest(organizationv1.DeleteProjectRequest_builder{
+	deleteReq := organizationv1.DeleteProjectRequest_builder{
 		ProjectId: state.ID.ValueString(),
-	}.Build())
+	}.Build()
 
 	_, err := r.client.ProjectService.DeleteProject(ctx, deleteReq)
 	if err != nil {

--- a/terraform-provider/internal/provider/projects_data_source.go
+++ b/terraform-provider/internal/provider/projects_data_source.go
@@ -122,7 +122,7 @@ func (d *ProjectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	tflog.Debug(ctx, "Fetching projects")
 
 	listReq := organizationv1.ListProjectsRequest_builder{ClusterId: state.ClusterID.ValueString()}.Build()
-	rpcReq := connect.NewRequest(listReq)
+	rpcReq := listReq
 
 	// Call the API
 	rpcResp, err := d.client.ProjectService.ListProjects(ctx, rpcReq)
@@ -149,21 +149,21 @@ func (d *ProjectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	// Build cluster name cache to avoid redundant API calls
 	clusterNames := make(map[string]string)
-	for _, project := range rpcResp.Msg.GetProjects() {
+	for _, project := range rpcResp.GetProjects() {
 		if _, ok := clusterNames[project.GetClusterId()]; !ok {
-			clusterReq := connect.NewRequest(organizationv1.GetClusterRequest_builder{
+			clusterReq := organizationv1.GetClusterRequest_builder{
 				ClusterId: project.GetClusterId(),
-			}.Build())
+			}.Build()
 			clusterResp, err := d.client.ClusterService.GetCluster(ctx, clusterReq)
 			if err == nil {
-				clusterNames[project.GetClusterId()] = clusterResp.Msg.GetCluster().GetName()
+				clusterNames[project.GetClusterId()] = clusterResp.GetCluster().GetName()
 			}
 		}
 	}
 
 	// Map response to state
-	state.Projects = make([]ProjectModel, len(rpcResp.Msg.GetProjects()))
-	for i, project := range rpcResp.Msg.GetProjects() {
+	state.Projects = make([]ProjectModel, len(rpcResp.GetProjects()))
+	for i, project := range rpcResp.GetProjects() {
 		var created basetypes.StringValue
 
 		if project.GetCreated().CheckValid() == nil {

--- a/terraform-provider/internal/provider/token_manager.go
+++ b/terraform-provider/internal/provider/token_manager.go
@@ -69,18 +69,18 @@ func (tm *TokenManager) refreshToken(ctx context.Context) (string, error) {
 		return tm.token, nil
 	}
 
-	// Create request with API key in Authorization header
-	req := connect.NewRequest(authnv1.ExchangeTokenRequest_builder{}.Build())
-	req.Header().Set("Authorization", "Bearer "+tm.apiKey)
+	// Send the API key in the Authorization header
+	ctx, callInfo := connect.NewClientContext(ctx)
+	callInfo.RequestHeader().Set("Authorization", "Bearer "+tm.apiKey)
 
-	resp, err := tm.client.ExchangeToken(ctx, req)
+	resp, err := tm.client.ExchangeToken(ctx, authnv1.ExchangeTokenRequest_builder{}.Build())
 	if err != nil {
 		return "", fmt.Errorf("token exchange failed for API key %q at %s: %w", apitoken.GetPrefix(tm.apiKey), tm.authnEndpoint, err)
 	}
 
 	// Parse expiration from the JWT itself
 	parser := jwt.NewParser()
-	token, _, err := parser.ParseUnverified(resp.Msg.GetAccessToken(), jwt.MapClaims{})
+	token, _, err := parser.ParseUnverified(resp.GetAccessToken(), jwt.MapClaims{})
 	if err != nil {
 		return "", fmt.Errorf("failed to parse token: %w", err)
 	}

--- a/terraform-provider/internal/provider/token_manager_test.go
+++ b/terraform-provider/internal/provider/token_manager_test.go
@@ -3,12 +3,15 @@ package provider
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
 
 	authnv1 "github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1"
 	"github.com/fundament-oss/fundament/authn-api/pkg/proto/gen/authn/v1/authnv1connect"
@@ -17,14 +20,25 @@ import (
 // mockTokenServiceClient is a mock implementation of TokenServiceClient for testing.
 type mockTokenServiceClient struct {
 	authnv1connect.UnimplementedTokenServiceHandler
-	exchangeFunc func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error)
+	exchangeFunc func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error)
 }
 
-func (m *mockTokenServiceClient) ExchangeToken(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
+func (m *mockTokenServiceClient) ExchangeToken(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
 	if m.exchangeFunc != nil {
 		return m.exchangeFunc(ctx, req)
 	}
 	return nil, errors.New("not implemented")
+}
+
+// newTestTokenServiceClient serves mock over a real Connect server so that
+// request headers set via the client context are visible to the handler.
+func newTestTokenServiceClient(t *testing.T, mock *mockTokenServiceClient) authnv1connect.TokenServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(authnv1connect.NewTokenServiceHandler(mock))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return authnv1connect.NewTokenServiceClient(srv.Client(), srv.URL)
 }
 
 // createTestJWT creates a JWT token for testing with the given expiration time.
@@ -80,21 +94,22 @@ func TestTokenManager_GetToken_Fresh(t *testing.T) {
 	testToken := createTestJWT(expTime)
 
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
 			// Verify Authorization header is set
-			if req.Header().Get("Authorization") != "Bearer test-api-key" {
-				t.Errorf("Authorization header = %q, want %q", req.Header().Get("Authorization"), "Bearer test-api-key")
+			callInfo, ok := connect.CallInfoForHandlerContext(ctx)
+			if assert.True(t, ok, "expected handler call info in context") {
+				assert.Equal(t, "Bearer test-api-key", callInfo.RequestHeader().Get("Authorization"))
 			}
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+			return authnv1.ExchangeTokenResponse_builder{
 				AccessToken: testToken,
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 
 	tm := &TokenManager{
 		apiKey:        "test-api-key",
 		authnEndpoint: "http://test.example.com",
-		client:        mock,
+		client:        newTestTokenServiceClient(t, mock),
 	}
 
 	token, err := tm.GetToken(context.Background())
@@ -112,10 +127,10 @@ func TestTokenManager_GetToken_Cached(t *testing.T) {
 	testToken := createTestJWT(expTime)
 
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+			return authnv1.ExchangeTokenResponse_builder{
 				AccessToken: testToken,
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 
@@ -149,10 +164,10 @@ func TestTokenManager_GetToken_RefreshesExpiredToken(t *testing.T) {
 	newToken := createTestJWT(newExpTime)
 
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+			return authnv1.ExchangeTokenResponse_builder{
 				AccessToken: newToken,
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 
@@ -176,7 +191,7 @@ func TestTokenManager_GetToken_RefreshesExpiredToken(t *testing.T) {
 
 func TestTokenManager_GetToken_ExchangeError(t *testing.T) {
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
 			return nil, errors.New("authentication failed")
 		},
 	}
@@ -202,10 +217,10 @@ func TestTokenManager_GetToken_ExchangeError(t *testing.T) {
 
 func TestTokenManager_GetToken_InvalidJWT(t *testing.T) {
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+			return authnv1.ExchangeTokenResponse_builder{ //nolint:gosec // not a real credential
 				AccessToken: "not-a-valid-jwt",
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 
@@ -229,10 +244,10 @@ func TestTokenManager_GetToken_MissingExpiration(t *testing.T) {
 	tokenString, _ := token.SignedString([]byte("test-secret"))
 
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
+			return authnv1.ExchangeTokenResponse_builder{
 				AccessToken: tokenString,
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 
@@ -258,12 +273,12 @@ func TestTokenManager_GetToken_ConcurrentAccess(t *testing.T) {
 	testToken := createTestJWT(expTime)
 
 	mock := &mockTokenServiceClient{
-		exchangeFunc: func(ctx context.Context, req *connect.Request[authnv1.ExchangeTokenRequest]) (*connect.Response[authnv1.ExchangeTokenResponse], error) {
+		exchangeFunc: func(ctx context.Context, req *authnv1.ExchangeTokenRequest) (*authnv1.ExchangeTokenResponse, error) {
 			// Add a small delay to simulate network latency
 			time.Sleep(10 * time.Millisecond)
-			return connect.NewResponse(authnv1.ExchangeTokenResponse_builder{
+			return authnv1.ExchangeTokenResponse_builder{
 				AccessToken: testToken,
-			}.Build()), nil
+			}.Build(), nil
 		},
 	}
 


### PR DESCRIPTION
## Summary

Migrates all Go connect code to the `protoc-gen-connect-go` **`simple`** option ([connectrpc/connect-go#851](https://github.com/connectrpc/connect-go/pull/851), shipped in v1.19). Handlers and clients now use plain message signatures — `Method(ctx, *Req) (*Resp, error)` — instead of `connect.Request[T]`/`connect.Response[T]` wrappers. This matches the API that connect-go v2 ([connectrpc/connect-go#951](https://github.com/connectrpc/connect-go/pull/951)) will make the default, so the eventual v2 bump becomes mostly an import change.

Two commits:
1. **deps**: connect-go v1.19.1 → v1.20.0 (go.mod + `protoc-gen-connect-go` pin in mise.toml) plus routine genproto bumps.
2. **migration**: `opt: paths=source_relative,simple` in all five Go proto modules (authn-api, organization-api, dcim-api, plugin-proxy, plugin-sdk metadata), 24 regenerated files, and ~230 migrated hand-written files.

## Notable changes beyond the mechanical unwrapping

- **Per-call metadata moves to context.** Handlers read headers via `connect.CallInfoForHandlerContext(ctx)` (authn-api JWT/Authorization handling); clients set per-request headers via `connect.NewClientContext(ctx)` (functl `ensureToken`, terraform `refreshToken`, plugin-publish `withAuth` — the latter redesigned from a request mutator into a context producer).
- **Interceptors are untouched** — they operate on `connect.AnyRequest`, which `simple` doesn't change.
- **Terraform `createIdempotent`** generics now take plain call funcs; a fresh client context per retry attempt carries `Idempotency-Key` and reads `Idempotency-Status` from response headers.
- **Two test suites moved from direct handler invocation to `httptest` servers** (`mint_plugin_token_test.go`, terraform `idempotent_create_test.go`): connect exports no way to fabricate a handler-side call-info context, so header-carrying direct calls are no longer possible. Coverage is equivalent (the real wire path is now exercised).
- Three test fakes intentionally keep the raw wrapped API (`connect.Client.CallUnary`) — that's the correct low-level plumbing, mirroring generated simple clients.
- Server-streaming (organization-api metrics) keeps its `*connect.ServerStream[T]` parameter; only the request wrapper is dropped. Frontend codegen (connect-es) is unaffected.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run --new-from-rev master` — 0 issues
- `go test -count=1 ./...` — all packages pass except the pre-existing `cluster-worker/pkg/handler/cluster` harness failure, which also fails on master and is fixed separately in #351