### PR TITLE
feat(console): require typing the full slug to delete a cluster or project

### DIFF
--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -653,6 +653,24 @@
   (open)="onDeleteModalOpen()"
   (close)="showDeleteModal.set(false)"
 >
+  <p class="text-sm text-gray-600 dark:text-gray-400">
+    To confirm, type
+    <span
+      class="rounded-md bg-gray-50 px-1.5 py-0.5 font-mono text-gray-900 dark:bg-gray-900 dark:text-white"
+      >{{ deleteConfirmationSlug() }}</span
+    >
+    below.
+  </p>
+  <nldd-spacer size="12"></nldd-spacer>
+  <nldd-form-field label="Cluster to delete">
+    <nldd-text-field
+      id="deleteConfirmation"
+      [value]="deleteConfirmationInput()"
+      [attr.placeholder]="deleteConfirmationSlug()"
+      (input)="onDeleteConfirmationInput($event)"
+    ></nldd-text-field>
+  </nldd-form-field>
+
   @if (errorMessage()) {
     <nldd-spacer size="24"></nldd-spacer>
     <div
@@ -679,5 +697,6 @@
     (click)="deleteCluster()"
     text="Delete cluster"
     variant="destructive"
+    [disabled]="!isDeleteConfirmed()"
   ></nldd-button>
 </nldd-modal-dialog>

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -396,7 +396,32 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   getNodePoolStatusLabel = getNodePoolStatusLabel;
 
+  deleteConfirmationInput = signal<string>('');
+
+  /**
+   * The full slug ("orgname/clustername") the user must type to confirm deletion.
+   * Empty until both parts are known, so a partial slug can never be confirmed.
+   */
+  deleteConfirmationSlug(): string {
+    const orgName = this.organizationDataService.organizations()[0]?.name;
+    const clusterName = this.clusterData.basics.name;
+    if (!orgName || !clusterName) return '';
+    return `${orgName}/${clusterName}`;
+  }
+
+  isDeleteConfirmed(): boolean {
+    const slug = this.deleteConfirmationSlug();
+    return slug !== '' && this.deleteConfirmationInput().trim() === slug;
+  }
+
+  onDeleteConfirmationInput(event: Event): void {
+    this.deleteConfirmationInput.set((event as CustomEvent<{ value: string }>).detail.value);
+  }
+
   async deleteCluster(): Promise<void> {
+    if (!this.isDeleteConfirmed()) {
+      return;
+    }
     try {
       const request = create(DeleteClusterRequestSchema, {
         clusterId: this.clusterData.basics.id,
@@ -490,6 +515,7 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   onDeleteModalOpen(): void {
     this.errorMessage.set(null);
+    this.deleteConfirmationInput.set('');
     const el = this.deleteDialogRef()?.nativeElement;
     if (el) focusFirstModalInput(el);
   }

--- a/console-frontend/src/app/project-detail/project-detail.component.html
+++ b/console-frontend/src/app/project-detail/project-detail.component.html
@@ -158,6 +158,24 @@
   (open)="onDeleteModalOpen()"
   (close)="showDeleteModal.set(false)"
 >
+  <p class="text-sm text-gray-600 dark:text-gray-400">
+    To confirm, type
+    <span
+      class="rounded-md bg-gray-50 px-1.5 py-0.5 font-mono text-gray-900 dark:bg-gray-900 dark:text-white"
+      >{{ deleteConfirmationSlug() }}</span
+    >
+    below.
+  </p>
+  <nldd-spacer size="12"></nldd-spacer>
+  <nldd-form-field label="Project to delete">
+    <nldd-text-field
+      id="deleteConfirmation"
+      [value]="deleteConfirmationInput()"
+      [attr.placeholder]="deleteConfirmationSlug()"
+      (input)="onDeleteConfirmationInput($event)"
+    ></nldd-text-field>
+  </nldd-form-field>
+
   <nldd-button
     slot="actions"
     type="button"
@@ -171,5 +189,6 @@
     (click)="deleteProject()"
     text="Delete project"
     variant="destructive"
+    [disabled]="!isDeleteConfirmed()"
   ></nldd-button>
 </nldd-modal-dialog>

--- a/console-frontend/src/app/project-detail/project-detail.component.ts
+++ b/console-frontend/src/app/project-detail/project-detail.component.ts
@@ -187,9 +187,34 @@ export default class ProjectDetailComponent implements OnInit {
     }
   }
 
+  deleteConfirmationInput = signal<string>('');
+
+  /**
+   * The full slug ("orgname/clustername/projectname") the user must type to confirm deletion.
+   * Empty until all parts are known, so a partial slug can never be confirmed.
+   */
+  deleteConfirmationSlug(): string {
+    const orgName = this.organizationDataService.organizations()[0]?.name;
+    const currentProject = this.project();
+    if (!orgName || !currentProject) return '';
+    const clusterName = this.clusters().find((c) => c.id === currentProject.clusterId)?.name;
+    if (!clusterName) return '';
+    return `${orgName}/${clusterName}/${currentProject.name}`;
+  }
+
+  isDeleteConfirmed(): boolean {
+    const slug = this.deleteConfirmationSlug();
+    return slug !== '' && this.deleteConfirmationInput().trim() === slug;
+  }
+
+  onDeleteConfirmationInput(event: Event): void {
+    this.deleteConfirmationInput.set((event as CustomEvent<{ value: string }>).detail.value);
+  }
+
   async deleteProject() {
     const currentProject = this.project();
     if (!currentProject) return;
+    if (!this.isDeleteConfirmed()) return;
 
     try {
       const request = create(DeleteProjectRequestSchema, {
@@ -222,6 +247,7 @@ export default class ProjectDetailComponent implements OnInit {
   deleteDialogRef = viewChild<ElementRef<HTMLElement>>('deleteDialog');
 
   onDeleteModalOpen(): void {
+    this.deleteConfirmationInput.set('');
     const el = this.deleteDialogRef()?.nativeElement;
     if (el) focusFirstModalInput(el);
   }


### PR DESCRIPTION
Adds a type-to-confirm step to the destructive delete modals in the console:

- **Cluster deletion** requires typing `orgname/clustername`.
- **Project deletion** requires typing `orgname/clustername/projectname` (three parts, since project names are only unique per cluster).

The required slug is shown in the modal in monospace, the delete button stays disabled until the input matches exactly (whitespace-trimmed), and the delete methods also guard on the match. The input resets each time the modal opens.

This is a frontend-only safeguard — the API is unchanged. The goal is to make the user consciously aware of *which* resource they are deleting, not to add server-side safety.