### PR TITLE
fix(authz): keep OpenFGA and the authz outbox consistent

### DIFF
--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -142,13 +142,16 @@ func (w *Worker) runWithConnection(ctx context.Context) error {
 	w.processBatch(ctx)
 
 	for {
-		notified, err := w.waitForNotification(ctx, conn)
-		if err != nil {
+		// The bool reports whether a NOTIFY arrived (true) or the poll interval
+		// elapsed (false); we drain the outbox on both. Polling matters because
+		// the outbox_notify trigger only fires AFTER INSERT: a row left in
+		// 'retrying' emits no NOTIFY when its retry_after elapses, so without a
+		// timeout-driven pass it would lag forever and trip the consumer's
+		// circuit breaker.
+		if _, err := w.waitForNotification(ctx, conn); err != nil {
 			return err
 		}
-		if notified {
-			w.processBatch(ctx)
-		}
+		w.processBatch(ctx)
 	}
 }
 

--- a/authz-worker/pkg/worker/worker_test.go
+++ b/authz-worker/pkg/worker/worker_test.go
@@ -16,6 +16,74 @@ import (
 	db "github.com/fundament-oss/fundament/authz-worker/pkg/db/gen"
 )
 
+// TestProcessesRetryingRowOnPollTimeoutWithoutNotify verifies the worker drains
+// due 'retrying' rows on its poll-interval timeout, not only when a NOTIFY
+// arrives. The outbox_notify trigger fires AFTER INSERT only, so a row a prior
+// worker instance left in 'retrying' emits no notification when its retry_after
+// elapses. If the worker processed exclusively on NOTIFY, such a row would lag
+// forever and trip organization-api's circuit breaker.
+func TestProcessesRetryingRowOnPollTimeoutWithoutNotify(t *testing.T) {
+	pool := createTestDB(t)
+
+	// Start from an empty outbox so the worker's initial batch has nothing to do
+	// and it parks in waitForNotification.
+	_, err := pool.Exec(t.Context(), `DELETE FROM authz.outbox`)
+	require.NoError(t, err)
+
+	w := &Worker{
+		pool:    pool,
+		queries: db.New(pool),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:     applyDefaults(Config{PollInterval: 50 * time.Millisecond}),
+	}
+	// Dispatch stub that succeeds, so a processed row is marked completed.
+	w.dispatch = func(context.Context, pgx.Tx, *db.Queries, *db.GetAndLockNextOutboxRowRow) error {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- w.runWithConnection(ctx) }()
+
+	require.Eventually(t, w.IsReady, 2*time.Second, 10*time.Millisecond)
+
+	// Insert the row as 'retrying' but not yet due (retry_after far in the
+	// future). The AFTER INSERT notify wakes the worker, but GetAndLockNextOutboxRow
+	// skips it (retry_after > now), so it is not processed yet.
+	var itemID uuid.UUID
+	err = pool.QueryRow(t.Context(),
+		`INSERT INTO authz.outbox (cluster_id, status, retries, retry_after)
+		 VALUES ($1, 'retrying', 1, now() + interval '1 hour') RETURNING id`,
+		seededClusterID,
+	).Scan(&itemID)
+	require.NoError(t, err)
+
+	// Let the insert-triggered batch run and find nothing due, then park again.
+	time.Sleep(150 * time.Millisecond)
+
+	// Make the row due via UPDATE — the outbox_notify trigger is INSERT-only, so
+	// this fires NO notification. The row is now reachable only via the
+	// poll-timeout code path.
+	_, err = pool.Exec(t.Context(),
+		`UPDATE authz.outbox SET retry_after = now() WHERE id = $1`, itemID)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		var status string
+		if err := pool.QueryRow(t.Context(),
+			`SELECT status FROM authz.outbox WHERE id = $1`, itemID,
+		).Scan(&status); err != nil {
+			return false
+		}
+		return status == "completed"
+	}, 3*time.Second, 20*time.Millisecond, "due retrying row must be processed on the poll timeout without a NOTIFY")
+
+	cancel()
+	<-done
+}
+
 // clusterID is seeded by db/testdata/001_0101-content.sql. The outbox row needs
 // a valid FK target; the entity type itself is irrelevant here because dispatch
 // is stubbed out.

--- a/charts/fundament/templates/authz-worker.yaml
+++ b/charts/fundament/templates/authz-worker.yaml
@@ -10,6 +10,18 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ $.Values.authzWorker.replicas }}
+  {{- if $.Values.db.reset }}
+  # Local/dev only (db.reset ⇒ this environment wipes+reseeds and resets OpenFGA
+  # on every deploy). Recreate — not RollingUpdate — so the old pod is torn down
+  # before the new one starts. An overlapping old pod still holds the previous
+  # OpenFGA store/model (resolved from a ConfigMap at pod start) and would write
+  # freshly-seeded outbox rows to the now-deleted store, stranding them and
+  # tripping the consumer's circuit breaker. No overlap, no split-brain; a brief
+  # gap in outbox processing is harmless — rows just queue. Prod keeps the
+  # default RollingUpdate for zero-downtime rollouts.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "fundament.selectorLabels" (dict "root" $ "name" "authz-worker") | nindent 6 }}

