### PR TITLE
feat(plugin-sdk): k8s write verbs and controller-runtime logging

### DIFF
--- a/console-frontend/src/plugin-sdk/plugin-sdk.spec.ts
+++ b/console-frontend/src/plugin-sdk/plugin-sdk.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** The host handshake the SDK waits for before any k8s call resolves. */
+function sendInit(): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window,
+      origin: window.location.origin,
+      data: {
+        type: 'fundament:init',
+        protocolVersion: 1,
+        theme: 'light',
+        pluginName: 'ceph-rook',
+        crdKind: 'StoragePool',
+        view: 'detail',
+        kubeApiProxyUrl: 'https://proxy.example/kube',
+        clusterId: 'cluster-1',
+        token: 'test-token',
+        tokenExpiresAt: Date.now() + 600_000,
+      },
+    }),
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const POOL = {
+  group: 'storage.fundament.io',
+  version: 'v1alpha1',
+  resource: 'storagepools',
+  name: 'test-pool',
+};
+
+describe('plugin-sdk k8s write verbs', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+    vi.stubGlobal('fetch', fetchMock);
+    await import('./plugin-sdk');
+    sendInit();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('patch sends a merge-patch to the named resource URL', async () => {
+    await window.fundament.k8s.patch(POOL, { spec: { replication: '2' } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(
+      'https://proxy.example/kube/clusters/cluster-1' +
+        '/apis/storage.fundament.io/v1alpha1/storagepools/test-pool',
+    );
+    expect(init.method).toBe('PATCH');
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/merge-patch+json');
+    expect(init.body).toBe(JSON.stringify({ spec: { replication: '2' } }));
+  });
+
+  it('delete sends DELETE with no body', async () => {
+    await window.fundament.k8s.delete(POOL);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/storagepools/test-pool');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('create still sends application/json', async () => {
+    await window.fundament.k8s.create(
+      { group: POOL.group, version: POOL.version, resource: POOL.resource },
+      { metadata: { name: 'p' } },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json');
+  });
+
+  it('surfaces the Kubernetes Status message on a rejected write', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ kind: 'Status', message: 'spec.disks: must not be empty' }, 422),
+    );
+
+    await expect(window.fundament.k8s.patch(POOL, { spec: { disks: [] } })).rejects.toThrow(
+      /must not be empty/,
+    );
+  });
+});

--- a/console-frontend/src/plugin-sdk/plugin-sdk.ts
+++ b/console-frontend/src/plugin-sdk/plugin-sdk.ts
@@ -70,6 +70,10 @@ interface K8sGetArgs extends K8sListArgs {
 
 type K8sCreateArgs = K8sListArgs;
 
+/** Patch and delete both address one named object, so they take K8sGetArgs. */
+type K8sPatchArgs = K8sGetArgs;
+type K8sDeleteArgs = K8sGetArgs;
+
 interface KubeListResult<T = unknown> {
   items: T[];
 }
@@ -102,6 +106,8 @@ interface FundamentSdk {
     list<T = unknown>(args: K8sListArgs): Promise<KubeListResult<T>>;
     get<T = unknown>(args: K8sGetArgs): Promise<T>;
     create<T = unknown>(args: K8sCreateArgs, body: unknown): Promise<T>;
+    patch<T = unknown>(args: K8sPatchArgs, body: unknown): Promise<T>;
+    delete<T = unknown>(args: K8sDeleteArgs): Promise<T>;
   };
   onThemeChange(cb: (theme: Theme) => void): () => void;
 }
