### PR TITLE
fix(frontend): prevent stale index.html after deploy via cache headers

### DIFF
--- a/console-frontend/nginx.conf
+++ b/console-frontend/nginx.conf
@@ -41,6 +41,12 @@ server {
     # Disable access to sensitive browser features not needed by the app
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
+    # Default caching policy: browsers may store responses but must revalidate
+    # before reuse (cheap 304 via ETag). Without an explicit Cache-Control,
+    # browsers apply heuristic freshness and keep serving a stale index.html
+    # after a deploy, which references hashed bundles that no longer exist.
+    add_header Cache-Control "no-cache" always;
+
     # Plugin UI assets: allow embedding in iframes from the same origin
     # nginx add_header in a location block replaces outer headers, so all desired
     # headers must be repeated here. frame-ancestors 'self' replaces 'none', and
@@ -53,19 +59,31 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        # Plugin UI files are not content-hashed, so they must be revalidated
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ =404;
+    }
+
+    # Build output at the root (main-*.js, chunk-*.js, styles-*.css) is
+    # content-hashed (outputHashing "all"), so it can be cached forever. This
+    # deliberately matches root-level files only: /assets/ (config.json) and
+    # /plugin-ui/ contain unhashed files and must keep the no-cache default.
+    # Missing bundles return 404 instead of the SPA index.html fallback, so a
+    # stale index.html can never cache an HTML response under a JS URL.
+    location ~* ^/[^/]+\.(js|css)$ {
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; frame-src 'self' ${CONNECT_SRC}; frame-ancestors 'none'; object-src 'none'; base-uri 'self';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        # No `always`: a 404 for a since-deleted bundle (e.g. a request racing
+        # to an old pod during a rolling deploy) must not be cached for a year
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
     }
 
     # SPA routing: serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;
     }
-
-    # Cache static assets (commented out for development)
-    # Uncomment in production to enable browser caching
-    # TODO: make configurable via env var
-    # location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
-    #     expires 1y;
-    #     add_header Cache-Control "public, immutable";
-    # }
 }

--- a/console-frontend/src/app/app.config.ts
+++ b/console-frontend/src/app/app.config.ts
@@ -6,12 +6,13 @@ import {
   Injector,
   runInInjectionContext,
 } from '@angular/core';
-import { provideRouter, withRouterConfig } from '@angular/router';
+import { provideRouter, withNavigationErrorHandler, withRouterConfig } from '@angular/router';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { BehaviorSubject } from 'rxjs';
 import { AUTHN_TRANSPORT, ORGANIZATION_TRANSPORT } from '../connect/connect.module';
 import EXPECTED_API_VERSION from '../proto-version.gen';
 import routes from './app.routes';
+import { recoverFromChunkLoadError } from './chunk-load-recovery';
 import { ConfigService } from './config.service';
 import OrganizationContextService from './organization-context.service';
 