--- a/charts/fundament/templates/db-migrations.yaml
+++ b/charts/fundament/templates/db-migrations.yaml
@@ -47,6 +47,15 @@ spec:
               trek apply
               echo "Seeding appstore plugin catalog..."
               psql --single-transaction -v ON_ERROR_STOP=1 -f /data/seed/0101-appstore-catalog.sql
+              {{- if and $.Values.db.reset $.Values.openfga.enabled }}
+              # Reset the OpenFGA datastore here, coupled with the DB reset, so
+              # the two always happen together as one triggered event. OpenFGA no
+              # longer resets itself on pod start, so an unrelated openfga rollout
+              # can't wipe the store out from under an already-synced outbox.
+              echo "Resetting OpenFGA datastore (coupled with the DB reset)..."
+              psql "$OPENFGA_DATASTORE_URI" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+              echo "OpenFGA datastore reset complete."
+              {{- end }}
           env:
             - name: TREK_POSTGRES_HOST
               value: {{ include "fundament.db.host" . }}
@@ -89,4 +98,13 @@ spec:
               value: fundament
             - name: PGSSLMODE
               value: disable
+            {{- if and $.Values.db.reset $.Values.openfga.enabled }}
+            # OpenFGA datastore connection (separate DB on the same cluster), used
+            # only for the coupled reset step above.
+            - name: OPENFGA_DATASTORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: db-fun-openfga
+                  key: uri
+            {{- end }}
 {{- end }}

--- a/charts/fundament/templates/openfga.yaml
+++ b/charts/fundament/templates/openfga.yaml
@@ -88,6 +88,13 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "create", "update", "patch"]
+  {{- if $.Values.db.reset }}
+  # The wait-for-reset init container waits on the db-migrations Job, which owns
+  # the coupled DB + OpenFGA reset (local/dev only).
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -136,11 +143,6 @@ spec:
                 sleep 3
               done
               echo "Database is ready!"
-              {{- if $.Values.db.reset }}
-              echo "Resetting OpenFGA database..."
-              psql "$OPENFGA_DATASTORE_URI" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
-              echo "OpenFGA database reset complete."
-              {{- end }}
           env:
             - name: PGCONNECT_TIMEOUT
               value: "5"
@@ -149,6 +151,25 @@ spec:
                 secretKeyRef:
                   name: {{ $openfgaSecretName }}
                   key: uri
+        {{- if $.Values.db.reset }}
+        # Local/dev only. The OpenFGA datastore reset is owned by the db-migrations
+        # Job (coupled with the app-DB reset) — NOT here — so a plain openfga
+        # rollout never wipes the store. Wait for that reset to finish before
+        # migrating, so openfga recreates its schema against the freshly-reset
+        # datastore. If db-migrations isn't running (a non-reset rollout), the
+        # wait returns immediately and the existing store is preserved.
+        - name: wait-for-reset
+          image: {{ $.Values.images.openfgaSetup }}
+          command:
+            - bash
+            - -c
+            - |
+              set -uo pipefail
+              echo "Waiting for db-migrations (owns the OpenFGA reset) to complete..."
+              kubectl wait --for=condition=complete job/db-migrations \
+                -n {{ $.Release.Namespace }} --timeout=600s \
+                || echo "db-migrations not running; proceeding without a reset."
+        {{- end }}
         - name: migrate
           image: {{ $.Values.openfga.image }}
           args:


### PR DESCRIPTION
In local dev (db.reset), the OpenFGA store could end up empty while the authz outbox showed every row completed, silently breaking authorization. Two independent causes:

1. Decoupled resets. The OpenFGA reset ran in the openfga pod's init container, so it fired on every openfga rollout — independent of the DB reset (a Job). An unrelated openfga roll wiped the store while the outbox kept its completed rows. Move the OpenFGA datastore reset into the db-migrations Job so both datastores reset together, once, only when a reset is actually triggered; openfga no longer wipes itself on rollout. A dev-only wait-for-reset init orders openfga's migrate after the coupled reset.

2. Worker split-brain. During a rollout that also reset OpenFGA, an overlapping old authz-worker pod (holding the previous store/model) wrote freshly-seeded rows to the deleted store, stranding them and tripping organization-api's circuit breaker. Use the Recreate strategy for the worker so there is no overlap, and process the outbox on the poll-interval timeout (not only on NOTIFY, which the outbox_notify trigger emits on INSERT only) so a stranded retrying row self-heals.

All new behavior is gated on db.reset; production rendering is unchanged (RollingUpdate, no coupled reset, no extra RBAC).