@@ -383,9 +389,12 @@ async function readK8sError(response: Response): Promise<string> {
 }
 
 async function k8sRequest<T>(
-  method: 'GET' | 'POST',
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
   args: K8sListArgs & { name?: string },
   body?: unknown,
+  // The apiserver rejects a PATCH sent as application/json, so the caller picks
+  // the media type. Everything else keeps the plain JSON default.
+  contentType = 'application/json',
 ): Promise<T> {
   const ctx = await initPromise;
   const url = buildKubeUrl(ctx, args);
@@ -394,7 +403,7 @@ async function k8sRequest<T>(
     res = await fetchImpl(url, {
       method,
       ...(body !== undefined
-        ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+        ? { headers: { 'Content-Type': contentType }, body: JSON.stringify(body) }
         : {}),
     });
   } catch (err) {
@@ -440,6 +449,15 @@ const sdk: FundamentSdk = {
     },
     create<T = unknown>(args: K8sCreateArgs, body: unknown): Promise<T> {
       return k8sRequest<T>('POST', args, body);
+    },
+    // Merge-patch, not PUT: a plugin form edits spec and must not clobber
+    // status or fields it does not model. Merge semantics also replace arrays
+    // wholesale, which is what a disk selection wants.
+    patch<T = unknown>(args: K8sPatchArgs, body: unknown): Promise<T> {
+      return k8sRequest<T>('PATCH', args, body, 'application/merge-patch+json');
+    },
+    delete<T = unknown>(args: K8sDeleteArgs): Promise<T> {
+      return k8sRequest<T>('DELETE', args);
     },
   },
   onThemeChange(cb) {

--- a/plugin-sdk/pluginruntime/helpers/controllerruntime/reconciler.go
+++ b/plugin-sdk/pluginruntime/helpers/controllerruntime/reconciler.go
@@ -7,14 +7,38 @@ package controllerruntime
 
 import (
 	"fmt"
+	"log/slog"
+	"sync"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+var setLoggerOnce sync.Once
+
+// setDefaultLogger routes controller-runtime's logging into the plugin's slog
+// output.
+//
+// Without this, controller-runtime discards every log line a reconciler emits
+// and prints a stack trace complaining that SetLogger was never called.
+// Anything a plugin reports through log.FromContext -- the usual way a
+// reconciler explains why it could not make progress -- then vanishes, which is
+// the worst possible failure mode for a background loop nobody is watching.
+//
+// It is set here rather than in each plugin's Start because the logger is
+// process-global and every plugin that builds a manager needs it. sync.Once
+// keeps a second SetupManager call from re-registering it.
+func setDefaultLogger() {
+	setLoggerOnce.Do(func() {
+		ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
+	})
+}
+
 // SetupManager creates a controller-runtime manager with the given scheme.
 func SetupManager(scheme *runtime.Scheme, opts *ctrl.Options) (manager.Manager, error) {
+	setDefaultLogger()
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("get kubeconfig: %w", err)

--- a/plugin-sdk/pluginruntime/helpers/controllerruntime/reconciler_test.go
+++ b/plugin-sdk/pluginruntime/helpers/controllerruntime/reconciler_test.go
@@ -1,0 +1,26 @@
+package controllerruntime
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// controller-runtime drops every log line until SetLogger is called, and a
+// reconciler's only way to explain why it could not make progress is
+// log.FromContext. Without this wiring that output goes nowhere.
+func TestSetDefaultLoggerRoutesIntoSlog(t *testing.T) {
+	var buf bytes.Buffer
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	setDefaultLogger()
+	ctrl.Log.Info("reconciler-said-something", "pool", "test-pool")
+
+	assert.Contains(t, buf.String(), "reconciler-said-something")
+	assert.Contains(t, buf.String(), "test-pool")
+}


### PR DESCRIPTION
## What

Adds `patch` and `delete` to the plugin SDK's `k8s` surface, and routes controller-runtime's logging into slog.

## Why

The SDK exposed only `list`/`get`/`create`, so no plugin console page could edit or delete a resource. The server side was already capable — `kubereq.inferVerb` maps `PUT`/`PATCH`/`DELETE` and the proxy has no method allowlist, with every request authorised as a user SubjectAccessReview intersected with the plugin ServiceAccount's RBAC. Only the client was missing.

Separately, `SetupManager` never called `ctrl.SetLogger`, so every reconciler log line was discarded and controller-runtime printed a stack trace about it. Anything a plugin reported through `log.FromContext` vanished — the worst failure mode for a background loop nobody watches.

## Decisions

- **Merge-patch, not PUT.** A form edits `spec` and must not clobber `status` or fields it does not model; merge semantics also replace arrays wholesale, which is what a disk selection wants. `k8sRequest` therefore takes a content type, since it previously hardcoded `application/json` for any body and the apiserver rejects a PATCH sent that way.
- **PUT is deliberately absent.** It would need `resourceVersion` threading for optimistic concurrency and nothing needs that yet. Concurrent edits are last-write-wins.
- **The logger is set in the helper, not each plugin's `Start`**, because it is process-global and every plugin building a manager needs it. `sync.Once` guards re-registration.

## Test plan

- `bun run test -- --include src/plugin-sdk/plugin-sdk.spec.ts` — 4 new tests covering URL construction, the merge-patch content type, `delete` sending no body, `create` still sending `application/json`, and `readK8sError` surfacing a `Status.message` on a 422.
- `bun x tsc -p tsconfig.app.json --noEmit` — clean.
- `go test ./plugin-sdk/...` — green, including a new test asserting `ctrl.Log` output reaches a slog handler.

Adds the first test file for `plugin-sdk.ts`. The module exports nothing and assigns `window.fundament` on import, so the tests drive it the way the host does: import, dispatch a synthetic `fundament:init`, assert on a stubbed `fetch`.

Note: `src/app/app.spec.ts` fails on this branch, but it fails identically on an unmodified `master` checkout — a pre-existing Angular DI gap (`No provider found for InjectionToken connect.transport.authn`), untouched by this PR.

## Consumed by

The ceph-rook console work on `feat/storage-plugin-ceph-rook`, which needs `patch` for pool editing and `delete` for pool removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)