### PR TITLE
fix(authz-worker): mark outbox retry on fresh conn after aborted tx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,40 @@ jobs:
         working-directory: cluster-worker
         run: go test ./... -count=1
 
+  authz-worker:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Trek binary
+        id: cache-trek
+        uses: actions/cache@v5
+        with:
+          path: ~/go/bin/trek
+          key: trek-${{ runner.os }}-v0.12.1
+
+      - name: Cache embedded PostgreSQL
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.FUNDAMENT_TEST_CACHE_DIR }}-authz-worker
+          key: embedded-pg-authz-worker-${{ runner.os }}
+
+      - name: Install dependencies
+        run: go get ./...
+
+      - name: Install Trek
+        if: steps.cache-trek.outputs.cache-hit != 'true'
+        run: go install github.com/printeers/trek@v0.12.1
+
+      - name: Run tests (authz-worker)
+        working-directory: authz-worker
+        run: go test ./... -count=1
+
   common:
     runs-on: ubuntu-24.04
     steps:
@@ -182,7 +216,7 @@ jobs:
         run: go get ./...
 
       - name: Run tests
-        run: go test -count=1 $(go list ./... | grep -v -E '/(organization-api|cluster-worker|common|dcim-api)/')
+        run: go test -count=1 $(go list ./... | grep -v -E '/(organization-api|authz-worker|cluster-worker|common|dcim-api)/')
 
   openfsc-console-ui:
     runs-on: ubuntu-24.04

