### PR TITLE
feat(k3d): dev token for plugin publishing

### DIFF
--- a/charts/fundament/values-local.yaml
+++ b/charts/fundament/values-local.yaml
@@ -197,6 +197,10 @@ dexDcim:
       hash: "$2y$10$KdEtpACqX8Jh0AYF2n1sfeySkYkG8hRK6Tmn85/VpvaVVPgxL3Hsi"
       username: Grace
       userID: "019d0000-1000-7000-8000-000000000007"
+    - email: platform-admin@fundament.io
+      hash: "$2y$10$KdEtpACqX8Jh0AYF2n1sfeySkYkG8hRK6Tmn85/VpvaVVPgxL3Hsi"
+      username: Platform Admin
+      userID: "019b4000-1000-7000-8000-000000000008"
 
 dcimAuthnApi:
   enabled: true

--- a/deploy/k3d/dev-token.sh
+++ b/deploy/k3d/dev-token.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Prints a user JWT from authn-api for dev tooling that needs a bearer token,
+# plugin-publish above all. Defaults to platform-admin@fundament.io: publishing
+# needs admin of the system org that owns the first-party plugins, so other dev
+# logins are refused.
+#
+#   export FUNDAMENT_TOKEN=$(./deploy/k3d/dev-token.sh)          # bash/zsh
+#   set -gx FUNDAMENT_TOKEN (./deploy/k3d/dev-token.sh)          # fish
+set -euo pipefail
+
+AUTHN_URL="${AUTHN_URL:-https://authn.fundament.localhost:8443}"
+EMAIL="${FUNDAMENT_EMAIL:-platform-admin@fundament.io}"
+PASSWORD="${FUNDAMENT_PASSWORD:-password}"
+
+# -k: the local ingress serves a self-signed certificate.
+curl -fsk -X POST "$AUTHN_URL/login/password" \
+    -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+    | yq -p json -r '.access_token'


### PR DESCRIPTION
plugin-publish needs a token for an admin of the owning org. Adds a helper that
fetches one, and seeds platform-admin in the local Dex config.

Independent of the ceph-rook stack.