### PR TITLE
feat(k3d): loop-backed block devices

### DIFF
--- a/deploy/k3d/storage-disks.sh
+++ b/deploy/k3d/storage-disks.sh
@@ -1,0 +1,563 @@
+#!/usr/bin/env bash
+# Loop-backed block devices for a k3d cluster, so Rook Ceph has raw devices to
+# consume: its only OSD backend is BlueStore, which writes to a block device.
+#
+#   file  --losetup-->  /dev/loopN  --GPT-->  /dev/loopNp1  -->  one Ceph OSD
+#
+#     /var/lib/docker/volumes/<vol>/_data/osdN.img   backing file
+#       -> /dev/loopN, /dev/loopNp1                  kernel loop device
+#         -> k3d node container (/dev is bind-mounted in, live)
+#           -> Rook OSD pod (hostPath /dev)
+#
+# Run without arguments for the commands. See docs/developer/fundament/k3d-block-devices.md for the
+# workflow, persistence and cleanup.
+#
+# TODO: single-node only, and the sandbox (servers:1/agents:0) is why it works.
+# reset, doctor, status and attach all inspect $NODE alone, and k3d-config.yaml
+# binds /dev with nodeFilters [server:0]. To widen: enumerate nodes via
+# `docker ps --filter label=k3d.cluster=$CLUSTER` and set nodeFilters to `all`.
+# Loop devices are global kernel objects, so every node sees every disk anyway.
+set -euo pipefail
+
+CLUSTER="${CLUSTER:-fundament-plugin}"
+DISK_COUNT="${DISK_COUNT:-3}"
+DISK_SIZE="${DISK_SIZE:-20G}"
+DISK_VOLUME="${DISK_VOLUME:-fundament-k3d-disks}"
+HELPER_IMAGE="${HELPER_IMAGE:-alpine:3.21}"
+
+NODE="k3d-${CLUSTER}-server-0"
+NATIVE="${NATIVE:-0}"
+ALLOW_BARE_METAL="${ALLOW_BARE_METAL:-0}"
+ROOK_NS="${ROOK_NS:-rook-ceph}"
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m /!\\\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERR\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Loop devices live in the kernel the Docker daemon runs on: the VM on macOS, the
+# machine itself on Linux. --pid=host enters that kernel's PID 1. --native is for
+# rootless Docker, where the container's PID 1 is not the host's.
+host_exec() {
+    if [ "$NATIVE" = 1 ]; then
+        sudo sh -s
+    else
+        docker run --rm -i --privileged --pid=host "$HELPER_IMAGE" \
+            nsenter -t 1 -m -u -i -n sh -s
+    fi
+}
+
+# A Docker volume puts the backing files on the Docker data disk, where a backend
+# keeps its bulk storage; /var/lib would land on the much smaller root fs.
+disk_dir() {
+    docker volume create "$DISK_VOLUME" >/dev/null
+    docker volume inspect "$DISK_VOLUME" --format '{{.Mountpoint}}'
+}
+
+require_docker() {
+    command -v docker >/dev/null || die "docker not found"
+    docker info >/dev/null 2>&1 || die "Docker daemon not reachable"
+}
+
+# True when this machine has ever had loop-backed disks attached: the volume is
+# created by `attach` and survives everything short of `purge`.
+#
+# The drain/uncordon hooks run on every cluster-start and cluster-stop, including
+# for people who never touch storage. This cheap local query is what stops them
+# spinning up a privileged helper container every time.
+disks_present() {
+    docker volume inspect "$DISK_VOLUME" >/dev/null 2>&1
+}
+
+# True when the Docker endpoint is a local socket rather than a remote host.
+# DOCKER_HOST wins because it overrides the active context.
+docker_daemon_is_local() {
+    local ep="${DOCKER_HOST:-}"
+    [ -n "$ep" ] || ep="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)"
+    case "$ep" in
+        ""|unix://*|npipe://*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# The Docker host's virtualisation technology, "none" for bare metal, "unknown"
+# when nothing answers. Probed inside the host, not here: DOCKER_HOST can point
+# elsewhere, and a Mac driving a remote bare-metal box must still refuse.
+host_virt() {
+    local virt
+    virt="$(printf '%s\n' '
+        if command -v systemd-detect-virt >/dev/null 2>&1; then
+            systemd-detect-virt 2>/dev/null || echo none
+        elif [ -r /sys/class/dmi/id/product_name ]; then
+            case "$(cat /sys/class/dmi/id/product_name)" in
+                *Virtual*|*VMware*|*KVM*|*QEMU*|*Hyper-V*) echo vm ;;
+                *) echo none ;;
+            esac
+        # Neither probe fires on an aarch64 guest: no SMBIOS/DMI to read, and
+        # the minimal guests these backends ship have no systemd -- i.e. every
+        # Docker backend on Apple Silicon. The device tree names the hypervisor,
+        # and a virtio bus only exists under paravirtualisation.
+        elif grep -qaiE "qemu|kvm|virt|apple|orbstack" /proc/device-tree/compatible 2>/dev/null; then
+            echo device-tree
+        elif [ -n "$(ls -A /sys/bus/virtio/devices 2>/dev/null)" ]; then
+            echo virtio
+        else
+            echo unknown
+        fi
+    ' | host_exec | tr -d '[:space:]')"
+
+    # Last resort: macOS cannot run Linux containers without a VM. Trusted only
+    # for a local daemon, and only after the in-guest probes are inconclusive.
+    if [ "$virt" = unknown ] && [ "$(uname -s)" = Darwin ] && docker_daemon_is_local; then
+        virt=macos
+    fi
+    printf '%s\n' "$virt"
+}
+
+# Ceph in k3d puts block devices and their kernel threads in the Docker host's
+# kernel. On a VM a mistake costs a restart; on a workstation an RBD mapping can
+# wedge unkillably and the privileged node enumerates the real drives. Rook:
+# "Never use your host system where local devices may mistakenly be consumed."
+require_vm() {
+    local virt; virt="$(host_virt)"
+    case "$virt" in
+        none|unknown) ;;
+        *) log "Docker host is a VM ($virt) -- mistakes are contained to it"; return 0 ;;
+    esac
+    [ "$ALLOW_BARE_METAL" = 1 ] && {
+        warn "bare-metal Docker host, continuing because ALLOW_BARE_METAL is set"
+        return 0
+    }
+    cat >&2 <<EOF
+
+  ####################################################################
+  #  REFUSING: the Docker host is not a virtual machine              #
+  ####################################################################
+
+  Detected: $virt. Every device, filesystem and kernel thread Ceph
+  creates lands in THIS machine's kernel.
+
+    * a stuck RBD mapping is an unkillable kernel thread, and unless
+      the StorageClass bounds its I/O the only recovery is a reboot
+    * the k3d node is privileged and sees your real disks
+
+  Rook's own guidance: "Always use a virtual machine when testing
+  Rook. Never use your host system where local devices may mistakenly
+  be consumed."
+
+  Run Docker inside a VM, which is what macOS already does. If you
+  accept the risk on this machine:
+
+      ALLOW_BARE_METAL=1 $0 ${args[*]}
+      just storage-disks --allow-bare-metal <command>
+
+EOF
+    exit 1
+}
+
+# Whether the host kernel has a module, loading it if not. A command so
+# rook-smoke.sh can decide what it can test: rbd maps block devices, ceph mounts
+# CephFS, and a kernel can ship one without the other (OrbStack has no ceph).
+has_module() {
+    [ -n "${1:-}" ] || die "usage: has-module <name>"
+    printf '%s\n' "[ -d /sys/module/$1 ] || modprobe $1 2>/dev/null" | host_exec >/dev/null 2>&1
+}
+
+doctor() {
+    require_docker
+    local dir; dir="$(disk_dir)"
+    log "Docker host kernel"
+    local kernel
+    kernel="$(printf '%s\n' "
+        echo \"  kernel:  \$(uname -r)  \$(uname -m)\"
+        for m in rbd ceph libceph loop; do
+            if [ -d /sys/module/\$m ]; then s='PRESENT (loaded or built-in)'
+            elif modprobe \$m 2>/dev/null; then s='OK (loaded just now)'
+            else s='MISSING'; fi
+            printf '  %-8s %s\n' \"\$m\" \"\$s\"
+        done
+        if [ -d /run/udev ]; then echo '  udev:    /run/udev present'
+        else echo '  udev:    /run/udev MISSING (ceph-volume may warn)'; fi
+        if command -v sfdisk >/dev/null 2>&1; then echo '  sfdisk:  present'
+        else echo '  sfdisk:  MISSING (partitioning falls back to a container)'; fi
+        echo '  --- space for the OSD images ---'
+        df -h '$dir' 2>/dev/null | tail -1 | sed 's/^/  /'
+    " | host_exec)"
+    printf '%s\n' "$kernel"
+
+    local virt; virt="$(host_virt)"
+    case "$virt" in
+        none)    echo "  host:    BARE METAL -- attach refuses; see docs/developer/fundament/k3d-block-devices.md" ;;
+        unknown) echo "  host:    could not determine whether this is a VM" ;;
+        *)       echo "  host:    virtual machine ($virt)" ;;
+    esac
+
+    log "cluster $CLUSTER"
+    if docker inspect "$NODE" >/dev/null 2>&1; then
+        if docker exec "$NODE" test -d /run/udev; then
+            echo "  /run/udev bound into the node: yes"
+        else
+            echo "  /run/udev bound into the node: NO"
+        fi
+        local devs; devs="$(docker exec "$NODE" sh -c 'ls /dev/loop* 2>/dev/null | tr "\n" " "' || true)"
+        echo "  loop devices visible in the node: ${devs:-none}"
+    else
+        echo "  node container $NODE does not exist"
+    fi
+
+    if printf '%s\n' "$kernel" | grep -qE '^ +rbd +MISSING'; then
+        cat <<'EOF'
+
+  /!\ rbd is MISSING: csi-rbdplugin will CrashLoopBackOff and RBD PVCs will not
+      mount. It fatals at startup, before reading a StorageClass, so
+      `mounter: rbd-nbd` does not help. Ceph itself still runs -- mons, mgr and
+      OSDs do not use the rbd module -- so the plugin's reconcile path stays
+      testable. For working PVCs, use colima.
+EOF
+    fi
+}
+
+# Writes a single GPT partition and waits for the kernel to surface it.
+partition() {
+    local dev="$1"
+    if printf '%s\n' "command -v sfdisk >/dev/null 2>&1" | host_exec; then
+        printf '%s\n' "printf 'label: gpt\n,,\n' | sfdisk '$dev'" | host_exec >/dev/null \
+            || die "sfdisk failed on $dev"
+    else
+        warn "no sfdisk on the Docker host; partitioning $dev in a container"
+        docker run --rm --privileged -v /dev:/dev "$HELPER_IMAGE" sh -c \
+            "apk add --no-cache sfdisk >/dev/null && printf 'label: gpt\n,,\n' | sfdisk $dev >/dev/null" \
+            || die "could not partition $dev -- install util-linux on the Docker host"
+    fi
+    printf '%s\n' "
+        n=0
+        while [ ! -b '${dev}p1' ] && [ \$n -lt 10 ]; do sleep 1; n=\$((n+1)); done
+        [ -b '${dev}p1' ]
+    " | host_exec || die "$dev was partitioned but ${dev}p1 never appeared"
+}
+
+# The OSD device is /dev/loopNp1 (type=part), never the bare /dev/loopN:
+# rook-discover does not report loop devices, so one never reaches the ConfigMap
+# the disk inventory reads. See docs/developer/fundament/k3d-block-devices.md.
+attach() {
+    require_docker
+    require_vm
+    local dir; dir="$(disk_dir)"
+    log "backing files in $DISK_VOLUME ($DISK_COUNT x $DISK_SIZE, sparse)"
+
+    # ceph-csi short-circuits its own modprobe when /sys/module/rbd exists, which
+    # also sidesteps container-side modprobe failures (zstd, module signatures).
+    local loops
+    loops="$(printf '%s\n' "
+        set -e
+        modprobe rbd 2>/dev/null || true
+        modprobe ceph 2>/dev/null || true
+        mkdir -p '$dir'
+        # The host may ship BusyBox losetup (OrbStack, colima do), which has
+        # neither -j nor --show. Both implementations agree that -a prints one
+        # \"/dev/loopN: ...\" line per association ending in the backing file
+        # (util-linux parenthesises it), so associations are found by parsing -a.
+        # 'if', not '[ ] && ...': a failing test as the last command makes the
+        # loop exit non-zero, which under set -e kills the script.
+        loop_for() {
+            losetup -a 2>/dev/null | while IFS= read -r line; do
+                d=\${line%%:*}
+                f=\${line##* }
+                f=\${f%\\)}
+                f=\${f#(}
+                if [ \"\$f\" = \"\$1\" ]; then echo \"\$d\"; break; fi
+            done
+        }
+        i=0
+        while [ \$i -lt '$DISK_COUNT' ]; do
+            img='$dir'/osd\$i.img
+            [ -f \"\$img\" ] || truncate -s '$DISK_SIZE' \"\$img\"
+            dev=\$(loop_for \"\$img\")
+            # An association made without -P never surfaces partitions; redo it.
+            if [ -n \"\$dev\" ] && [ ! -b \"\${dev}p1\" ]; then
+                losetup -d \"\$dev\" 2>/dev/null && dev=''
+            fi
+            if [ -z \"\$dev\" ]; then
+                losetup -P -f \"\$img\"
+                dev=\$(loop_for \"\$img\")
+                [ -n \"\$dev\" ] || { echo \"could not associate \$img\" >&2; exit 1; }
+            fi
+            # The kernel creates partition devices asynchronously after losetup
+            # -P. Deciding too early reports an already-partitioned image as raw
+            # and rewrites its GPT over live OSD data.
+            n=0
+            while [ ! -b \"\${dev}p1\" ] && [ \$n -lt 5 ]; do sleep 1; n=\$((n+1)); done
+            if [ -b \"\${dev}p1\" ]; then echo \"\$dev ready\"; else echo \"\$dev raw\"; fi
+            i=\$((i+1))
+        done
+    " | host_exec)"
+    [ -n "$loops" ] || die "no loop devices were attached"
+
+    # Herestring, not a pipe: must run in the main shell so die works. 'if', not
+    # '[ ] && ...': that leaves exit status 1 when the last device is already
+    # partitioned, and set -e then aborts an idempotent re-attach silently.
+    local dev state
+    while read -r dev state; do
+        if [ "$state" = raw ]; then partition "$dev"; fi
+    done <<<"$loops"
+
+    while read -r dev state; do
+        echo "  ${dev}p1"
+    done <<<"$loops"
+
+    require_node_bind
+}
+
+# Without the bind a node's /dev is a snapshot from container start. Probing for
+# a device inside the node cannot detect that: the snapshot may already hold one,
+# and CSI would still fail later, since it creates /dev/rbdN only on mount. Mount
+# type is no signal either -- a backend whose own /dev is a tmpfs (OrbStack)
+# reports tmpfs either way. Only the container's bind list distinguishes them.
+require_node_bind() {
+    docker inspect "$NODE" >/dev/null 2>&1 || return 0
+    # From the container definition, not from inside: a stopped node cannot be
+    # exec'd into, which is not the same as a node without the bind.
+    docker inspect "$NODE" --format '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' 2>/dev/null \
+        | grep -qx '/dev' && return 0
+    die "$NODE has no /dev bind, so the cluster cannot use these disks.
+      Recreate it: cd plugins && just cluster-delete && just cluster-create-storage"
+}
+
+# Short kernel names of the OSD partitions, one per line. Rook must name devices
+# this way: a k3d node has no /dev/disk/by-id, and rook-discover reports no
+# by-id field at all.
+devices() {
+    require_docker
+    local dir; dir="$(disk_dir)"
+    printf '%s\n' "
+        losetup -a 2>/dev/null | grep -F '$dir' | cut -d: -f1 | sort | while read -r d; do
+            [ -b \"\${d}p1\" ] && echo \"\${d}p1\" | sed 's|/dev/||'
+        done
+        true
+    " | host_exec
+}
+
+status() {
+    require_docker
+    local dir; dir="$(disk_dir)"
+    log "attachments on the Docker host"
+    printf '%s\n' "losetup -a 2>/dev/null | grep -F '$dir' || echo '  (none)'" | host_exec
+    log "block devices in $NODE"
+    if docker inspect "$NODE" >/dev/null 2>&1; then
+        docker exec "$NODE" sh -c 'ls -l /dev/loop* 2>/dev/null || echo "  (none)"'
+    else
+        echo "  node container $NODE does not exist"
+    fi
+}
+
+# Our devices that something still holds, by open fd or mount. Must be answered
+# before detaching: losetup -d on a held device reports success while only
+# flagging autoclear, so trusting its exit status would detach the idle devices
+# and leave the cluster on a half-dismantled set.
+busy_devices() {
+    local dir="$1"
+    printf '%s\n' "
+        devs=\$(losetup -a 2>/dev/null | grep -F '$dir' | cut -d: -f1)
+        [ -n \"\$devs\" ] || exit 0
+        held=\$( { for p in /proc/[0-9]*; do
+                     for f in \"\$p\"/fd/*; do [ -L \"\$f\" ] && readlink \"\$f\"; done
+                   done
+                   cut -d' ' -f1 /proc/self/mounts
+                 } 2>/dev/null | sort -u)
+        for d in \$devs; do
+            for dev in \"\$d\" \"\$d\"p1; do
+                echo \"\$held\" | grep -qx \"\$dev\" && echo \"\$dev\"
+            done
+        done
+        true
+    " | host_exec
+}
+
+detach() {
+    require_docker
+    local dir; dir="$(disk_dir)"
+    local busy; busy="$(busy_devices "$dir")"
+    if [ -n "$busy" ]; then
+        warn "still held by a running process or mount:"
+        printf '%s\n' "$busy" | sed 's/^/      /' >&2
+        warn "stop the Ceph cluster first: deploy/k3d/rook-smoke.sh down"
+        return 1
+    fi
+    log "detaching loop devices for $dir"
+    # The post-check is authoritative: catches refused and deferred detaches.
+    local out rc=0
+    out="$(printf '%s\n' "
+        losetup -a 2>/dev/null | grep -F '$dir' | cut -d: -f1 | while read -r dev; do
+            losetup -d \"\$dev\" 2>/dev/null && echo \"  detached \$dev\" || echo \"  FAILED \$dev\"
+        done
+        losetup -a 2>/dev/null | grep -F '$dir' | sed 's/^/  still attached: /'
+        losetup -a 2>/dev/null | grep -qF '$dir' && exit 1
+        exit 0
+    " | host_exec)" || rc=$?
+    [ -n "$out" ] && printf '%s\n' "$out"
+    if [ "$rc" != 0 ]; then
+        warn "not everything detached"
+        return 1
+    fi
+}
+
+# Consumers must release their volumes while Ceph still runs to service the
+# unmounts -- Rook's documented order. drain waits for the pods to be gone, which
+# forces the teardown, and cordons so nothing reschedules. The selector keeps the
+# Ceph daemons; --ignore-daemonsets is what keeps csi-rbdplugin, which has to be
+# there for NodeUnstageVolume. Skipped entirely when nothing is mapped.
+drain() {
+    command -v docker >/dev/null && docker info >/dev/null 2>&1 || return 0
+    disks_present || return 0
+    local ctx="k3d-$CLUSTER" mapped
+    mapped="$(printf '%s\n' "ls /dev/rbd[0-9]* 2>/dev/null | tr '\\n' ' '" | host_exec 2>/dev/null)" || return 0
+    [ -n "$mapped" ] || return 0
+
+    kubectl --context "$ctx" get node "$NODE" >/dev/null 2>&1 || {
+        warn "$mapped still mapped but $CLUSTER is unreachable, so nothing can unmount it.
+      The node will not stop until you run: just storage-disks unmap-stale"
+        return 0
+    }
+    log "draining Ceph consumers from $NODE"
+    kubectl --context "$ctx" drain "$NODE" \
+        --pod-selector="rook_cluster!=$ROOK_NS" \
+        --ignore-daemonsets --delete-emptydir-data --force --timeout=2m \
+        || warn "drain reported errors; the device check below is what decides"
+
+    local left
+    left="$(printf '%s\n' "ls /dev/rbd[0-9]* 2>/dev/null | tr '\\n' ' '" | host_exec)"
+    [ -z "$left" ] || die "still mapped after draining: $left
+      Something outside this cluster holds a Ceph volume. Stopping now would
+      wedge the Docker host (see docs/developer/fundament/k3d-block-devices.md)."
+    log "no Ceph volumes are mapped; safe to stop"
+}
+
+# After a stop that bypassed the drain, the mapping is what keeps the node
+# container alive: rbd retries its watch registration with no timeout. Removing
+# the device ends it. The write blocks until teardown finishes, so it runs
+# detached and we poll the device list. Needs the workload's I/O already aborted
+# (see the StorageClass mapOptions in rook-smoke.sh) or the freeze never ends.
+unmap_stale() {
+    require_docker
+    # A wedged node stays Status=running, so that cannot tell live from stuck.
+    # exec can: the stuck mapping pins the namespaces, so entering it fails.
+    if docker inspect -f '{{.State.Running}}' "$NODE" 2>/dev/null | grep -qx true &&
+       docker exec "$NODE" true >/dev/null 2>&1; then
+        die "$NODE is live -- unmapping now would pull the device out from
+      under a running workload. Use: just cluster-stop"
+    fi
+    local left
+    left="$(printf '%s\n' "ls /sys/bus/rbd/devices/ 2>/dev/null | tr '\\n' ' '" | host_exec)"
+    [ -n "$left" ] || { log "no stale rbd mappings"; return 0; }
+    log "removing stale rbd mappings: $left"
+    printf '%s\n' '
+        for d in /sys/bus/rbd/devices/*/; do
+            [ -e "$d" ] || continue
+            (echo "${d%/}" | sed "s#.*/##" > /sys/bus/rbd/remove_single_major) &
+        done
+        i=0
+        while [ -n "$(ls /sys/bus/rbd/devices/ 2>/dev/null)" ] && [ $i -lt 60 ]; do
+            sleep 1; i=$((i+1))
+        done
+        echo "  remaining after ${i}s: [$(ls /sys/bus/rbd/devices/ 2>/dev/null | tr "\n" " ")]"
+    ' | host_exec
+    left="$(printf '%s\n' "ls /sys/bus/rbd/devices/ 2>/dev/null | tr '\\n' ' '" | host_exec)"
+    [ -z "$left" ] || die "still mapped: $left
+      Restart the Docker host to clear it (on macOS: colima restart)."
+}
+
+# k3d restart clears the cordon itself; this covers a drain without one.
+uncordon() {
+    command -v docker >/dev/null && docker info >/dev/null 2>&1 || return 0
+    disks_present || return 0
+    local ctx="k3d-$CLUSTER"
+    # Only this path waits for the API server, and only when disks exist.
+    kubectl --context "$ctx" wait --for=condition=Ready node --all --timeout=300s >/dev/null 2>&1 || return 0
+    kubectl --context "$ctx" get node "$NODE" >/dev/null 2>&1 || return 0
+    kubectl --context "$ctx" uncordon "$NODE"
+}
+
+# Removes the disks for good; reset recreates them and detach keeps the files.
+# Detaching first is not optional: deleting an image while its loop device is
+# attached frees no space, since the kernel keeps the inode alive.
+purge() {
+    require_docker
+    detach || die "refusing to delete the images while they are still in use"
+    log "removing the docker volume $DISK_VOLUME"
+    docker volume rm "$DISK_VOLUME" >/dev/null || die "could not remove $DISK_VOLUME"
+    echo "  removed"
+}
+
+# Stale OSD metadata or Rook state under dataDirHostPath is the usual reason a
+# second install attempt fails.
+reset() {
+    require_docker
+    detach || die "refusing to wipe the images while they are still in use"
+    local dir; dir="$(disk_dir)"
+    [ -n "$dir" ] || die "could not resolve the volume mountpoint"
+    log "removing the backing files"
+    printf '%s\n' "rm -f '$dir'/osd*.img; true" | host_exec
+    if docker inspect "$NODE" >/dev/null 2>&1; then
+        log "removing /var/lib/rook in $NODE"
+        docker exec "$NODE" rm -rf /var/lib/rook || true
+    fi
+    attach
+}
+
+usage() {
+    cat <<EOF
+Loop-backed block devices for the k3d cluster '$CLUSTER'.
+
+  doctor    check the kernel Docker actually runs on
+  has-module NAME
+            exit 0 if the Docker host's kernel has (or can load) a module;
+            'rbd' maps block devices, 'ceph' mounts CephFS
+  attach    create + attach the disks (also the post-reboot fix)
+  devices   short kernel names, one per line, for scripts
+  status    what is attached, and what the node can see
+  detach    detach, keep the backing files
+  drain     evict Ceph consumers so the cluster can be stopped safely;
+            does nothing unless a volume is mapped
+  uncordon  undo the cordon that drain leaves
+  unmap-stale
+            drop rbd mappings left by a stop that bypassed the drain
+  reset     wipe the disks and Rook's on-node state, reattach
+  purge     detach and delete the disks for good, freeing the space
+
+All commands are idempotent.
+
+  --native  run host commands via sudo instead of a helper container
+            (rootless Docker, where the container's PID 1 is not the host's)
+  --allow-bare-metal
+            proceed when the Docker host is not a VM. Ceph then runs against
+            this machine's kernel: a stuck RBD mapping needs a reboot, and the
+            privileged node sees your real disks.
+
+Environment: CLUSTER=$CLUSTER DISK_COUNT=$DISK_COUNT DISK_SIZE=$DISK_SIZE
+             DISK_VOLUME=$DISK_VOLUME NATIVE=$NATIVE
+EOF
+}
+
+args=()
+for a in "$@"; do
+    case "$a" in
+        --native) NATIVE=1 ;;
+        --allow-bare-metal) ALLOW_BARE_METAL=1 ;;
+        *) args+=("$a") ;;
+    esac
+done
+
+case "${args[0]:-}" in
+    doctor)  doctor ;;
+    has-module) has_module "${args[1]:-}" ;;
+    attach)  attach ;;
+    devices) devices ;;
+    status)  status ;;
+    detach)  detach ;;
+    drain)     drain ;;
+    uncordon) uncordon ;;
+    unmap-stale) unmap_stale ;;
+    reset)   reset ;;
+    purge)   purge ;;
+    "")      usage ;;
+    *)       printf 'unknown command: %s\n\n' "${args[0]}" >&2; usage >&2; exit 1 ;;
+esac