--- a/authz-worker/pkg/worker/main_test.go
+++ b/authz-worker/pkg/worker/main_test.go
@@ -1,0 +1,316 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/fundament-oss/fundament/common/testdb"
+)
+
+const testDBPort = 45329
+
+func TestMain(m *testing.M) {
+	cacheDir := os.Getenv("FUNDAMENT_TEST_CACHE_DIR")
+	if cacheDir == "" {
+		userCache, err := os.UserCacheDir()
+		if err != nil {
+			log.Fatalf("failed to determine user cache directory: %v", err)
+		}
+
+		cacheDir = filepath.Join(userCache, "fundament-test-pg-authz-worker")
+	} else {
+		cacheDir += "-authz-worker"
+	}
+
+	err := os.MkdirAll(cacheDir, 0o750) //nolint:gosec // test helper, paths are not user-controlled
+	if err != nil {
+		log.Fatalf("failed to create cache directory: %v", err)
+	}
+
+	dataDir := filepath.Join(cacheDir, "data")
+	pgBin := filepath.Join(cacheDir, "bin")
+
+	var stopPostgres func()
+
+	if dirExists(dataDir) && dirExists(pgBin) {
+		log.Printf("existing embedded-postgres detected at %q", cacheDir) //nolint:gosec // test log
+		startExistingEmbeddedPostgres(pgBin, dataDir)
+
+		stopPostgres = func() {
+			pgCtl := filepath.Join(pgBin, "pg_ctl")
+			cmd := exec.Command(pgCtl, "-D", dataDir, "-w", "-m", "fast", "stop") //nolint:gosec,noctx // test helper
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				log.Printf("failed to stop postgres: %v", err)
+			}
+		}
+	} else {
+		log.Printf("setting up new embedded-postgres installation %q", cacheDir) //nolint:gosec // test log
+		epDB := createAndStartNewEmbeddedPostgres(cacheDir, dataDir)
+
+		stopPostgres = func() {
+			if err := epDB.Stop(); err != nil {
+				log.Printf("failed to stop postgres: %v", err)
+			}
+		}
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.Println("received signal, stopping postgres...")
+		stopPostgres()
+		os.Exit(1)
+	}()
+
+	adminPool := newAdminPool()
+
+	useGlobalTrustAuth(dataDir, adminPool)
+	testdb.CreateRoles(context.Background(), adminPool)
+
+	if err = setupTemplateDatabaseWithMigrations(adminPool); err != nil {
+		adminPool.Close()
+		log.Fatalf("failed to setup template database: %v", err)
+	}
+
+	adminPool.Close()
+
+	code := m.Run()
+
+	stopPostgres()
+	os.Exit(code)
+}
+
+func startExistingEmbeddedPostgres(pgBin, dataDir string) {
+	removeStalePostmasterPID(pgBin, dataDir)
+
+	pgCtl := filepath.Join(pgBin, "pg_ctl")
+	cmd := exec.Command(pgCtl, //nolint:gosec,noctx // test helper
+		"-D", dataDir,
+		"-w",
+		"-o", fmt.Sprintf("-p %d -c fsync=off -c synchronous_commit=off", testDBPort),
+		"start",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("failed to start postgres from cache: %v", err)
+	}
+}
+
+func removeStalePostmasterPID(pgBin, dataDir string) {
+	pidFile := filepath.Join(dataDir, "postmaster.pid")
+
+	data, err := os.ReadFile(pidFile) //nolint:gosec // test helper
+	if err != nil {
+		return
+	}
+
+	lines := strings.SplitN(string(data), "\n", 2)
+	if len(lines) == 0 {
+		return
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		log.Printf("removing stale postmaster.pid (pid %d)", pid)
+		_ = os.Remove(pidFile) //nolint:gosec // test helper
+		return
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		log.Printf("removing stale postmaster.pid (pid %d no longer running)", pid)
+		_ = os.Remove(pidFile) //nolint:gosec // test helper
+		return
+	}
+
+	log.Printf("stopping already-running postgres (pid %d) before restart", pid)
+	pgCtl := filepath.Join(pgBin, "pg_ctl")
+	cmd := exec.Command(pgCtl, "-D", dataDir, "-w", "-m", "fast", "stop") //nolint:gosec,noctx // test helper
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("failed to stop existing postgres (pid %d): %v", pid, err)
+	}
+}
+
+func createAndStartNewEmbeddedPostgres(runtimePath, dataDir string) *embeddedpostgres.EmbeddedPostgres {
+	err := os.RemoveAll(dataDir) //nolint:gosec // test helper
+	if err != nil {
+		log.Fatalf("failed to remove old data directory: %v", err)
+	}
+
+	epDB := embeddedpostgres.NewDatabase(
+		embeddedpostgres.DefaultConfig().
+			Version(embeddedpostgres.V18).
+			Port(testDBPort).
+			Username("postgres").
+			Password("postgres").
+			Database("postgres").
+			RuntimePath(runtimePath).
+			StartParameters(map[string]string{
+				"fsync":              "off",
+				"synchronous_commit": "off",
+			}),
+	)
+	if err := epDB.Start(); err != nil {
+		log.Fatalf("failed to start embedded postgres: %v", err)
+	}
+
+	return epDB
+}
+
+func setupTemplateDatabaseWithMigrations(pool *pgxpool.Pool) error {
+	projectRoot := findProjectRoot()
+
+	_, err := pool.Exec(context.Background(), "UPDATE pg_database SET datistemplate = false WHERE datname = 'fundament'")
+	if err != nil {
+		return fmt.Errorf("failed to unmark fundament as template: %w", err)
+	}
+
+	trekApply(projectRoot)
+
+	_, err = pool.Exec(context.Background(), "UPDATE pg_database SET datistemplate = true WHERE datname = 'fundament'")
+	if err != nil {
+		return fmt.Errorf("failed to mark fundament as template: %w", err)
+	}
+
+	return nil
+}
+
+func findProjectRoot() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("failed to get caller information")
+	}
+
+	dir := filepath.Dir(filename)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			log.Fatal("could not find project root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path) //nolint:gosec // test helper
+	return err == nil && info.IsDir()
+}
+
+func newAdminPool() *pgxpool.Pool {
+	pool, err := pgxpool.New(context.Background(), fmt.Sprintf("postgres://postgres:postgres@localhost:%d/postgres?sslmode=disable", testDBPort))
+	if err != nil {
+		log.Fatalf("failed to connect to postgres: %v", err)
+	}
+	return pool
+}
+
+func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
+	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
+	content, err := os.ReadFile(pgHBAPath) //nolint:gosec // test helper
+	if err != nil {
+		log.Fatalf("failed to read pg_hba.conf: %v", err)
+	}
+	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
+	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil { //nolint:gosec // test helper
+		log.Fatalf("failed to write pg_hba.conf: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
+		log.Fatalf("failed to reload pg_hba.conf: %v", err)
+	}
+}
+
+func trekApply(projectRoot string) {
+	cmd := exec.Command("trek", "apply", //nolint:gosec,noctx // test helper
+		"--reset-database",
+		"--insert-test-data",
+		"--postgres-host", "localhost",
+		"--postgres-port", fmt.Sprintf("%d", testDBPort),
+		"--postgres-user", "postgres",
+		"--postgres-password", "postgres",
+	)
+	cmd.Dir = filepath.Join(projectRoot, "db")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("trek apply failed: %v", err)
+	}
+}
+
+func testNameToDbName(testName string) string {
+	name := strings.ToLower(testName)
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	name = re.ReplaceAllString(name, "_")
+	name = strings.Trim(name, "_")
+
+	if len(name) > 63 {
+		name = name[:63]
+	}
+
+	return name
+}
+
+// createTestDB clones the fundament template into a fresh, test-scoped database
+// and returns a superuser pool (which bypasses RLS) connected to it.
+func createTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	name := testNameToDbName(t.Name())
+
+	adminPool, err := pgxpool.New(t.Context(), fmt.Sprintf(
+		"postgres://postgres:postgres@localhost:%d/postgres?sslmode=disable",
+		testDBPort,
+	))
+	if err != nil {
+		t.Fatalf("failed to connect to admin: %v", err)
+	}
+	defer adminPool.Close()
+
+	_, err = adminPool.Exec(t.Context(), fmt.Sprintf(`DROP DATABASE IF EXISTS %q WITH (FORCE)`, name))
+	if err != nil {
+		t.Fatalf("failed to drop test database: %v", err)
+	}
+
+	_, err = adminPool.Exec(t.Context(), fmt.Sprintf(`CREATE DATABASE %q TEMPLATE fundament`, name))
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+
+	pool, err := pgxpool.New(t.Context(), fmt.Sprintf(
+		"postgres://postgres:postgres@localhost:%d/%s?sslmode=disable",
+		testDBPort, name,
+	))
+	if err != nil {
+		t.Fatalf("failed to connect to test database: %v", err)
+	}
+
+	t.Cleanup(pool.Close)
+
+	return pool
+}