@@ -30,7 +31,14 @@ const handleVersionMismatch = (serverVersion: string) => {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withRouterConfig({ paramsInheritanceStrategy: 'always' })),
+    provideRouter(
+      routes,
+      withRouterConfig({ paramsInheritanceStrategy: 'always' }),
+      // A deploy replaces the content-hashed bundles, so a tab still running
+      // the old app fails to lazy-load route chunks; recover via a full page
+      // load of the destination url.
+      withNavigationErrorHandler(recoverFromChunkLoadError),
+    ),
     // Initialize configuration before app starts
     provideAppInitializer(() => {
       const configService = inject(ConfigService);

--- a/console-frontend/src/app/chunk-load-recovery.spec.ts
+++ b/console-frontend/src/app/chunk-load-recovery.spec.ts
@@ -1,0 +1,125 @@
+import { NavigationError } from '@angular/router';
+import { isChunkLoadError, recoverFromChunkLoadError } from './chunk-load-recovery';
+
+const fakeStorage = (): Storage => {
+  const items = new Map<string, string>();
+  return {
+    getItem: (key: string) => items.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      items.set(key, value);
+    },
+    removeItem: (key: string) => {
+      items.delete(key);
+    },
+    clear: () => items.clear(),
+    key: () => null,
+    get length() {
+      return items.size;
+    },
+  };
+};
+
+const navigationError = (error: unknown, url = '/clusters/add'): NavigationError =>
+  ({ id: 1, url, error }) as NavigationError;
+
+describe('isChunkLoadError', () => {
+  it('detects Chrome dynamic import failures', () => {
+    expect(
+      isChunkLoadError(
+        new TypeError('Failed to fetch dynamically imported module: https://x/chunk-abc.js'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects Firefox dynamic import failures', () => {
+    expect(isChunkLoadError(new TypeError('error loading dynamically imported module'))).toBe(true);
+  });
+
+  it('detects Safari dynamic import failures', () => {
+    expect(isChunkLoadError(new TypeError('Importing a module script failed.'))).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isChunkLoadError(new Error('route guard rejected'))).toBe(false);
+  });
+
+  it('ignores non-Error values', () => {
+    expect(isChunkLoadError('Failed to fetch dynamically imported module')).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('recoverFromChunkLoadError', () => {
+  const chunkError = () =>
+    new TypeError('Failed to fetch dynamically imported module: https://x/chunk-abc.js');
+
+  it('does a full page navigation to the intended url on a chunk load error', () => {
+    const assign = vi.fn();
+    recoverFromChunkLoadError(navigationError(chunkError(), '/clusters/add'), {
+      storage: fakeStorage(),
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).toHaveBeenCalledExactlyOnceWith('/clusters/add');
+  });
+
+  it('does not navigate on unrelated navigation errors', () => {
+    const assign = vi.fn();
+    recoverFromChunkLoadError(navigationError(new Error('boom')), {
+      storage: fakeStorage(),
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('does not reload again within the loop guard window', () => {
+    const assign = vi.fn();
+    const storage = fakeStorage();
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000,
+    });
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000 + 5_000,
+    });
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads again once the loop guard window has passed', () => {
+    const assign = vi.fn();
+    const storage = fakeStorage();
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000,
+    });
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000 + 60_000,
+    });
+    expect(assign).toHaveBeenCalledTimes(2);
+  });
+
+  it('still navigates when session storage is unavailable', () => {
+    const assign = vi.fn();
+    const broken = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {
+        throw new Error('storage disabled');
+      },
+    } as unknown as Storage;
+    recoverFromChunkLoadError(navigationError(chunkError(), '/clusters/add'), {
+      storage: broken,
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).toHaveBeenCalledExactlyOnceWith('/clusters/add');
+  });
+});

--- a/console-frontend/src/app/chunk-load-recovery.ts
+++ b/console-frontend/src/app/chunk-load-recovery.ts
@@ -1,0 +1,56 @@
+import { NavigationError } from '@angular/router';
+
+// Browser-specific messages for a failed dynamic import() (Chrome, Firefox,
+// Safari respectively). Thrown when a lazy route chunk no longer exists on the
+// server, i.e. a deploy replaced the content-hashed bundles while this tab was
+// still running the previous version of the app.
+const CHUNK_LOAD_ERROR_PATTERN =
+  /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i;
+
+const RELOADED_AT_KEY = 'chunk-load-recovery:reloaded-at';
+
+// Allow at most one forced reload per window, so a persistently broken server
+// results in a normal navigation error instead of a reload loop.
+const RELOAD_LOOP_WINDOW_MS = 30_000;
+
+export const isChunkLoadError = (error: unknown): boolean =>
+  error instanceof Error && CHUNK_LOAD_ERROR_PATTERN.test(error.message);
+
+interface RecoveryDeps {
+  storage: Storage;
+  assign: (url: string) => void;
+  now: () => number;
+}
+
+// Recover from a navigation that failed because its lazy chunk is gone: leave
+// the stale app via a full page load of the url the user was navigating to.
+// This only ever replaces a navigation the user already initiated, so no
+// in-page state is lost that the route change would not have discarded anyway.
+export const recoverFromChunkLoadError = (
+  event: NavigationError,
+  deps?: Partial<RecoveryDeps>,
+): void => {
+  const { storage, assign, now }: RecoveryDeps = {
+    storage: window.sessionStorage,
+    assign: (url) => window.location.assign(url),
+    now: () => Date.now(),
+    ...deps,
+  };
+
+  if (!isChunkLoadError(event.error)) {
+    return;
+  }
+
+  try {
+    const reloadedAt = Number(storage.getItem(RELOADED_AT_KEY) ?? 0);
+    if (now() - reloadedAt < RELOAD_LOOP_WINDOW_MS) {
+      return;
+    }
+    storage.setItem(RELOADED_AT_KEY, String(now()));
+  } catch {
+    // Storage being unavailable should not prevent recovery; without the loop
+    // guard the worst case is periodic reloads while the server stays broken.
+  }
+
+  assign(event.url);
+};

--- a/dcim-frontend/nginx.conf
+++ b/dcim-frontend/nginx.conf
@@ -6,11 +6,34 @@ server {
 
     add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';" always;
 
+    # Default caching policy: browsers may store responses but must revalidate
+    # before reuse (cheap 304 via ETag). Without an explicit Cache-Control,
+    # browsers apply heuristic freshness and keep serving a stale index.html
+    # after a deploy, which references hashed bundles that no longer exist.
+    add_header Cache-Control "no-cache" always;
+
+    # Build output at the root (main-*.js, chunk-*.js, styles-*.css) is
+    # content-hashed (outputHashing "all"), so it can be cached forever. This
+    # deliberately matches root-level files only: /assets/ (config.json)
+    # contains unhashed files and must keep the no-cache default. Missing
+    # bundles return 404 instead of the SPA index.html fallback, so a stale
+    # index.html can never cache an HTML response under a JS URL.
+    # nginx add_header in a location block replaces outer headers, so the CSP
+    # header must be repeated here.
+    location ~* ^/[^/]+\.(js|css)$ {
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';" always;
+        # No `always`: a 404 for a since-deleted bundle (e.g. a request racing
+        # to an old pod during a rolling deploy) must not be cached for a year
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }
 
     location /assets/config/ {
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';" always;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 }

--- a/dcim-frontend/src/app/app.config.ts
+++ b/dcim-frontend/src/app/app.config.ts
@@ -4,16 +4,23 @@ import {
   provideAppInitializer,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withNavigationErrorHandler } from '@angular/router';
 
 import routes from './app.routes';
+import { recoverFromChunkLoadError } from './chunk-load-recovery';
 import { ConfigService } from './config.service';
 import AuthService from './auth.service';
 
 const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes),
+    provideRouter(
+      routes,
+      // A deploy replaces the content-hashed bundles, so a tab still running
+      // the old app fails to lazy-load route chunks; recover via a full page
+      // load of the destination url.
+      withNavigationErrorHandler(recoverFromChunkLoadError),
+    ),
     provideAppInitializer(async () => {
       const config = inject(ConfigService);
       const auth = inject(AuthService);

--- a/dcim-frontend/src/app/chunk-load-recovery.spec.ts
+++ b/dcim-frontend/src/app/chunk-load-recovery.spec.ts
@@ -1,0 +1,125 @@
+import { NavigationError } from '@angular/router';
+import { isChunkLoadError, recoverFromChunkLoadError } from './chunk-load-recovery';
+
+const fakeStorage = (): Storage => {
+  const items = new Map<string, string>();
+  return {
+    getItem: (key: string) => items.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      items.set(key, value);
+    },
+    removeItem: (key: string) => {
+      items.delete(key);
+    },
+    clear: () => items.clear(),
+    key: () => null,
+    get length() {
+      return items.size;
+    },
+  };
+};
+
+const navigationError = (error: unknown, url = '/devices'): NavigationError =>
+  ({ id: 1, url, error }) as NavigationError;
+
+describe('isChunkLoadError', () => {
+  it('detects Chrome dynamic import failures', () => {
+    expect(
+      isChunkLoadError(
+        new TypeError('Failed to fetch dynamically imported module: https://x/chunk-abc.js'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects Firefox dynamic import failures', () => {
+    expect(isChunkLoadError(new TypeError('error loading dynamically imported module'))).toBe(true);
+  });
+
+  it('detects Safari dynamic import failures', () => {
+    expect(isChunkLoadError(new TypeError('Importing a module script failed.'))).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isChunkLoadError(new Error('route guard rejected'))).toBe(false);
+  });
+
+  it('ignores non-Error values', () => {
+    expect(isChunkLoadError('Failed to fetch dynamically imported module')).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('recoverFromChunkLoadError', () => {
+  const chunkError = () =>
+    new TypeError('Failed to fetch dynamically imported module: https://x/chunk-abc.js');
+
+  it('does a full page navigation to the intended url on a chunk load error', () => {
+    const assign = vi.fn();
+    recoverFromChunkLoadError(navigationError(chunkError(), '/devices'), {
+      storage: fakeStorage(),
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).toHaveBeenCalledExactlyOnceWith('/devices');
+  });
+
+  it('does not navigate on unrelated navigation errors', () => {
+    const assign = vi.fn();
+    recoverFromChunkLoadError(navigationError(new Error('boom')), {
+      storage: fakeStorage(),
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('does not reload again within the loop guard window', () => {
+    const assign = vi.fn();
+    const storage = fakeStorage();
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000,
+    });
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000 + 5_000,
+    });
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads again once the loop guard window has passed', () => {
+    const assign = vi.fn();
+    const storage = fakeStorage();
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000,
+    });
+    recoverFromChunkLoadError(navigationError(chunkError()), {
+      storage,
+      assign,
+      now: () => 1_000_000 + 60_000,
+    });
+    expect(assign).toHaveBeenCalledTimes(2);
+  });
+
+  it('still navigates when session storage is unavailable', () => {
+    const assign = vi.fn();
+    const broken = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {
+        throw new Error('storage disabled');
+      },
+    } as unknown as Storage;
+    recoverFromChunkLoadError(navigationError(chunkError(), '/devices'), {
+      storage: broken,
+      assign,
+      now: () => 1_000_000,
+    });
+    expect(assign).toHaveBeenCalledExactlyOnceWith('/devices');
+  });
+});

--- a/dcim-frontend/src/app/chunk-load-recovery.ts
+++ b/dcim-frontend/src/app/chunk-load-recovery.ts
@@ -1,0 +1,56 @@
+import { NavigationError } from '@angular/router';
+
+// Browser-specific messages for a failed dynamic import() (Chrome, Firefox,
+// Safari respectively). Thrown when a lazy route chunk no longer exists on the
+// server, i.e. a deploy replaced the content-hashed bundles while this tab was
+// still running the previous version of the app.
+const CHUNK_LOAD_ERROR_PATTERN =
+  /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i;
+
+const RELOADED_AT_KEY = 'chunk-load-recovery:reloaded-at';
+
+// Allow at most one forced reload per window, so a persistently broken server
+// results in a normal navigation error instead of a reload loop.
+const RELOAD_LOOP_WINDOW_MS = 30_000;
+
+export const isChunkLoadError = (error: unknown): boolean =>
+  error instanceof Error && CHUNK_LOAD_ERROR_PATTERN.test(error.message);
+
+interface RecoveryDeps {
+  storage: Storage;
+  assign: (url: string) => void;
+  now: () => number;
+}
+
+// Recover from a navigation that failed because its lazy chunk is gone: leave
+// the stale app via a full page load of the url the user was navigating to.
+// This only ever replaces a navigation the user already initiated, so no
+// in-page state is lost that the route change would not have discarded anyway.
+export const recoverFromChunkLoadError = (
+  event: NavigationError,
+  deps?: Partial<RecoveryDeps>,
+): void => {
+  const { storage, assign, now }: RecoveryDeps = {
+    storage: window.sessionStorage,
+    assign: (url) => window.location.assign(url),
+    now: () => Date.now(),
+    ...deps,
+  };
+
+  if (!isChunkLoadError(event.error)) {
+    return;
+  }
+
+  try {
+    const reloadedAt = Number(storage.getItem(RELOADED_AT_KEY) ?? 0);
+    if (now() - reloadedAt < RELOAD_LOOP_WINDOW_MS) {
+      return;
+    }
+    storage.setItem(RELOADED_AT_KEY, String(now()));
+  } catch {
+    // Storage being unavailable should not prevent recovery; without the loop
+    // guard the worst case is periodic reloads while the server stays broken.
+  }
+
+  assign(event.url);
+};

--- a/docs-frontend/nginx.conf
+++ b/docs-frontend/nginx.conf
@@ -13,17 +13,24 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Default caching policy: browsers may store responses but must revalidate
+    # before reuse (cheap 304 via ETag). Without an explicit Cache-Control,
+    # browsers apply heuristic freshness and keep serving stale HTML after a
+    # deploy, which references hashed assets that no longer exist.
+    add_header Cache-Control "no-cache" always;
+
+    # Astro content-hashes everything under /_astro/, so it can be cached
+    # forever. Missing assets return 404 instead of the index.html fallback.
+    location /_astro/ {
+        # No `always`: a 404 for a since-deleted asset (e.g. a request racing
+        # to an old pod during a rolling deploy) must not be cached for a year
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     # Serve files and directories without trailing slash redirects
     # Try: exact file -> directory/index.html -> directory/ -> fallback to site root index.html
     location / {
         try_files $uri $uri/index.html $uri/ /index.html;
     }
-
-    # Cache static assets (commented out for development)
-    # Uncomment in production to enable browser caching
-    # TODO: make configurable via env var
-    # location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
-    #     expires 1y;
-    #     add_header Cache-Control "public, immutable";
-    # }
 }


### PR DESCRIPTION
## Problem

On first load after a deploy the console breaks: the browser serves a cached `index.html` that references old content-hashed bundles (`chunk-XXXX.js`) that no longer exist in the new image.

Root cause: none of the frontend nginx configs set `Cache-Control` (the caching block was commented out with a TODO). nginx still sends `Last-Modified`/`ETag`, so browsers apply *heuristic* freshness (~10% of the file's age) and reuse the cached `index.html` **without revalidating**. It gets worse: the SPA fallback `try_files ... /index.html` answers the missing-bundle requests with a 200 + HTML instead of a 404, so the browser tries to execute HTML as a JS module ("Unexpected token '<'") and can even cache that HTML under the JS URL.

## Fix 1: cache headers (nginx)

Applied to `console-frontend`, `dcim-frontend`, and `docs-frontend` nginx configs (all shared the flaw):

- **`Cache-Control: no-cache` by default** — browsers may store but must revalidate before reuse; the existing ETag makes that a cheap 304, and a fresh `index.html` is guaranteed on every load.
- **1-year `immutable` caching for content-hashed build output** — root-level `*.js`/`*.css` for the Angular apps (`outputHashing: all`), `/_astro/` for the Astro docs. Scoped so unhashed files (`/assets/config/config.json`, `/plugin-ui/`) keep the no-cache default.
- **404 for missing bundles** instead of the index.html SPA fallback, so stale HTML can never be cached under a JS URL.
- The immutable header deliberately omits `always` so a bundle 404 (e.g. a request racing to an old pod during a rolling deploy) is not cached for a year.
- Security headers are repeated in the new location blocks (nginx `add_header` in a location replaces all inherited headers).

## Fix 2: recover open tabs from failed chunk loads (Angular)

A tab that was already open *during* the deploy still runs the old app and fails to lazy-load route chunks (the old hashed files are gone). New `chunk-load-recovery.ts` in `console-frontend` (demo build inherits via `appConfig`) and `dcim-frontend`, wired via `withNavigationErrorHandler`:

- Detects dynamic-import failures (Chrome/Firefox/Safari message variants) on navigation errors and does a full page load of the **destination** url, landing the user on the new version at the route they wanted.
- **No data loss beyond normal navigation**: the reload only ever replaces a navigation the user already initiated — in-page form state would have been discarded by the route change anyway. There is never a spontaneous mid-edit reload.
- A sessionStorage timestamp allows at most one forced reload per 30 s, so a persistently broken server surfaces a normal navigation error instead of a reload loop.

## Verification

nginx: ran each config in `nginx:alpine` with a fake docroot and curled headers:

| Path | Result |
|---|---|
| `/`, SPA routes, `config.json`, `/plugin-ui/*` | `Cache-Control: no-cache`, ETag present |
| existing hashed bundle | `public, max-age=31536000, immutable` |
| missing hashed bundle | `404`, no cache header, no HTML fallback |
| all of the above | all 5 security headers intact |

Angular: TDD'd the recovery module (10 unit tests per app: browser message variants, ignore unrelated errors, loop guard window, storage-unavailable fallback). `ng lint`, `ng test`, and `ng build` pass for both apps — except one **pre-existing** failure in `console-frontend/src/app/app.spec.ts` (`NG0201` missing authn transport provider) that is unrelated: the spec and everything it imports are identical to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
