### PR TITLE
refactor(testdb): deduplicate trust-auth setup into common/testdb

### DIFF
--- a/cluster-worker/pkg/handler/cluster/main_test.go
+++ b/cluster-worker/pkg/handler/cluster/main_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	adminPool := newAdminPool()
 
-	useGlobalTrustAuth(dataDir, adminPool)
+	testdb.UseGlobalTrustAuth(dataDir, adminPool)
 	testdb.CreateRoles(context.Background(), adminPool)
 
 	if err = setupTemplateDatabaseWithMigrations(adminPool); err != nil {
@@ -220,23 +220,6 @@ func findProjectRoot() string {
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
-}
-
-// useGlobalTrustAuth switches pg_hba.conf to trust auth so the passwordless
-// roles created by testdb.CreateRoles can connect over TCP.
-func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
-	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
-	content, err := os.ReadFile(pgHBAPath) //nolint:gosec // test helper
-	if err != nil {
-		log.Fatalf("failed to read pg_hba.conf: %v", err)
-	}
-	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
-	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil { //nolint:gosec // test helper
-		log.Fatalf("failed to write pg_hba.conf: %v", err)
-	}
-	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
-		log.Fatalf("failed to reload pg_hba.conf: %v", err)
-	}
 }
 
 func newAdminPool() *pgxpool.Pool {

--- a/common/idempotency/main_test.go
+++ b/common/idempotency/main_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 
 	adminPool := newAdminPool()
 
-	useGlobalTrustAuth(dataDir, adminPool)
+	testdb.UseGlobalTrustAuth(dataDir, adminPool)
 	testdb.CreateRoles(context.Background(), adminPool)
 
 	if err = setupTemplateDatabaseWithMigrations(adminPool); err != nil {
@@ -229,21 +229,6 @@ func newAdminPool() *pgxpool.Pool {
 		log.Fatalf("failed to connect to postgres: %v", err)
 	}
 	return pool
-}
-
-func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
-	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
-	content, err := os.ReadFile(pgHBAPath) //nolint:gosec // test helper
-	if err != nil {
-		log.Fatalf("failed to read pg_hba.conf: %v", err)
-	}
-	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
-	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil { //nolint:gosec // test helper
-		log.Fatalf("failed to write pg_hba.conf: %v", err)
-	}
-	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
-		log.Fatalf("failed to reload pg_hba.conf: %v", err)
-	}
 }
 
 func trekApply(projectRoot string) {

--- a/common/testdb/trust.go
+++ b/common/testdb/trust.go
@@ -1,0 +1,32 @@
+package testdb
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// UseGlobalTrustAuth reconfigures the embedded-postgres instance to accept
+// connections without any credential check. The embedded-postgres library
+// hardcodes `initdb -A password`, so `pg_hba.conf` requires password auth for
+// every connection, while the roles created by [CreateRoles] have no password.
+// Intended to be called from TestMain before [CreateRoles]; it terminates the
+// process on failure.
+func UseGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
+	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
+	content, err := os.ReadFile(pgHBAPath) //nolint:gosec // test helper, paths are not user-controlled
+	if err != nil {
+		log.Fatalf("failed to read pg_hba.conf: %v", err)
+	}
+	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
+	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil { //nolint:gosec // test helper
+		log.Fatalf("failed to write pg_hba.conf: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
+		log.Fatalf("failed to reload pg_hba.conf: %v", err)
+	}
+}

--- a/dcim-api/pkg/dcim/main_test.go
+++ b/dcim-api/pkg/dcim/main_test.go
@@ -79,7 +79,7 @@ func TestMain(m *testing.M) {
 	adminPool := newAdminPool()
 	defer adminPool.Close()
 
-	useGlobalTrustAuth(dataDir, adminPool)
+	testdb.UseGlobalTrustAuth(dataDir, adminPool)
 	testdb.CreateRoles(context.Background(), adminPool)
 
 	err = setupTemplateDatabaseWithMigrations(adminPool)
@@ -228,24 +228,6 @@ func newAdminPool() *pgxpool.Pool {
 		log.Fatalf("failed to connect to postgres: %v", err)
 	}
 	return pool
-}
-
-// The embedded-postgres library hardcodes `initdb -A password`, so `pg_hba.conf` requires
-// password auth for every connection. In this function we reconfigure PostgreSQL
-// to use 'trust', which means it will accept connections without any credential check.
-func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
-	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
-	content, err := os.ReadFile(pgHBAPath)
-	if err != nil {
-		log.Fatalf("failed to read pg_hba.conf: %v", err)
-	}
-	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
-	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil {
-		log.Fatalf("failed to write pg_hba.conf: %v", err)
-	}
-	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
-		log.Fatalf("failed to reload pg_hba.conf: %v", err)
-	}
 }
 
 func trekApply(projectRoot string) {

--- a/organization-api/pkg/organization/main_test.go
+++ b/organization-api/pkg/organization/main_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 	adminPool := newAdminPool()
 	defer adminPool.Close()
 
-	useGlobalTrustAuth(dataDir, adminPool)
+	testdb.UseGlobalTrustAuth(dataDir, adminPool)
 	testdb.CreateRoles(context.Background(), adminPool)
 
 	err = setupTemplateDatabaseWithMigrations(adminPool)
@@ -265,25 +265,6 @@ func newAdminPool() *pgxpool.Pool {
 		log.Fatalf("failed to connect to postgres: %v", err)
 	}
 	return pool
-}
-
-// The embedded-postgres library hardcodes `initdb -A password`, so `pg_hba.conf` requires                                                                                                   │
-// password auth for every connection. In this function we reconfigure PostgreSQL
-// to use 'trust', which means it will accept connections without any credential check.
-// By doing this, we don't have to set passwords and use the password when connecting.
-func useGlobalTrustAuth(dataDir string, pool *pgxpool.Pool) {
-	pgHBAPath := filepath.Join(dataDir, "pg_hba.conf")
-	content, err := os.ReadFile(pgHBAPath)
-	if err != nil {
-		log.Fatalf("failed to read pg_hba.conf: %v", err)
-	}
-	updated := strings.ReplaceAll(string(content), " password\n", " trust\n")
-	if err := os.WriteFile(pgHBAPath, []byte(updated), 0o600); err != nil {
-		log.Fatalf("failed to write pg_hba.conf: %v", err)
-	}
-	if _, err := pool.Exec(context.Background(), "SELECT pg_reload_conf()"); err != nil {
-		log.Fatalf("failed to reload pg_hba.conf: %v", err)
-	}
 }
 
 func trekApply(projectRoot string) {


### PR DESCRIPTION
## Summary

Follow-up to #351. The dcim-api, organization-api, common/idempotency, and (since #351) cluster-worker test harnesses each carried their own copy of `useGlobalTrustAuth`. This moves the helper to `common/testdb` as `UseGlobalTrustAuth` and replaces the four copies with a call to it, next to the `CreateRoles` it exists for.

No behavior change: same pg_hba.conf rewrite to trust auth, same reload, called at the same point in each TestMain.

## Test plan

- `go vet` on all five affected packages — clean
- `go test -count=1` on all four harness-dependent packages (cluster-worker handler/cluster, common/idempotency, dcim-api, organization-api) — all pass
- `golangci-lint run --new-from-rev master` — 0 issues