--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -48,6 +48,11 @@ type Worker struct {
 	logger  *slog.Logger
 	cfg     Config
 	ready   atomic.Bool
+
+	// dispatch processes a single locked outbox item within tx. It defaults to
+	// dispatchItem and exists as a field so tests can substitute failure
+	// scenarios, including ones that abort tx (SQLSTATE 25P02).
+	dispatch func(ctx context.Context, tx pgx.Tx, qtx *db.Queries, item *db.GetAndLockNextOutboxRowRow) error
 }
 
 // New creates a new authz worker with sensible defaults.
@@ -57,13 +62,18 @@ func New(pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, logger *slog.Logge
 	hostname, _ := os.Hostname()
 	workerID := fmt.Sprintf("%s-%d", hostname, os.Getpid())
 
-	return &Worker{
+	w := &Worker{
 		pool:    pool,
 		queries: db.New(pool),
 		handler: handler.New(fgaClient, logger),
 		logger:  logger.With("worker_id", workerID),
 		cfg:     cfg,
 	}
+	w.dispatch = func(ctx context.Context, _ pgx.Tx, qtx *db.Queries, item *db.GetAndLockNextOutboxRowRow) error {
+		return w.dispatchItem(ctx, qtx, item)
+	}
+
+	return w
 }
 
 // IsReady returns whether the worker has an active LISTEN connection and is processing.
@@ -263,7 +273,7 @@ func (w *Worker) processOneItem(ctx context.Context) (found bool, err error) {
 		return false, fmt.Errorf("get next outbox row: %w", err)
 	}
 
-	dispatchErr := w.dispatchItem(ctx, qtx, &item)
+	dispatchErr := w.dispatch(ctx, tx, qtx, &item)
 
 	// Past this point the side effect on OpenFGA has already happened (success
 	// or partial), so the outbox row MUST be marked + committed even if the
@@ -273,12 +283,16 @@ func (w *Worker) processOneItem(ctx context.Context) (found bool, err error) {
 	defer cancel()
 
 	if dispatchErr != nil {
-		if err := w.handleProcessingError(finalizeCtx, qtx, &item, dispatchErr); err != nil {
-			return true, fmt.Errorf("handle processing error: %w", err)
+		// dispatchItem may have failed on a SQL statement, which aborts the
+		// transaction (SQLSTATE 25P02) and makes it unusable for any further
+		// query. Roll back to release the row lock, then record the retry or
+		// failure via a fresh pool connection instead of the aborted tx.
+		if err := tx.Rollback(finalizeCtx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			return true, fmt.Errorf("rollback after dispatch error: %w", err)
 		}
 
-		if err := tx.Commit(finalizeCtx); err != nil {
-			return true, fmt.Errorf("dispatch item commit: %w", err)
+		if err := w.handleProcessingError(finalizeCtx, w.queries, &item, dispatchErr); err != nil {
+			return true, fmt.Errorf("handle processing error: %w", err)
 		}
 
 		return true, dispatchErr

--- a/authz-worker/pkg/worker/worker_test.go
+++ b/authz-worker/pkg/worker/worker_test.go
@@ -1,0 +1,84 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	db "github.com/fundament-oss/fundament/authz-worker/pkg/db/gen"
+)
+
+// clusterID is seeded by db/testdata/001_0101-content.sql. The outbox row needs
+// a valid FK target; the entity type itself is irrelevant here because dispatch
+// is stubbed out.
+const seededClusterID = "019b4000-2000-7000-8000-000000000001"
+
+// TestProcessOneItem_DispatchAbortsTx verifies that when dispatch fails in a way
+// that aborts the transaction (SQLSTATE 25P02), the worker still records the
+// retry on a fresh pool connection and surfaces the real dispatch error rather
+// than the masking "current transaction is aborted" error.
+func TestProcessOneItem_DispatchAbortsTx(t *testing.T) {
+	pool := createTestDB(t)
+
+	// Seeding test data fires the sync triggers, which populate authz.outbox.
+	// Clear it so our row is the one GetAndLockNextOutboxRow (ORDER BY created)
+	// picks up.
+	_, err := pool.Exec(t.Context(), `DELETE FROM authz.outbox`)
+	require.NoError(t, err)
+
+	var itemID uuid.UUID
+	err = pool.QueryRow(t.Context(),
+		`INSERT INTO authz.outbox (cluster_id) VALUES ($1) RETURNING id`,
+		seededClusterID,
+	).Scan(&itemID)
+	require.NoError(t, err)
+
+	w := &Worker{
+		pool:    pool,
+		queries: db.New(pool),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:     applyDefaults(Config{}),
+	}
+
+	// Simulate a handler whose SQL statement fails mid-transaction: the failing
+	// statement poisons tx, after which any further query on tx returns 25P02.
+	wantErr := errors.New("boom: handler sql failed")
+	w.dispatch = func(ctx context.Context, tx pgx.Tx, _ *db.Queries, _ *db.GetAndLockNextOutboxRowRow) error {
+		_, execErr := tx.Exec(ctx, "SELECT 1 / 0")
+		require.Error(t, execErr, "the poisoning statement must fail")
+		return wantErr
+	}
+
+	found, err := w.processOneItem(t.Context())
+
+	require.True(t, found)
+	// The real dispatch error must surface, not a masked "transaction is aborted".
+	require.ErrorIs(t, err, wantErr)
+
+	// The retry bookkeeping must have committed via a fresh connection.
+	var (
+		status     string
+		retries    int32
+		statusInfo *string
+		retryAfter *time.Time
+	)
+	err = pool.QueryRow(t.Context(),
+		`SELECT status, retries, status_info, retry_after FROM authz.outbox WHERE id = $1`,
+		itemID,
+	).Scan(&status, &retries, &statusInfo, &retryAfter)
+	require.NoError(t, err)
+
+	assert.Equal(t, "retrying", status)
+	assert.Equal(t, int32(1), retries)
+	require.NotNil(t, statusInfo)
+	assert.Contains(t, *statusInfo, "boom")
+	assert.NotNil(t, retryAfter, "retry backoff must be scheduled")
+}


### PR DESCRIPTION
## Problem

The authz-worker was logging, in a loop:

```
failed to process outbox item ... error: handle processing error: mark outbox retry:
ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
```

When `dispatchItem` failed on a SQL statement, the transaction entered an aborted state (SQLSTATE 25P02). `handleProcessingError` then ran `MarkOutboxRowRetry` on that **same aborted transaction**, which Postgres rejects with "current transaction is aborted".

Two consequences:
- **Item stuck forever** — it could never be marked for retry, so the worker kept re-processing it.
- **Real error masked** — the underlying dispatch failure was swallowed by the secondary 25P02.

## Fix

On dispatch error, roll back the transaction first (releasing the row lock), then record the retry/failure via a **fresh pool connection** (`w.queries`) instead of the aborted tx. This mirrors the existing `cluster-worker` pattern. The real dispatch error now surfaces in the logs.

## Test

Adds an embedded-postgres integration test (same harness the rest of the repo uses) that:
- Inserts a pending outbox row and injects a dispatch that aborts the tx (`SELECT 1/0`, SQLSTATE 25P02) then returns a sentinel error.
- Asserts the row ends up `retrying` / `retries=1` with backoff scheduled, and that the real error surfaces rather than the masking abort error.

Verified it **reproduces the exact production error against the old code** and passes with the fix. Dispatch is extracted behind a small seam so the tx-abort scenario can be driven deterministically; production behavior is unchanged.