--- a/deploy/k3d/storage-disks.sh
+++ b/deploy/k3d/storage-disks.sh
@@ -86,7 +86,10 @@ host_virt() {
     local virt
     virt="$(printf '%s\n' '
         if command -v systemd-detect-virt >/dev/null 2>&1; then
-            systemd-detect-virt 2>/dev/null || echo none
+            # On bare metal it prints "none" *and* exits 1, so an "|| echo none"
+            # fallback would emit it twice; only an empty result needs one.
+            v=$(systemd-detect-virt 2>/dev/null) || true
+            echo "${v:-none}"
         elif [ -r /sys/class/dmi/id/product_name ]; then
             case "$(cat /sys/class/dmi/id/product_name)" in
                 *Virtual*|*VMware*|*KVM*|*QEMU*|*Hyper-V*) echo vm ;;
@@ -119,10 +122,12 @@ host_virt() {
 # "Never use your host system where local devices may mistakenly be consumed."
 require_vm() {
     local virt; virt="$(host_virt)"
-    case "$virt" in
-        none|unknown) ;;
-        *) log "Docker host is a VM ($virt) -- mistakes are contained to it"; return 0 ;;
-    esac
+    # "none" is bare metal and "unknown" is a probe that found nothing; every
+    # other value names a hypervisor or a paravirt signal, so it is a VM.
+    if [ "$virt" != none ] && [ "$virt" != unknown ]; then
+        log "Docker host is a VM ($virt) -- mistakes are contained to it"
+        return 0
+    fi
     [ "$ALLOW_BARE_METAL" = 1 ] && {
         warn "bare-metal Docker host, continuing because ALLOW_BARE_METAL is set"
         return 0

--- a/docs/assets/k3d-block-devices.svg
+++ b/docs/assets/k3d-block-devices.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="660" viewBox="0 0 900 660"
+     style="background: #ffffff; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); color-scheme: light dark;">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fg    { fill: light-dark(#111827, #e5e7eb); }
+    .muted { fill: light-dark(#6b7280, #9ca3af); }
+    .mono  { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .panel { fill: light-dark(#f9fafb, #1b2130); stroke: light-dark(#d1d5db, #3b4457); }
+    .host  { fill: light-dark(#eef2ff, #312e81); stroke: #6366f1; }
+    .box   { fill: light-dark(#ffffff, #1f2937); stroke: light-dark(#d1d5db, #3b4457); }
+    .keep  { fill: light-dark(#ecfdf5, #064e3b); stroke: #10b981; }
+    .lose  { fill: light-dark(#fffbeb, #78350f); stroke: #f59e0b; }
+    .keept { fill: light-dark(#047857, #6ee7b7); }
+    .loset { fill: light-dark(#b45309, #fcd34d); }
+    .arrow { stroke: light-dark(#6b7280, #9ca3af); stroke-width: 2; fill: none; }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="light-dark(#6b7280, #9ca3af)"/>
+    </marker>
+  </defs>
+
+  <!-- platform comparison -->
+  <rect class="panel" x="30" y="16" width="400" height="132" rx="8"/>
+  <text class="fg" x="46" y="40" font-size="15" font-weight="600">macOS</text>
+  <text class="muted" x="46" y="60" font-size="12">Docker runs in a VM. Everything below</text>
+  <text class="muted" x="46" y="76" font-size="12">is inside it, never on the Mac filesystem.</text>
+  <rect class="host" x="46" y="88" width="368" height="46" rx="6"/>
+  <text class="fg mono" x="60" y="107" font-size="12.5">colima / Docker Desktop VM</text>
+  <text class="fg" x="60" y="125" font-size="12" font-weight="600">= the Docker host</text>
+
+  <rect class="panel" x="470" y="16" width="400" height="132" rx="8"/>
+  <text class="fg" x="486" y="40" font-size="15" font-weight="600">Linux</text>
+  <text class="muted" x="486" y="60" font-size="12">No VM layer. Same commands, but the</text>
+  <text class="muted" x="486" y="76" font-size="12">disks live on your actual machine.</text>
+  <rect class="host" x="486" y="88" width="368" height="46" rx="6"/>
+  <text class="fg mono" x="500" y="107" font-size="12.5">the machine itself</text>
+  <text class="fg" x="500" y="125" font-size="12" font-weight="600">= the Docker host</text>
+
+  <text class="muted" x="450" y="176" font-size="13" text-anchor="middle">every layer below runs on the Docker host</text>
+
+  <!-- layer stack -->
+  <rect class="box" x="150" y="192" width="470" height="58" rx="6"/>
+  <text class="fg mono" x="168" y="216" font-size="12.5">osd0.img  osd1.img  osd2.img</text>
+  <text class="muted" x="168" y="236" font-size="11.5">docker volume fundament-k3d-disks — sparse files, 20G each</text>
+  <rect class="keep" x="640" y="204" width="230" height="34" rx="17"/>
+  <text class="keept" x="755" y="226" font-size="12" font-weight="600" text-anchor="middle">survives every reboot</text>
+
+  <path class="arrow" marker-end="url(#a)" d="M385,250 L385,286"/>
+  <text class="muted mono" x="397" y="272" font-size="11.5">losetup -P</text>
+
+  <rect class="box" x="150" y="288" width="470" height="58" rx="6"/>
+  <text class="fg mono" x="168" y="312" font-size="12.5">/dev/loopN  ──GPT──▶  /dev/loopNp1</text>
+  <text class="muted" x="168" y="332" font-size="11.5">partitioned: rook-discover rejects a bare loop device</text>
+  <rect class="lose" x="640" y="300" width="230" height="34" rx="17"/>
+  <text class="loset" x="755" y="322" font-size="12" font-weight="600" text-anchor="middle">gone on reboot — re-attach</text>
+
+  <path class="arrow" marker-end="url(#a)" d="M385,346 L385,382"/>
+  <text class="muted mono" x="397" y="368" font-size="11.5">/dev bind-mounted (live devtmpfs)</text>
+
+  <rect class="box" x="150" y="384" width="470" height="52" rx="6"/>
+  <text class="fg" x="168" y="406" font-size="13" font-weight="600">k3d node container</text>
+  <text class="muted" x="168" y="424" font-size="11.5">privileged, so it sees every device on the Docker host</text>
+
+  <path class="arrow" marker-end="url(#a)" d="M385,436 L385,472"/>
+  <text class="muted mono" x="397" y="458" font-size="11.5">hostPath /dev</text>
+
+  <rect class="box" x="150" y="474" width="470" height="52" rx="6"/>
+  <text class="fg" x="168" y="496" font-size="13" font-weight="600">Rook OSD pod</text>
+  <text class="muted" x="168" y="514" font-size="11.5">one OSD per partition</text>
+
+  <path class="arrow" marker-end="url(#a)" d="M385,526 L385,562"/>
+
+  <rect class="host" x="150" y="564" width="470" height="52" rx="6"/>
+  <text class="fg" x="168" y="586" font-size="13" font-weight="600">BlueStore</text>
+  <text class="muted" x="168" y="604" font-size="11.5">writes to the raw device — this is why a plain file will not do</text>
+</svg>

--- a/docs/developer/fundament/getting-started.md
+++ b/docs/developer/fundament/getting-started.md
@@ -67,3 +67,8 @@ just dev
 The Console frontend should now be available at https://console.fundament.localhost:8443/. See
 [`console-frontend/README.md`](https://github.com/fundament-oss/fundament/blob/master/console-frontend/README.md)
 for linting, formatting and the other frontend commands.
+
+## Storage
+
+Working on the `ceph-rook` plugin needs raw block devices, which a k3d node does not have.
+See [Block devices for k3d](./k3d-block-devices.md).

--- a/docs/developer/fundament/k3d-block-devices.md
+++ b/docs/developer/fundament/k3d-block-devices.md
@@ -1,0 +1,125 @@
+---
+title: Block devices for k3d
+sidebar:
+  order: 2
+---
+
+:::danger[Run this on a virtual machine, not on your workstation]
+Ceph puts block devices, filesystems and their kernel threads in **the Docker host's kernel**. On macOS that is any of the VM's available for supporting Docker/Containers (Docker for Desktop, Colima, Podman etc), so a mistake costs only a reboot of the VM. On a Linux workstation the Docker host is the machine itself, and two things follow: a stuck RBD mapping is an unkillable kernel thread on that machine, clearable without **a reboot** only if the StorageClass bounded its I/O, and the privileged k3d node enumerates your real drives.
+
+Rook says the same: *"Always use a virtual machine when testing Rook. Never use your host system where local devices may mistakenly be consumed."*
+
+`storage-disks attach` refuses on a non-virtual host for that reason. If you accept the risk, override it with `ALLOW_BARE_METAL=1` or `--allow-bare-metal` — but the safe answer on Linux is to run Docker inside a VM, which is the property macOS gets for free.
+:::
+
+A k3d node has no raw block devices, so a storage plugin that needs one cannot run locally. `deploy/k3d/storage-disks.sh` provides them as loop-backed partitions. Rook Ceph is the first consumer and shapes some of the requirements below, but the disks themselves are generic.
+
+![How the loop-backed disks are layered on macOS and Linux](../../assets/k3d-block-devices.svg)
+
+## Quick start
+
+```bash
+cd plugins
+just cluster-create-storage        # binds the host block devices in
+just storage-disks doctor          # check the kernel Docker runs on
+just storage-disks attach          # creates /dev/loop0p1 .. /dev/loop2p1
+```
+
+Then verify the disks really work, independently of any plugin:
+
+```bash
+../deploy/k3d/rook-smoke.sh up     # upstream Rook chart + a minimal CephCluster
+../deploy/k3d/rook-smoke.sh status # expect HEALTH_OK
+../deploy/k3d/rook-smoke.sh test   # 1Gi PVC + a pod that writes to it -> SMOKE-OK
+../deploy/k3d/rook-smoke.sh down   # frees the rook-ceph namespace
+```
+
+`rook-smoke.sh` uses no fundament code, so it separates a broken environment from a broken plugin.
+
+## Requirements
+
+The cluster must bind `/dev` and `/run/udev` into its node, which is off by default so a cluster only exposes the host's devices when someone is working on storage: use `just cluster-create-storage` instead of `just cluster-create`. Docker fixes a container's mounts at creation, so an existing cluster has to be recreated — `just cluster-delete && just cluster-create-storage`.
+
+Neither bind is optional. Without `/dev` the OSDs come up and Ceph reports `HEALTH_OK`, but no PVC can mount: a node container's `/dev` is then a private snapshot taken at container start rather than the host's live one, so the `/dev/rbdN` that Ceph CSI creates when it maps a volume never appears there.
+
+Do not try to tell the two apart by filesystem type. It is tempting — devtmpfs for the real thing, tmpfs for a snapshot — but some backends (OrbStack) use a tmpfs-backed `/dev` on the host itself, so a correctly bound node reports `tmpfs` too. The reliable checks are the container's bind list, or simply whether a device created on the host *after* the node started shows up inside it:
+
+```bash
+docker inspect k3d-fundament-plugin-server-0 \
+  --format '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' | grep -qx /dev && echo bound
+just storage-disks attach && docker exec k3d-fundament-plugin-server-0 ls /dev/loop0p1
+``` Ceph checks for exactly this and says so — `rbd: mapping succeeded but /dev/rbd0 is not accessible, is host /dev mounted?` (`ceph/src/krbd.cc`, `do_map`). There is no way around it: rbd-nbd has the same dependency, and Rook's own RBD node plugin hardcodes a hostPath mount of `/dev`.
+
+`/run/udev` is mounted because Rook mounts it into every OSD pod, the prepare job and the discover daemon, and it is a documented prerequisite from Rook v1.20 on. Running without it here wedged the prepare job with a process in uninterruptible I/O wait; the cause was not established, and the plausible explanations point at device probing rather than at udev itself.
+
+Defaults are 3 disks of 20 GiB, sparse, overridable with `DISK_COUNT` and `DISK_SIZE`. Three is the useful floor: it is what lets a pool hold 3 replicas across OSDs. BlueStore reserves several GiB of overhead, so do not go below 10 GiB per disk.
+
+Ceph needs roughly 2 GiB per OSD plus its own daemons, so give the VM at least 8 GiB — on colima, `colima start --cpus 4 --memory 8`. Memory cannot be changed on a running VM.
+
+## After a reboot
+
+The backing files are ordinary files on the Docker data disk, so they survive a Docker daemon restart, a VM restart and a laptop reboot. The loop devices do not — those are kernel state. Recovery is `just storage-disks attach`, and nothing else: `/dev` is bound into the node as a live devtmpfs, so the devices reappear there immediately.
+
+## Stopping a cluster that has Ceph volumes mounted
+
+Stopping the cluster kills the OSDs while the kernel still has the volume mapped, so the filesystem's journal thread blocks forever on a device that will never answer. The node container then cannot be stopped and cannot be entered.
+
+`just cluster-stop` handles this by itself: a mapped device is the signal that storage is in play, so it evicts the Ceph consumers first — while Ceph is still up to service the unmounts — and skips straight to stopping when nothing is mapped. `just cluster-delete` does the same. Nothing extra to remember, and a cluster that never used storage pays nothing. Nothing can intercept `k3d cluster stop` run directly, a `docker stop`, a `kill -9` or closing the laptop lid. For those the StorageClass sets `mapOptions: "krbd:osd_request_timeout=90"`, which turns krbd's endless retry into an I/O error and so keeps the filesystem's journal thread out of uninterruptible sleep. It is deliberately dev-only: it aborts *all* requests once they exceed the timeout, which is the wrong trade for a real cluster.
+
+That bounds the damage without removing it. Measured on the bypass path: the filesystem unmounts, but the mapping stays and the node container will not exit — `k3d cluster stop` fails at its own 30s timeout, repeated `docker stop` calls fail too, and the node can no longer be entered. What holds it is a kernel worker retrying the rbd watch, a wait with no timeout of its own. Removing the device ends it:
+
+```bash
+just storage-disks unmap-stale
+```
+
+The container then stops immediately, and a normal start brings the cluster back with its data intact. This works only because the timeout already aborted the in-flight I/O; without it the removal blocks for the same reason `rbd unmap -o force` does, and only restarting the host clears it.
+
+After any restart, an OSD can come back with a PG stuck in `laggy`, which blocks reads on it indefinitely while `ceph -s` reports `slow ops` and the OSD itself shows no latency. Restart that OSD's deployment.
+
+## Cleaning up
+
+Nothing removes the images on its own — `k3d cluster delete` knows nothing about the volume, and `reset` deletes them only to recreate them empty. `just storage-disks purge` detaches and deletes the volume, which is the only way to get the space back. This matters more on Linux than on macOS, where deleting the VM takes the disks with it.
+
+Deleting an image while its loop device is still attached frees nothing, because the kernel keeps the deleted inode alive until the device goes away. `purge` and `reset` therefore refuse while anything still holds a device; stop the consumer first.
+
+Use `just storage-disks reset` to start over from clean disks, which is needed after deleting the cluster: the images keep their on-disk state while the node that referenced them is gone.
+
+The volume is never attached to a container, so Docker counts it as unused: `docker volume prune -a` and `docker system prune --volumes` will delete the images. Plain `docker volume prune` will not, as it only removes anonymous volumes.
+
+## Only ever select /dev/loopNpN
+
+A k3d node container is privileged, and Docker populates its `/dev` with **every** device on the Docker host, so the node can open the host's real disks with or without the `/dev` bind. On macOS those are the VM's virtual disks; on a Linux desktop they are the machine's own drives. They also reach Rook's discover ConfigMap, so nothing at the Rook layer filters them out.
+
+Whatever consumes these disks must therefore restrict itself to the loop partitions rather than trusting discovery. One consequence on Linux: any loop partition qualifies, including one backing an unrelated disk image you attached yourself with `losetup -P`.
+
+## Docker backends
+
+Loop devices and kernel modules live in the kernel the Docker daemon runs on: the VM on macOS, the machine itself on Linux. The helper reaches it the same way everywhere, with `docker run --privileged --pid=host … nsenter -t 1`, so no backend-specific shell is needed. Use `--native` for rootless Docker, where the container's PID 1 is not the host's.
+
+What varies between backends is kernel module availability, which is what `doctor` reports.
+
+| Backend | `rbd` / `ceph` modules |
+|---|---|
+| colima | verified present (Ubuntu 24.04 base `linux-modules`) |
+| Rancher Desktop | Alpine `linux-virt` ships them, but the ISO is minimized — run `doctor` |
+| Docker Desktop | its kernel is built by Docker — run `doctor`. Enhanced Container Isolation blocks `--privileged`, and then this does not work at all |
+| OrbStack | custom kernel, undocumented — run `doctor` |
+| Linux desktop | distro kernels ship `rbd` in the standard modules package |
+
+A missing `rbd` module does not stop the disks working. Ceph OSDs write to the block device directly and never use it; only `csi-rbdplugin` crash-loops, so RBD PVCs fail to mount. It fatals at startup before reading a StorageClass, so `mounter: rbd-nbd` does not help. If you need working PVCs on such a backend, use colima.
+
+If you run an unlisted backend, run `doctor` and report the result.
+
+Ceph's reef (v18.x) arm64 images segfault on startup — `ceph-osd --version` exits 139 in a plain `docker run` — so anything running Ceph here needs v19 or newer.
+
+## Why partitions and not bare loop devices
+
+`rook-discover` does not report bare loop devices, so a `/dev/loopN` never reaches the ConfigMap Rook consumers read. Partitions are reported as `type=part`, which it accepts, so each image is attached with partition scanning and given a single GPT partition.
+
+The partition exists for discovery alone. OSD provisioning takes a bare loop device once the operator has `allowLoopDevices=true`, which is what `rook-smoke.sh` relies on — it names devices explicitly and never consults the inventory. The partition is needed only by a consumer that discovers disks rather than being told about them, as the `ceph-rook` plugin does. Note also that `type=part` puts these devices back in scope for `useAllDevices`, which excludes loop devices deliberately, so that setting must stay false.
+
+The cause is an upstream defect rather than a design decision. Rook gates the device-type allowlist on an environment variable — `pkg/clusterd/disk.go:50` calls `getAllowLoopDevices()`, which reads `CEPH_VOLUME_ALLOW_LOOP_DEVICES` (`disk.go:256-258`) — and the operator injects that variable into the discover DaemonSet when `controller.LoopDevicesAllowed()` is true (`pkg/operator/discover/discover.go:236-238`). Here the operator ConfigMap contains `ROOK_CEPH_ALLOW_LOOP_DEVICES: true` while the DaemonSet has no such variable, so the allowance never reaches the daemon that needs it. Setting it by hand with `kubectl -n rook-ceph set env ds/rook-discover CEPH_VOLUME_ALLOW_LOOP_DEVICES=true` makes an unpartitioned device appear as `type=loop empty=True`.
+
+It is an ordering bug, not a race. `pkg/operator/ceph/controller.go` builds the discover DaemonSet at line 129 and only then calls `SetAllowLoopDevices` at line 134 — the sole non-test caller of the global that `discover.go` reads. Because the DaemonSet is created-or-updated, an operator restart also strips the variable from an existing DaemonSet on its first reconcile; it reappears on the next one, so the setting looks intermittent while the cause is deterministic. The ordering is unchanged through Rook `master`, so upgrading does not help, and no upstream issue reports it.
+
+Partitioning is kept because it is self-contained: the alternative depends on patching a resource the operator owns, after it creates it, and having that patch removed again on the next operator restart.

--- a/plugins/Justfile
+++ b/plugins/Justfile
@@ -1,11 +1,16 @@
 mod cert-manager
 mod openfsc
 mod envoy-gateway 'gateway-api/envoy-gateway'
+mod ceph-rook 'storage/ceph-rook'
 
 cluster := "fundament-plugin"
 registry := "plugin-registry.localhost"
 registry_port := "5112"
 export kube_context := "k3d-" + cluster
+
+# Both binds are required; see docs/developer/fundament/k3d-block-devices.md.
+# Off by default: they expose the host's devices.
+storage_volumes := "--volume /dev:/dev@server:0 --volume /run/udev:/run/udev:ro@server:0"
 
 _default:
     @just --list
@@ -16,18 +21,32 @@ _default:
 cluster-create:
     k3d cluster create --config=sandbox/k3d-config.yaml
 
-# Start the cluster (creates if it doesn't exist)
+# Create the cluster with the host's block devices bound in (storage plugin work)
+cluster-create-storage:
+    k3d cluster create --config=sandbox/k3d-config.yaml {{ storage_volumes }}
+
+# Start the cluster (creates if it doesn't exist), clearing any leftover cordon.
+# uncordon is a no-op unless storage disks were ever attached.
 cluster-start:
     @k3d cluster list {{ cluster }} > /dev/null 2>&1 && k3d cluster start {{ cluster }} || just cluster-create
+    CLUSTER={{ cluster }} ../deploy/k3d/storage-disks.sh uncordon
 
-# Stop the cluster without deleting it
+# Stop the cluster, evicting Ceph consumers first. drain fails on purpose while a
+# volume is still mapped, because stopping then wedges the Docker host — so do not
+# add a `-` prefix here.
 cluster-stop:
+    CLUSTER={{ cluster }} ../deploy/k3d/storage-disks.sh drain
     k3d cluster stop {{ cluster }}
 
 # Delete the local K3D cluster and registry
 cluster-delete:
+    -@CLUSTER={{ cluster }} ../deploy/k3d/storage-disks.sh drain
     k3d cluster delete {{ cluster }}
     @k3d registry delete {{ registry }} 2>/dev/null || true
+
+# Loop-backed block devices for a storage plugin; run without arguments for usage
+storage-disks *args:
+    CLUSTER={{ cluster }} ../deploy/k3d/storage-disks.sh {{ args }}
 
 # --- Deployment commands ---
 


### PR DESCRIPTION
k3d nodes have no raw disks and Rook's BlueStore needs one. Creates loop-backed
devices in the Docker host's kernel, plus the cluster start/stop hooks that keep
a mapped volume from wedging it.

Refuses to run unless the Docker host is a VM.