### PR TITLE
fix(k3d): make local plugin development work from a clean
  machine

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -51,8 +51,11 @@ setup-certs:
     TRUST_STORES=system,nss mkcert -install
     echo "Waiting for cert-manager to become available..."
     deadline=$(( $(date +%s) + 120 ))
-    until kubectl get ns cert-manager > /dev/null 2>&1; do
-        [ "$(date +%s)" -ge "$deadline" ] && { echo "Timed out waiting for cert-manager namespace"; exit 1; }
+    # Wait for the Deployments themselves, not just the namespace: k3s creates the
+    # namespace before the helm-install Job creates their contents, and `kubectl wait`
+    # errors immediately on a resource that does not exist yet instead of polling.
+    until kubectl get deployment cert-manager cert-manager-webhook -n cert-manager > /dev/null 2>&1; do
+        [ "$(date +%s)" -ge "$deadline" ] && { echo "Timed out waiting for the cert-manager deployments"; exit 1; }
         sleep 5
     done
     kubectl wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook -n cert-manager --timeout=300s
@@ -174,8 +177,39 @@ plugin-sandbox-kubeconfig:
         --dry-run=client -o yaml | \
         kubectl --context k3d-fundament-plugin apply -f -
 
-    echo "plugin-sandbox-kubeconfig Secret updated. Restart plugin-proxy:"
-    echo "  kubectl --context k3d-fundament -n fundament rollout restart deployment/plugin-proxy"
+    # The console refuses a plugin install unless the cluster reports RUNNING, which
+    # organization-api derives from tenant.clusters.shoot_status = 'ready'. Locally there is
+    # no Gardener to set it, so the seeded row stays NULL and the cluster shows as
+    # provisioning forever. Every cluster id routes to the sandbox here (see
+    # kube-api-proxy/pkg/kube/sandbox_proxy.go), so the sandbox just wired up is what those
+    # rows stand for — which makes this the point where "ready" becomes true. A db.reset
+    # clears it again, and re-running this recipe is already the documented step after one.
+    echo "- marking the local cluster(s) ready so the console allows plugin installs"
+    kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+        psql -U postgres -d fundament -qc \
+        "UPDATE tenant.clusters SET shoot_status = 'ready', shoot_status_updated = now() \
+         WHERE deleted IS NULL AND shoot_status IS DISTINCT FROM 'ready';" \
+        || echo "  (could not reach the database — the console will still show provisioning)" >&2
+
+    # Both consumers read the Secret only at startup, and Reloader does not reliably pick
+    # this one up, so restart them here rather than leave a Secret that has no effect.
+    echo "- restarting plugin-proxy and kube-api-proxy to pick the Secret up"
+    kubectl --context k3d-fundament -n fundament rollout restart \
+        deployment/plugin-proxy deployment/kube-api-proxy > /dev/null
+    kubectl --context k3d-fundament -n fundament rollout status deployment/kube-api-proxy --timeout=180s > /dev/null
+
+    # Confirm the new pod actually switched off the in-memory mock. `rollout status`
+    # returns slightly before the logs are attached, so poll rather than read once.
+    for i in $(seq 1 30); do
+        if kubectl --context k3d-fundament -n fundament logs deployment/kube-api-proxy 2>/dev/null \
+            | grep -q "plugin sandbox cluster"; then
+            echo "- kube-api-proxy is proxying to the sandbox (mock disabled)"
+            exit 0
+        fi
+        sleep 2
+    done
+    echo "kube-api-proxy did not report the sandbox proxy; check: kubectl -n fundament logs deployment/kube-api-proxy" >&2
+    exit 1
 
 # Delete deployment, can also be used to remove the deployment created by `just dev`.
 undeploy env:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,20 @@ The focus of the project is currently on research and ideation. Some initial PoC
 
 ## Documentation
 
+Published at **<https://docs.fundament.projects.digilab.network/docs>**. The pages below are the
+same content, rendered on GitHub.
+
 - [Overview](docs/user/overview.md)
 - [Infrastructure](docs/user/infrastructure.md)
 - [Organizations and projects](docs/user/organizations.md)
 - [Plugins](docs/user/plugins.md)
-- [Fundament development](docs/developer/fundament/getting-started.md)
-- [Plugin development](docs/developer/plugins/index.md)
+- [Run Fundament locally](docs/developer/fundament/getting-started.md)
+- [The two development clusters](docs/developer/plugins/dev-environment.md)
+- [Install and test a plugin](docs/developer/plugins/install-a-plugin.md)
+- [Plugin development reference](docs/developer/plugins/index.md)
+
+Once the platform is running locally, the same documentation is served from the cluster at
+<https://docs.fundament.localhost:8443>.
 
 ## Contributing
 

--- a/charts/fundament/templates/console-frontend.yaml
+++ b/charts/fundament/templates/console-frontend.yaml
@@ -37,8 +37,11 @@ spec:
         - name: console-frontend
           image: {{ $.Values.images.consoleFrontend }}
           env:
+            # Feeds both connect-src and frame-src in nginx.conf. plugin-proxy is its own
+            # origin and serves the plugin console pages the iframe loads (FUN-17), so
+            # leaving it out blocks every plugin UI with a CSP frame-src violation.
             - name: CONNECT_SRC
-              value: "{{ $.Values.externalUrls.authn }} {{ $.Values.externalUrls.organization }} {{ $.Values.externalUrls.kubeApiProxy }}"
+              value: "{{ $.Values.externalUrls.authn }} {{ $.Values.externalUrls.organization }} {{ $.Values.externalUrls.kubeApiProxy }} {{ $.Values.externalUrls.pluginProxy }}"
           ports:
             - name: http
               containerPort: 80

--- a/charts/fundament/templates/db-migrations.yaml
+++ b/charts/fundament/templates/db-migrations.yaml
@@ -56,6 +56,27 @@ spec:
               # the two always happen together as one triggered event. OpenFGA no
               # longer resets itself on pod start, so an unrelated openfga rollout
               # can't wipe the store out from under an already-synced outbox.
+              # CNPG creates the openfga database asynchronously, so on a cold start
+              # it can still be absent here — the init container's port check says
+              # nothing about which databases exist. Failing here is unrecoverable:
+              # the Job exhausts backoffLimit, ttlSecondsAfterFinished then removes
+              # it, and openfga's wait-for-reset blocks forever on a Job name that
+              # no longer exists. Wait for the database itself.
+              echo "Waiting for the openfga database..."
+              i=0
+              until psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'openfga'" | grep -q 1; do
+                i=$((i + 1))
+                if [ "$i" -ge 150 ]; then
+                  echo "openfga database did not appear after 5 minutes" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              # TODO: this reset does not always converge. openfga-setup can create a new store
+              # while the tuples authz-worker writes go to the previous one, leaving every
+              # authorization decision false with every pod healthy — and it stays that way
+              # until another reset happens to line them up. Observed 1 run in 3. Couple the
+              # store id to the outbox, or re-emit the outbox when the store is recreated.
               echo "Resetting OpenFGA datastore (coupled with the DB reset)..."
               psql "$OPENFGA_DATASTORE_URI" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
               echo "OpenFGA datastore reset complete."

--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- include "fundament.labels" (dict "root" $ "name" "kube-api-proxy" "component" "backend") | nindent 4 }}
   annotations:
     reloader.stakater.com/auto: "true"
+    {{- if $.Values.kubeApiProxy.sandboxKubeconfigSecret }}
+    # `auto` only tracks what a pod actually references, and the sandbox kubeconfig is
+    # mounted optional: true — created out of band after this pod is already running, so
+    # the pod never referenced it and a later create goes unnoticed. Name it explicitly.
+    secret.reloader.stakater.com/reload: {{ $.Values.kubeApiProxy.sandboxKubeconfigSecret | quote }}
+    {{- end }}
 spec:
   replicas: {{ $.Values.kubeApiProxy.replicas }}
   selector:

--- a/charts/fundament/templates/plugin-proxy.yaml
+++ b/charts/fundament/templates/plugin-proxy.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- include "fundament.labels" (dict "root" $ "name" "plugin-proxy" "component" "backend") | nindent 4 }}
   annotations:
     reloader.stakater.com/auto: "true"
+    {{- if $.Values.pluginProxy.sandboxKubeconfigSecret }}
+    # `auto` only tracks what a pod actually references, and the sandbox kubeconfig is
+    # mounted optional: true — created out of band after this pod is already running, so
+    # the pod never referenced it and a later create goes unnoticed. Name it explicitly.
+    secret.reloader.stakater.com/reload: {{ $.Values.pluginProxy.sandboxKubeconfigSecret | quote }}
+    {{- end }}
 spec:
   replicas: {{ $.Values.pluginProxy.replicas }}
   selector:

--- a/charts/fundament/values-local.yaml
+++ b/charts/fundament/values-local.yaml
@@ -19,6 +19,12 @@ db:
   enabled: true
   instances: 1
   storageSize: 1Gi
+  # Resetting on every deploy is what makes testdata re-appliable: db/testdata/*.sql use
+  # plain INSERTs, unlike db/seed/*.sql which upsert. The side effect is that published
+  # PluginDefinitions go too, while the PluginInstallations referencing them live in the
+  # sandbox cluster and are not reset — so they dangle, and keep reporting Running.
+  # TODO: make testdata idempotent (ON CONFLICT) so this can be opt-in, and surface an
+  # unresolvable definitionRef in PluginInstallation.status.
   reset: true
   insertTestData: true
   exposePort: 54328

--- a/console-frontend/nginx.conf
+++ b/console-frontend/nginx.conf
@@ -22,7 +22,7 @@ server {
     #   - style-src 'unsafe-inline'    Angular inlines component styles at runtime
     #   - connect-src ${CONNECT_SRC}   injected at container startup via envsubst;
     #                                  set via externalUrls.authn + externalUrls.organization + externalUrls.kubeApiProxy in Helm values
-    #   - frame-src ${CONNECT_SRC}     plugin custom UIs are served from the kube-api-proxy origin
+    #   - frame-src ${CONNECT_SRC}     plugin custom UIs are served from the plugin-proxy origin
     #                                  and embedded here as iframes; without frame-src this falls
     #                                  back to default-src 'self' and the browser blocks them
     #   - frame-ancestors 'none'       equivalent to X-Frame-Options DENY (superset)

--- a/docs/developer/fundament/getting-started.md
+++ b/docs/developer/fundament/getting-started.md
@@ -12,6 +12,11 @@ sidebar:
 - [Docker](https://www.docker.com)
 - `certutil` (part of NSS tools). Required for `mkcert` to install the CA into system trust stores
 
+Every other tool these docs use is provided by mise — see `mise.toml` for the list. The
+commands throughout assume an activated mise environment; without one they are not on `PATH`.
+Either [activate mise in your shell](https://mise.jdx.dev/getting-started.html) or prefix
+commands with `mise x --`.
+
 ### Installing certutil
 
 **macOS:**
@@ -57,18 +62,82 @@ mise install
 
 ## Run cluster
 
+From the repository root:
+
 ```shell
 just cluster-start
 just dev
 ```
 
-## Console frontend
+`cluster-start` creates the **platform** cluster `k3d-fundament` and installs the mkcert CA as a
+cert-manager issuer.
+On a machine with no mkcert CA yet, `mkcert -install` asks for sudo to add it to the system
+trust store.
 
-The Console frontend should now be available at https://console.fundament.localhost:8443/. See
+`just dev` is `skaffold dev`. It builds the platform images, pushes them to the local registry,
+deploys the chart, and then **stays attached to your terminal watching your source files** —
+edit a Go file and it rebuilds that one image and redeploys it, streaming the pods' logs
+meanwhile. On a cold Docker cache expect about ten minutes: roughly a minute for the cluster,
+six to build the images, and a few more for them to roll out. Nothing is pulled from a registry;
+every image is built locally.
+
+Once the deployments are stable you can **stop it with Ctrl-C** — the recipe passes
+`--cleanup=false`, so nothing is torn down. The cluster keeps running and the console keeps
+serving. Leave it running only if you are editing Fundament's own source and want your changes
+rebuilt automatically; if you are here to work on plugins, you do not need it.
+
+:::caution[Stopping is safe — restarting is not]
+Running `just dev` again re-runs the database migrations, and `values-local.yaml` sets
+`db.reset: true`, so it **wipes and re-seeds the platform database**. Every published plugin
+definition goes with it, and the installed plugin keeps reporting `Running` until its controller
+next restarts. Once you have published a plugin, avoid re-running `just dev` unless you mean to
+start over — see
+[Install a plugin](../plugins/install-a-plugin.md#known-issues-on-this-path).
+:::
+
+## What you just started
+
+`k3d-fundament` is the **platform** cluster. It runs the Fundament services themselves: a
+CloudNativePG Postgres, `authn-api`, `organization-api`, `authz-worker` with OpenFGA, `dex`, the
+console and docs frontends, `kube-api-proxy`, `plugin-proxy`, `plugin-controller` and
+ingress-nginx.
+
+Plugins do **not** run here. They run on a second, separate k3d cluster that you create later —
+in production that is a managed tenant cluster, and locally it is `k3d-fundament-plugin`. See
+[The two development clusters](../plugins/dev-environment.md).
+
+## Where things are
+
+Once `just dev` reports the deployments stable:
+
+| | URL | Sign in with |
+|---|---|---|
+| Console | <https://console.fundament.localhost:8443> | `alice@acme-corp.com` / `password` |
+| Documentation | <https://docs.fundament.localhost:8443> | — |
+
+Other services follow the same pattern — `authn`, `organization`, `dex` and `plugin-proxy` are
+each at `https://<name>.fundament.localhost:8443`. Publishing plugins uses a different identity,
+`platform-admin@fundament.io`, minted by `deploy/k3d/dev-token.sh`.
+
+These docs are served from the cluster you just started, so the documentation URL above is your
+branch's content. The published site — built from `master` — is at
+<https://docs.fundament.projects.digilab.network/docs>. To work on the docs themselves, `just docs-dev` runs a live
+dev server on <http://localhost:4321>, and `just docs-build` validates every internal link and
+fails on a broken one. The pages live in `docs/`; the link-writing rules are in
+[`docs-frontend/README.md`](https://github.com/fundament-oss/fundament/blob/master/docs-frontend/README.md).
+
+## Next: install a plugin
+
+Working on the console frontend itself? See
 [`console-frontend/README.md`](https://github.com/fundament-oss/fundament/blob/master/console-frontend/README.md)
 for linting, formatting and the other frontend commands.
 
+Otherwise the next step is [Install a plugin](../plugins/install-a-plugin.md), which takes you
+from the running platform to `cert-manager` installed and visible in the console. Read
+[The two development clusters](../plugins/dev-environment.md) first if you have not already.
+
 ## Storage
 
-Working on the `ceph-rook` plugin needs raw block devices, which a k3d node does not have.
-See [Block devices for k3d](./k3d-block-devices.md).
+Only if you are working on the `ceph-rook` plugin: it needs raw block devices, which a k3d node
+does not have. See [Block devices for k3d](./k3d-block-devices.md). This is not part of the
+plugin walkthrough.

--- a/docs/developer/fundament/k3d-block-devices.md
+++ b/docs/developer/fundament/k3d-block-devices.md
@@ -1,6 +1,7 @@
 ---
 title: Block devices for k3d
 sidebar:
+  label: Block devices for k3d
   order: 2
 ---
 
@@ -48,7 +49,9 @@ Do not try to tell the two apart by filesystem type. It is tempting — devtmpfs
 docker inspect k3d-fundament-plugin-server-0 \
   --format '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' | grep -qx /dev && echo bound
 just storage-disks attach && docker exec k3d-fundament-plugin-server-0 ls /dev/loop0p1
-``` Ceph checks for exactly this and says so — `rbd: mapping succeeded but /dev/rbd0 is not accessible, is host /dev mounted?` (`ceph/src/krbd.cc`, `do_map`). There is no way around it: rbd-nbd has the same dependency, and Rook's own RBD node plugin hardcodes a hostPath mount of `/dev`.
+```
+
+Ceph checks for exactly this and says so — `rbd: mapping succeeded but /dev/rbd0 is not accessible, is host /dev mounted?` (`ceph/src/krbd.cc`, `do_map`). There is no way around it: rbd-nbd has the same dependency, and Rook's own RBD node plugin hardcodes a hostPath mount of `/dev`.
 
 `/run/udev` is mounted because Rook mounts it into every OSD pod, the prepare job and the discover daemon, and it is a documented prerequisite from Rook v1.20 on. Running without it here wedged the prepare job with a process in uninterruptible I/O wait; the cause was not established, and the plausible explanations point at device probing rather than at udev itself.
 

--- a/docs/developer/plugins/ceph-rook-runbook.md
+++ b/docs/developer/plugins/ceph-rook-runbook.md
@@ -1,19 +1,29 @@
 ---
 title: "Runbook: verifying the Ceph/Rook plugin"
 sidebar:
-  order: 5
+  label: Ceph/Rook runbook
+  order: 9
 ---
 
-End-to-end verification of the `ceph-rook` plugin against a local k3d sandbox, from an
-empty machine to a pod writing to a Ceph-backed volume.
+End-to-end verification of the `ceph-rook` plugin against the local `k3d-fundament-plugin`
+sandbox cluster, from an empty machine to a pod writing to a Ceph-backed volume.
+
+**Advanced.** This is the longest path in the repo. For the standard plugin flow, start with
+[Install a plugin](./install-a-plugin.md).
 
 The unit tests cover the plugin's decision logic and its reconcilers against a fake
 client. They cannot tell you whether Rook actually builds an OSD out of a real block
 device, whether the CSI driver can map an RBD image, or whether the console pages render.
 That is what this runbook is for.
 
-Budget 45–60 minutes for a first run; most of it is Ceph pulling images and waiting for
-OSDs.
+Budget 45–60 minutes for a first run on a warm Docker cache; most of it is Ceph pulling
+images and waiting for OSDs. From no images at all, closer to two hours — the platform
+cluster and its 14 images account for most of the difference.
+
+New to the two-cluster setup? Read
+[The two development clusters](./dev-environment.md) first, and ideally do the shorter
+[Install a plugin](./install-a-plugin.md) walkthrough before this one. This runbook assumes both
+clusters already exist.
 
 ## What each phase proves
 
@@ -39,13 +49,20 @@ nothing you learn in phases 4–8 means anything.
   [Block devices for k3d](../fundament/k3d-block-devices.md).
 - **At least 8 GiB of VM memory.** Ceph needs roughly 2 GiB per OSD plus its daemons. On
   colima: `colima start --cpus 4 --memory 8`. Memory cannot be changed on a running VM.
-- **The management cluster (`k3d-fundament`) must be up**, because publishing goes through
-  organization-api. The sandbox cluster (`k3d-fundament-plugin`) is where the plugin runs.
+- **The `k3d-fundament` platform cluster must be up**, because publishing goes through
+  organization-api. The `k3d-fundament-plugin` sandbox cluster is where the plugin runs.
+- **An activated mise environment.** `just`, `skaffold`, `jq` and `yq` come from mise and are
+  otherwise not on `PATH`.
 
-:::caution[Check your kubectl context]
-`just dev` and skaffold deploy to the *current* context, and they do not switch for you.
-Every command below passes `--context` explicitly for that reason. If you drop the flag,
-confirm your context first.
+:::caution[Watch which directory you are in]
+The repository root and `plugins/` both define a `just dev`, and they deploy different things
+to different clusters — the root one deploys the platform to `k3d-fundament`, the `plugins/`
+one deploys the plugin-controller to `k3d-fundament-plugin`. `just` picks the recipe from your
+current directory, so every step below states the directory it runs in.
+
+Your kubectl context does not disambiguate them: both skaffold configurations pin
+`kubeContext`, so `kubectl config use-context` has no effect on where they deploy. Every
+`kubectl` command below passes `--context` explicitly for the same reason.
 :::
 
 ## Phase 0 · Clean slate
@@ -86,7 +103,12 @@ cd plugins
 just cluster-create-storage    # binds /dev and /run/udev into the node
 just storage-disks doctor      # inspect the kernel Docker actually runs on
 just storage-disks attach      # 3 × 20 GiB sparse images -> /dev/loop0p1 .. /dev/loop2p1
+just dev                       # plugin-controller into the sandbox; leave it running
 ```
+
+`just dev` here is the `plugins/` recipe: it deploys the plugin-controller to
+`k3d-fundament-plugin`. Without it the sandbox has the `PluginInstallation` CRD but nothing
+that reconciles it, and phase 4 will apply a CR that never progresses.
 
 `doctor` is worth reading rather than skimming. The line that matters most:
 
@@ -165,14 +187,15 @@ state under `dataDirHostPath`, is the usual reason a second install fails.
 
 ## Phase 3 · Build and publish
 
-Publishing resolves the plugin's catalog id by name, so the appstore seed must be applied
-in the management cluster. This PR adds the `ceph-rook` catalog entry and a `Storage`
-category, so **the seed must be re-applied** — it is idempotent (`ON CONFLICT DO UPDATE`),
-and the `db-migrations` Job runs it:
+Publishing resolves the plugin's catalog id by name, so the appstore seed must be present in
+the `k3d-fundament` platform cluster. The seed carries the `ceph-rook` catalog entry and its `Storage`
+category, is idempotent (`ON CONFLICT DO UPDATE`), and is applied by the `db-migrations` Job. If
+the database predates that entry, re-run the Job:
+
+From the **repository root** (not `plugins/` — see the caution above):
 
 ```bash
-kubectl config use-context k3d-fundament
-just dev                            # or: just deploy — re-runs db-migrations
+just dev                            # or: just deploy local — re-runs db-migrations
 ```
 
 Bridge the sandbox controller to organization-api (re-run after recreating either cluster,
@@ -213,12 +236,11 @@ One `admin`/`accepted` row is what you need. If it is missing, re-run the migrat
 `db.reset: true`, or insert `db/testdata/033_0101-content.sql` by hand.
 :::
 
-```bash
-export PLUGIN_REGISTRY=localhost:5112
-export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
-export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
-export FUNDAMENT_TOKEN=...      # a token for platform-admin@fundament.io — required
+Set the four publish variables exactly as in
+[Install a plugin, step 3](./install-a-plugin.md#3-publish-the-plugin-definition) — that page is
+canonical for them — then, from `plugins/`:
 
+```bash
 just plugin-publish storage/ceph-rook
 ```
 
@@ -316,8 +338,8 @@ kubectl --context k3d-fundament-plugin get disks
 Expect exactly three, one per loop partition:
 
 ```
-NAME                                  NODE                            SIZE          AVAILABLE
-k3d-fundament-plugin-server-0-1a2b3c  k3d-fundament-plugin-server-0   21472739328   true
+NAME                                      NODE                            PATH           SIZE          AVAILABLE
+k3d-fundament-plugin-server-0-2e7309e042  k3d-fundament-plugin-server-0   /dev/loop0p1   21472739328   true
 ...
 ```
 
@@ -370,6 +392,10 @@ Watch it provision — the first OSD takes a few minutes:
 ```bash
 kubectl --context k3d-fundament-plugin get storagepool test-pool -w
 ```
+
+The pool stays `Provisioning` for another 60–90 seconds after its `CephBlockPool` reports
+`Ready`; the reconciler picks the change up on its next pass. That wait is normal, not a
+stall.
 
 ```bash
 kubectl --context k3d-fundament-plugin get storagepool test-pool -o yaml | yq .status
@@ -481,7 +507,7 @@ Previously the pages were embedded but never routed, and the iframe 404'd.
 
 ```bash
 kubectl --context k3d-fundament-plugin -n plugin-ceph-rook \
-  port-forward deploy/ceph-rook 8080:8080 &
+  port-forward deploy/plugin-ceph-rook 8080:8080 &
 curl -sS -o /dev/null -w '%{http_code}\n' localhost:8080/console/storagepools-list.html
 curl -sS -o /dev/null -w '%{http_code}\n' localhost:8080/console/storagepools-create.html
 kill %1
@@ -494,6 +520,22 @@ and that clicking a pool row navigates — the previous version's inline styles 
 ```
 https://console.fundament.localhost:8443/
 ```
+
+The console reaches the plugin through plugin-proxy in the `k3d-fundament` platform cluster,
+which needs a
+kubeconfig for the sandbox. Create it once per cluster pair, from the **repository root**:
+
+```bash
+just plugin-sandbox-kubeconfig
+```
+
+The recipe restarts plugin-proxy and kube-api-proxy and waits until the switch is confirmed,
+ending with `- kube-api-proxy is proxying to the sandbox (mock disabled)`.
+
+The Secret is mounted optionally, so plugin-proxy starts and reports healthy without it and
+fails only when a plugin page is opened. A blank or erroring plugin iframe with a healthy
+plugin pod usually means this step is missing, or that the sandbox cluster was recreated
+since it last ran.
 
 Check the browser console for CSP violations. There should be none.
 
@@ -523,46 +565,7 @@ violation anywhere here is a failure, not cosmetic.
    `Claimed by` is set for a pooled disk (plain text — cross-kind links are not
    expressible in the host contract).
 
-### 8b · Foreign objects are not adopted
-
-The old code would adopt a same-named StorageClass and delete it when the pool went away.
-
-```bash
-kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-squatter
-provisioner: rancher.io/local-path
-YAML
-
-kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
-apiVersion: storage.fundament.io/v1alpha1
-kind: StoragePool
-metadata:
-  name: squatter
-spec:
-  replication: auto
-  disks: []
-YAML
-
-kubectl --context k3d-fundament-plugin get storagepool squatter -o jsonpath='{.status.phase}{"\n"}{.status.message}{"\n"}'
-```
-
-Expect `Degraded` and a message naming the conflict. Critically, the foreign object must be
-untouched:
-
-```bash
-kubectl --context k3d-fundament-plugin get storageclass ceph-squatter \
-  -o jsonpath='{.provisioner}{" owners="}{.metadata.ownerReferences}{"\n"}'
-# rancher.io/local-path owners=      <- unchanged, no owner reference
-
-kubectl --context k3d-fundament-plugin delete storagepool squatter
-kubectl --context k3d-fundament-plugin get storageclass ceph-squatter   # must still exist
-kubectl --context k3d-fundament-plugin delete storageclass ceph-squatter
-```
-
-### 8c · `claimedBy` updates immediately
+### 8b · `claimedBy` updates immediately
 
 It used to wait for the discovery daemon's next sweep (~60m), long enough to hand one disk
 to two pools through the UI.
@@ -576,7 +579,7 @@ Every disk in `test-pool` must already show `claimedBy=test-pool` — no waiting
 also what makes the create form's picker correct, so re-open it and confirm it offers no
 disks.
 
-### 8d · Deleting a pool shrinks the CephCluster
+### 8c · Deleting a pool shrinks the CephCluster
 
 Nothing else recomputes this: the CephCluster carries no owner reference.
 
@@ -598,6 +601,59 @@ explicit Ceph purge. `kubectl -n rook-ceph get pods -l app=rook-ceph-osd` will s
 them. This is expected and documented; it is why disk removal is a two-step operation.
 :::
 
+### 8d · Foreign objects are not adopted
+
+The old code would adopt a same-named StorageClass and delete it when the pool went away.
+
+This check runs last on purpose. The guard only fires once the reconciler actually reaches
+the StorageClass write, which needs the pool to resolve at least one disk — a pool with
+`disks: []` goes `Degraded` with `no disks selected` and never gets that far. Step 8c freed
+the disks, so they can be reused here.
+
+```bash
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-squatter
+provisioner: rancher.io/local-path
+YAML
+
+DISKS=$(kubectl --context k3d-fundament-plugin get disks -o jsonpath='{range .items[*]}      - {.metadata.name}{"\n"}{end}')
+kubectl --context k3d-fundament-plugin apply -f - <<YAML
+apiVersion: storage.fundament.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: squatter
+spec:
+  replication: auto
+  disks:
+$DISKS
+YAML
+
+kubectl --context k3d-fundament-plugin get storagepool squatter -o jsonpath='{.status.phase}{"\n"}{.status.message}{"\n"}'
+```
+
+Expect `Degraded`, and a message naming the conflict:
+
+```
+apply StorageClass ceph-squatter: terminal error: StorageClass "ceph-squatter" already
+exists and is not owned by this StoragePool; refusing to adopt it (deleting the pool would
+then delete that object). Rename the StoragePool or remove the conflicting StorageClass
+```
+
+Critically, the foreign object must be untouched:
+
+```bash
+kubectl --context k3d-fundament-plugin get storageclass ceph-squatter \
+  -o jsonpath='{.provisioner}{" owners="}{.metadata.ownerReferences}{"\n"}'
+# rancher.io/local-path owners=      <- unchanged, no owner reference
+
+kubectl --context k3d-fundament-plugin delete storagepool squatter
+kubectl --context k3d-fundament-plugin get storageclass ceph-squatter   # must still exist
+kubectl --context k3d-fundament-plugin delete storageclass ceph-squatter
+```
+
 ## Phase 9 · Teardown
 
 Order matters. Ceph consumers must release volumes while Ceph is still running to service
@@ -611,6 +667,46 @@ just storage-disks purge       # detach and delete the backing images, freeing t
 ```
 
 To keep the disks for a future run, use `just storage-disks reset` instead of `purge`.
+
+`cluster-stop` and `cluster-delete` drain the node first, which evicts pods — a bare
+verification pod is deleted, not restarted. Only its PersistentVolumeClaim survives a
+stop/start cycle.
+
+## When the platform cluster changes under you
+
+Both failure modes below are described in full, with recovery, under
+[Install a plugin → Known issues on this path](./install-a-plugin.md#known-issues-on-this-path).
+That page is canonical; this section adds only what is specific to a mid-runbook redeploy.
+
+A `just dev` at the repository root re-seeds the platform database and drops every published
+`PluginDefinition`, so it invalidates what phase 3 published. `just plugin-status` will not tell
+you — the CR keeps reporting `Running`/`READY=true`. The controller log is where it shows:
+
+```bash
+kubectl --context k3d-fundament-plugin -n fundament logs deploy/fundament-plugin-controller | tail
+# fetch definition: GetPluginDefinition RPC: not_found: plugin definition ceph-rook@v0.1.0 not found
+```
+
+Redo phase 3, then delete and re-apply the `PluginInstallation` with the new hash —
+`definitionRef` is immutable, so it cannot be edited in place. Deleting runs the uninstall path,
+which for `ceph-rook` tears down the CephCluster; on a verification run that is usually what you
+want anyway, but do not do it to a pool holding data you care about.
+
+If publishing then fails with `permission_denied` while both checks in phase 3 look right —
+the `admin`/`accepted` row present and both OpenFGA tuples present — the OpenFGA store was
+recreated during the reset and the tuples belong to the previous one:
+
+```bash
+kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+  psql -U postgres -d openfga -c "SELECT store, count(*) FROM tuple GROUP BY 1;"
+kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+  psql -U postgres -d openfga -c "SELECT id FROM store;"
+```
+
+The two store ids must match. When they do not, every authorization decision resolves to
+false while every pod looks healthy. Restarting `organization-api`, `kube-api-proxy` or
+`authz-worker` does not repair it — the tuples are already written and the outbox is
+drained. Another platform redeploy does.
 
 ## Troubleshooting
 
@@ -631,6 +727,10 @@ To keep the disks for a future run, use `just storage-disks reset` instead of `p
 | PVC Pending, provisioner logs quiet | No OSD is up | `kubectl -n rook-ceph get pods -l app=rook-ceph-osd` |
 | `rbd: mapping succeeded but /dev/rbd0 is not accessible` | No `/dev` bind | Recreate with `just cluster-create-storage` |
 | Second install fails after a first attempt | Stale OSD metadata | `just storage-disks reset` |
+| `PluginInstallation` never leaves `Deploying`, no plugin namespace appears | No plugin-controller in the sandbox | `just dev` from `plugins/` (phase 1) |
+| `GetPluginDefinition … not found` after a platform redeploy | `db.reset: true` wiped the published definition | Redo phase 3 — see "When the platform cluster changes under you" |
+| `permission_denied` on publish, but both phase 3 checks look right | OpenFGA store recreated; tuples in the old store | Redeploy the platform again — same section |
+| Plugin iframe blank in the console, plugin pod healthy | `plugin-sandbox-kubeconfig` Secret missing or stale | `just plugin-sandbox-kubeconfig` from the root, then restart plugin-proxy |
 | Node container will not stop | Stale RBD mapping | `just storage-disks unmap-stale` |
 | Pool stuck `Provisioning` | CephBlockPool not Ready | `kubectl -n rook-ceph describe cephblockpool ceph-<pool>` |
 | Pool `Degraded` | Conflict or drift | Read `status.message` — it names the action |

--- a/docs/developer/plugins/console-integration.md
+++ b/docs/developer/plugins/console-integration.md
@@ -1,7 +1,7 @@
 ---
 title: Console integration
 sidebar:
-  order: 6
+  order: 7
 ---
 
 How a Fundament plugin renders inside the Console: the iframe boundary, the
@@ -12,7 +12,7 @@ This document is the architecture reference for anyone working on the
 Console-plugin boundary. For a plugin author's how-to, start with
 [Writing a plugin](writing-a-plugin) and [Custom UI](custom-ui). For the
 container lifecycle (controller, RBAC, install/uninstall), see the
-[Plugins overview](.).
+[Plugins overview](/docs/developer/plugins).
 
 ## Overview
 

--- a/docs/developer/plugins/custom-ui.md
+++ b/docs/developer/plugins/custom-ui.md
@@ -1,7 +1,7 @@
 ---
 title: Custom UI
 sidebar:
-  order: 4
+  order: 6
 ---
 
 Custom UI is optional. When a plugin omits `customComponents` for a CRD it

--- a/docs/developer/plugins/dev-environment.md
+++ b/docs/developer/plugins/dev-environment.md
@@ -1,0 +1,87 @@
+---
+title: The two development clusters
+sidebar:
+  label: Dev environment
+  order: 2
+---
+
+Plugin development uses **two k3d clusters**: the `k3d-fundament` platform cluster and the
+`k3d-fundament-plugin` sandbox cluster. Knowing which is which, and which directory a command
+runs in, is most of what makes the rest of these pages make sense.
+
+Throughout these docs a cluster is named by its kubectl context — `k3d-fundament` or
+`k3d-fundament-plugin` — with "platform" or "sandbox" as a descriptor. The context name is the
+unambiguous part, and it is what every `kubectl --context` command already uses.
+
+```
+  ┌─ k3d-fundament ─────────────────┐        ┌─ k3d-fundament-plugin ─────────┐
+  │ the platform                    │        │ the sandbox                    │
+  │ Justfile: repository root       │        │ Justfile: plugins/             │
+  ├─────────────────────────────────┤        ├────────────────────────────────┤
+  │ fundament namespace             │        │ fundament namespace            │
+  │   organization-api              ◄──(1)───┤   plugin-controller            │
+  │   authn-api · dex               │        │        │ creates               │
+  │   authz-worker + OpenFGA        │        │        ▼                       │
+  │   CloudNativePG (db)            │        │ plugin-<name> namespace        │
+  │   console-frontend              │        │   the plugin's Deployment      │
+  │   docs-frontend                 │        │   + what the plugin installs   │
+  │   plugin-proxy · kube-api-proxy ├──(2)───►     (cert-manager, Rook, …)    │
+  │ ingress-nginx                   │        │                                │
+  │   *.fundament.localhost:8443    │        │ no ingress                     │
+  │ registry  localhost:5111        │        │ registry  localhost:5112       │
+  └─────────────────────────────────┘        └────────────────────────────────┘
+```
+
+The clusters sit on separate Docker networks, so the two links between them are created by
+hand. **Both must be re-run after recreating either cluster** — each resolves a container IP
+that changes.
+
+**(1) `just plugin-sandbox-orgapi`** — run from `plugins/`. The plugin-controller resolves a
+`PluginInstallation` by fetching its published definition from organization-api (FUN-19).
+
+**(2) `just plugin-sandbox-kubeconfig`** — run from the repository root, then restart
+plugin-proxy and kube-api-proxy. One Secret, read by both: it is what lets the console see and
+manage what is installed in the sandbox (FUN-17). It does more than it sounds like — locally
+kube-api-proxy runs in `mock` mode serving an in-memory fake cluster, and this Secret replaces
+that mock with a real proxy to the sandbox. Until it exists the console shows fabricated data
+and plugin pages fail to load. It is mounted optionally, so plugin-proxy starts and reports
+healthy without it.
+
+This mirrors production: Fundament manages *other* clusters, and a plugin runs on the managed
+cluster, not on the platform itself.
+
+## Which `just dev` am I running?
+
+Both Justfiles define a `dev` recipe, and they deploy different things to different clusters.
+`just` resolves the recipe from the **current directory**, and neither recipe honours your
+kubectl context — both skaffold configurations pin `kubeContext`, so
+`kubectl config use-context` has no effect on where they deploy.
+
+| Run from | Recipe | Deploys | To |
+|---|---|---|---|
+| repository root | `just dev` | the full platform | `k3d-fundament` |
+| `plugins/` | `just dev` | plugin-controller only | `k3d-fundament-plugin` |
+
+Every command in these docs therefore names the directory it runs in. When in doubt, `pwd`.
+
+## How long it takes
+
+On a cold Docker cache, from no images at all:
+
+| Step | Time |
+|---|---|
+| `just cluster-start` (platform) | ~1 min |
+| `just dev` (platform, 14 images) | ~6 min to build, a few more to roll out |
+| sandbox cluster + `just dev` | ~1 min |
+| `just plugin-publish` (first plugin) | ~4 min |
+
+Measured on an 8-CPU macOS VM after `docker system prune -a`, so nothing was cached. Around
+fifteen minutes in total before a plugin is installable; later runs reuse the build cache and are
+much quicker. There is no prebuilt-image path — every platform image is built locally.
+
+## Next
+
+- Prerequisites and the platform cluster: [Getting started](../fundament/getting-started.md)
+- The commands, in order: [Install a plugin](./install-a-plugin.md)
+- Raw block devices, for the `ceph-rook` plugin only:
+  [Block devices for k3d](../fundament/k3d-block-devices.md)

--- a/docs/developer/plugins/example-ceph-rook.md
+++ b/docs/developer/plugins/example-ceph-rook.md
@@ -1,10 +1,15 @@
 ---
 title: "Example: Ceph Storage (Rook)"
 sidebar:
-  order: 5
+  label: Ceph/Rook plugin
+  order: 8
 ---
 
 The ceph-rook plugin provides block storage for in-cluster workloads by installing and managing the Rook-Ceph operator and a singleton CephCluster.
+
+**Advanced.** Storage is the most demanding plugin to run locally — it needs raw block devices
+and a virtualised Docker host. It is not part of the standard
+[plugin walkthrough](./install-a-plugin.md).
 
 :::tip[Verifying it works]
 This page describes the design. To actually exercise the plugin against a local

--- a/docs/developer/plugins/example-cert-manager.md
+++ b/docs/developer/plugins/example-cert-manager.md
@@ -1,10 +1,18 @@
 ---
 title: "Example: cert-manager"
 sidebar:
-  order: 5
+  label: cert-manager plugin
+  order: 4
 ---
 
-The cert-manager plugin is a reference implementation that installs and manages cert-manager.
+The cert-manager plugin is a reference implementation that installs and manages cert-manager. It
+The version a `PluginInstallation` pins is the plugin's own `metadata.version`, from
+`plugins/cert-manager/definition.yaml`.
+
+:::tip[Install and test it]
+This page describes the design. To run it locally, follow
+[Install a plugin](./install-a-plugin.md) — cert-manager is the plugin that walkthrough uses.
+:::
 
 ## What it does
 
@@ -43,7 +51,7 @@ helpers — copy it as a starting point for new plugins. See
 [Custom UI](custom-ui) for the pattern and
 [Console integration](console-integration) for the architecture.
 
-## Why it needs `cluster-admin`
+## Why it needs cluster-wide RBAC
 
 cert-manager installs cluster-scoped resources that require broad permissions:
 - CRDs (`certificates.cert-manager.io`, etc.)
@@ -51,19 +59,24 @@ cert-manager installs cluster-scoped resources that require broad permissions:
 - ValidatingWebhookConfigurations / MutatingWebhookConfigurations
 - Resources across multiple namespaces
 
-The default namespace-admin RoleBinding only covers the plugin's own namespace. The `clusterRoles: [cluster-admin]` field in the PluginInstallation grants the additional access.
+The default namespace-admin RoleBinding only covers the plugin's own namespace. The extra access
+is declared by the plugin itself, under `spec.permissions.rbac` in
+`plugins/cert-manager/definition.yaml`, as a set of narrowly scoped rules — not `cluster-admin`.
+The controller materialises those rules into a `plugin-cert-manager-scope` ClusterRole at install
+time, which is what lets an admin see the exact permissions before approving them.
+
+The installation itself therefore carries no permissions at all:
 
 ```yaml
-# plugins/cert-manager/install.yaml
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
-  name: cert-manager-test
+  name: cert-manager
 spec:
-  image: localhost:5111/cert-manager-plugin:latest
-  pluginName: cert-manager-test
-  clusterRoles:
-    - cluster-admin
+  definitionRef:
+    pluginName: cert-manager
+    pluginVersion: …          # metadata.version from definition.yaml
+    definitionHash: sha256:…  # required — printed by plugin-publish
 ```
 
 ## Plugin lifecycle

--- a/docs/developer/plugins/index.md
+++ b/docs/developer/plugins/index.md
@@ -2,16 +2,27 @@
 title: Plugins
 sidebar:
   label: Overview
-  order: 2
+  order: 1
 ---
 
 The plugin system allows extending Fundament with installable plugins that integrate into the platform's console UI, RBAC, and lifecycle management.
+
+## Start here
+
+This page is reference material. To actually do something:
+
+| I want to… | Go to |
+|---|---|
+| Run Fundament on my machine | [Getting started](/docs/developer/fundament/getting-started) |
+| Understand the local setup | [The two development clusters](/docs/developer/plugins/dev-environment) |
+| **Install and test a plugin** | [Install a plugin](/docs/developer/plugins/install-a-plugin) |
+| Write a plugin of my own | [Writing a plugin](/docs/developer/plugins/writing-a-plugin) |
 
 ## System overview
 
 ```
   ┌──────────────────────────────────────────────────────────────────────────┐
-  │                         Fundament Cluster                                │
+  │              Managed cluster (locally: k3d-fundament-plugin)             │
   │                                                                          │
   │  PluginInstallation CRs (cluster-scoped)                                 │
   │  ┌──────────────────────┐                                                │
@@ -37,8 +48,8 @@ The plugin system allows extending Fundament with installable plugins that integ
   │  ┌───────────────────────┐  ┌───────────────────────┐                    │
   │  │ SA + RoleBinding      │  │ SA + RoleBinding      │                    │
   │  │ Deployment + Service  │  │ Deployment + Service  │                    │
-  │  │ (+ ClusterRoleBinding │  │                       │                    │
-  │  │  if requested)        │  │                       │                    │
+  │  │ + plugin-scope        │  │                       │                    │
+  │  │   ClusterRole         │  │                       │                    │
   │  └───────────────────────┘  └───────────────────────┘                    │
   └──────────────────────────────────────────────────────────────────────────┘
 ```
@@ -195,30 +206,44 @@ The controller watches `PluginInstallation` CRs.
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
-  name: cert-manager-test
+  name: cert-manager
 spec:
-  image: ghcr.io/fundament-oss/fundament/cert-manager-plugin:v1.0.0
-  pluginName: cert-manager-test
-  clusterRoles:          # Optional: bind SA to these ClusterRoles
-    - cluster-admin
-  config:                # Optional: extra env vars (injected with FUNP_ prefix)
-    LOG_LEVEL: debug     # → becomes FUNP_LOG_LEVEL in the container
+  definitionRef:              # Which published definition to install
+    pluginName: cert-manager
+    pluginVersion: v1.2.3     # the plugin's own version, not the platform's
+    definitionHash: sha256:…  # the admin's consent record; see below
+  config:                     # Optional: extra env vars (injected with FUNP_ prefix)
+    LOG_LEVEL: debug          # → becomes FUNP_LOG_LEVEL in the container
 ```
+
+`definitionRef` and `config` are the only fields you set. The container image and the plugin's
+RBAC are **not** in the CR — they come from the published definition the reference resolves to
+(FUN-19). `definitionRef` is immutable once set: to move a plugin to a new version, delete and
+recreate the installation.
+
+`definitionHash` records exactly which definition an admin approved. Always set it: although
+`pluginController.allowUnpinnedHash` suggests otherwise, the CRD's immutability rule rejects the
+controller's first update when the hash is absent, and the installation never reconciles — see
+[Install a plugin](/docs/developer/plugins/install-a-plugin).
 
 ### What the controller creates
 
 For each `PluginInstallation`, the controller creates:
 
 ```
-  plugin-{pluginName} namespace
-  ├─ ServiceAccount/plugin-{pluginName}
+  plugin-{name} namespace                    ← {name} is metadata.name, max 56 chars
+  ├─ ServiceAccount/plugin-{name}
   ├─ RoleBinding ──► ClusterRole/admin (always, namespace-scoped)
-  ├─ Deployment (runs the plugin image)
+  ├─ Deployment (image taken from the published definition)
   └─ Service (:8080)
 
-  ClusterRoleBinding (only if spec.clusterRoles is set)
-  └─ Binds SA to requested ClusterRoles at cluster scope
+  ClusterRole/plugin-{name}-scope + binding
+  └─ Materialised from the definition's spec.permissions.rbac
 ```
+
+The cluster-scoped permissions are always derived from the published definition, never requested
+by the CR. That is what lets an admin see, at install time, exactly what a plugin will be able to
+do.
 
 ### RBAC model
 
@@ -234,10 +259,11 @@ For each `PluginInstallation`, the controller creates:
   └─────────────────────────────────────┘
                   +
   ┌─────────────────────────────────────┐
-  │  OPTIONAL (spec.clusterRoles)       │
+  │  FROM THE PUBLISHED DEFINITION      │
   │                                     │
-  │  ClusterRoleBinding                 │
-  │  → ClusterRole/{requested}          │
+  │  ClusterRole/plugin-{name}-scope    │
+  │  → rules from                       │
+  │    spec.permissions.rbac            │
   │                                     │
   │  For plugins that need cluster-wide │
   │  access (CRDs, webhooks, resources  │
@@ -254,7 +280,7 @@ For each `PluginInstallation`, the controller creates:
   Add finalizer ──► Create Namespace ──► Create SA
            │
            ├──► Create RoleBinding (→ admin)
-           ├──► Create ClusterRoleBindings (if spec.clusterRoles)
+           ├──► Materialise plugin-scope ClusterRole + binding
            ├──► Create Deployment
            ├──► Create Service
            │
@@ -275,7 +301,7 @@ For each `PluginInstallation`, the controller creates:
 
 ```
   CR deleted ──► Finalizer triggers:
-                 ├─ Delete ClusterRoleBindings (if any)
+                 ├─ Delete the plugin-scope ClusterRole + binding
                  ├─ Delete Namespace (cascades to all resources)
                  └─ Remove finalizer → CR garbage collected
 ```

--- a/docs/developer/plugins/install-a-plugin.md
+++ b/docs/developer/plugins/install-a-plugin.md
@@ -1,0 +1,233 @@
+---
+title: Install a plugin
+sidebar:
+  order: 3
+---
+
+Install `cert-manager` into the local `k3d-fundament-plugin` sandbox cluster, prove it works,
+and see it in the console. This is the standard path for working with plugins locally, and the
+one to follow first.
+
+About fifteen minutes from a cold Docker cache, much less with a warm one — see the
+[timings](./dev-environment.md#how-long-it-takes).
+
+**Before you start:** the platform must be running —
+[Getting started](../fundament/getting-started.md) — and it is worth reading
+[The two development clusters](./dev-environment.md) first, because every step below names the
+directory it runs in and the two directories mean different things.
+
+## 1. Create the `k3d-fundament-plugin` sandbox cluster
+
+From `plugins/`:
+
+```bash
+cd plugins
+just cluster-create
+just dev
+```
+
+`cluster-create` must run from `plugins/` — the k3d config resolves paths relative to it. This
+`just dev` is the `plugins/` recipe, not the one at the repository root: it deploys the
+plugin-controller into `k3d-fundament-plugin` and then watches for changes.
+
+Like the platform one it passes `--cleanup=false`, so once the controller is available you can
+stop it with Ctrl-C and everything stays deployed. Keep it running only while you are editing
+plugin-controller source.
+
+## 2. Bridge the two clusters
+
+```bash
+just plugin-sandbox-orgapi
+```
+
+Still in `plugins/`. This lets the controller reach organization-api to fetch plugin
+definitions.
+
+The second bridge is what makes the console real: locally kube-api-proxy runs in `mock` mode and
+serves an in-memory fake cluster, and this replaces that mock with a proxy to the real sandbox.
+From the **repository root**:
+
+```bash
+cd ..
+just plugin-sandbox-kubeconfig
+```
+
+That writes a Secret holding a kubeconfig for the sandbox, restarts the two consumers that
+mount it, and waits until one of them confirms the switch. It ends with:
+
+```
+- kube-api-proxy is proxying to the sandbox (mock disabled)
+```
+
+If you do not see that line the bridge is not in place, and plugin pages in the console will
+fail to load.
+
+Re-run both bridges after recreating either cluster.
+
+## 3. Publish the plugin definition
+
+A plugin is installed by reference: you publish its **definition** to organization-api, then
+point a `PluginInstallation` at it. From `plugins/`:
+
+```bash
+cd plugins
+export PLUGIN_REGISTRY=localhost:5112
+export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
+export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
+export FUNDAMENT_TOKEN=$(../deploy/k3d/dev-token.sh)
+just plugin-publish cert-manager
+```
+
+Expect a last line like:
+
+```
+published plugin=cert-manager version=… hash=sha256:… id=… definition_id=…
+```
+
+`dev-token.sh` logs in as `platform-admin@fundament.io`. That identity matters: publishing
+requires admin of the organization that owns the plugin, first-party plugins are owned by the
+seeded `system` org, and the ordinary dev logins are not members of it. Republishing the same
+version needs `--replace`.
+
+## 4. Install it
+
+`pluginVersion` and `definitionHash` must both match what step 3 printed — the version is the
+plugin's own (`metadata.version` in its `definition.yaml`), not a Fundament version, and it
+differs per plugin. Copy both from that output rather than from here:
+
+```bash
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: plugins.fundament.io/v1
+kind: PluginInstallation
+metadata:
+  name: cert-manager
+spec:
+  definitionRef:
+    pluginName: cert-manager
+    pluginVersion: PASTE_THE_VERSION_FROM_STEP_3
+    definitionHash: PASTE_THE_HASH_FROM_STEP_3
+YAML
+```
+
+The `PluginInstallation` goes in the **sandbox**, not the platform. `definitionHash` is the
+admin's record of exactly which definition was approved.
+
+:::caution[Always set `definitionHash`, even locally]
+The sandbox sets `pluginController.allowUnpinnedHash: true`, which suggests the hash can be
+omitted. It cannot. The CRD marks `definitionRef` immutable with a `self == oldSelf` rule, and an
+absent `definitionHash` does not survive the controller's round-trip, so its very first update is
+rejected:
+
+```
+add finalizer: PluginInstallation … spec.definitionRef: Invalid value: definitionRef is immutable once set
+```
+
+The CR is created but never reconciles: `PHASE` stays empty and no namespace appears. Delete it,
+re-apply with the hash, and it proceeds.
+
+:::
+
+## 5. Watch it come up
+
+```bash
+just plugin-status
+just plugin-logs cert-manager
+```
+
+Expect `PHASE=Running` and `READY=true`. The first install pulls the cert-manager images and
+takes a few minutes; the controller polls plugin status every 30 seconds, so the CR lags a
+little behind reality.
+
+```bash
+kubectl --context k3d-fundament-plugin get plugininstallations
+kubectl --context k3d-fundament-plugin -n cert-manager get pods
+```
+
+## 6. Prove it works
+
+```bash
+just cert-manager test
+```
+
+This creates a self-signed `ClusterIssuer` and a `Certificate` and waits for cert-manager to
+issue it. Clean up with `just cert-manager test-cleanup`.
+
+## 7. See it in the console
+
+Open <https://console.fundament.localhost:8443> and sign in as `alice@acme-corp.com` with
+password `password`. Go to **Clusters → acme-cluster → cert-manager → ClusterIssuers**.
+
+A blank or erroring panel here almost always means step 2 was skipped, or a cluster was recreated
+after the bridges were made.
+
+## Clean up
+
+```bash
+just plugin-uninstall cert-manager
+just cluster-delete
+```
+
+## Known issues on this path
+
+### A platform redeploy invalidates published plugin definitions
+
+`charts/fundament/values-local.yaml` sets `db.reset: true`, so every `just dev` at the repository
+root re-seeds the platform database and drops every published `PluginDefinition`.
+
+`just plugin-status` will not show it: the `PluginInstallation` keeps reporting `Running` and
+`READY=true`, because that status reflects the plugin's own health rather than the controller's
+ability to resolve its definition. It surfaces in the controller log:
+
+```
+fetch definition: GetPluginDefinition RPC: not_found: plugin definition cert-manager@… not found
+```
+
+**Recovery:** redo step 3, then **delete and re-apply** the `PluginInstallation` with the newly
+printed hash. It cannot be edited in place — the whole of `definitionRef` is immutable, so
+`kubectl apply`/`edit` is rejected with `definitionRef is immutable once set`.
+
+Deleting runs the plugin's uninstall path, so whatever it manages goes with it — for
+cert-manager that means cert-manager itself leaves the sandbox and is reinstalled by the new CR.
+
+The hash covers the published manifest, and `plugin-publish` injects the freshly built image's
+digest into that manifest before hashing. So the hash only stays the same if the rebuild
+reproduces a byte-identical image — which a warm Docker cache does, and a cold one does not.
+Observed: the same `definition.yaml` published as `sha256:7c9dcb61…` from a warm cache and
+`sha256:782914be…` after `docker system prune -a`. Do not assume it is stable.
+
+
+### `permission_denied` when publishing after a redeploy
+
+The same reset recreates the OpenFGA store, and the authorization tuples written earlier can be
+left behind in the previous one. Every authorization decision then resolves to false while every
+pod looks healthy — including when the seeded admin row and the tuples themselves look correct.
+Restarting `organization-api`, `kube-api-proxy` or `authz-worker` does **not** repair it.
+
+**Recovery:** redeploy the platform again, then republish.
+
+
+## Other plugins
+
+Steps 3 to 6 work for any plugin that has a catalog entry — only the name and version change.
+Steps 1 and 2 are one-time setup, and `ceph-rook` is the exception: it needs block devices on
+the node and has its own verification procedure.
+
+`plugin-publish` takes a **path** under `plugins/`, while `pluginName` in the CR is the
+`metadata.name` from that plugin's `definition.yaml`. They differ for the gateway plugin.
+
+| Plugin (`pluginName`) | `plugin-publish` argument | Notes |
+|---|---|---|
+| `cert-manager` | `cert-manager` | This walkthrough. Has `just cert-manager test` |
+| `openfsc` | `openfsc` | Extra setup first; see `plugins/openfsc/README.md` |
+| `gateway-api-envoy` | `gateway-api/envoy-gateway` | — |
+| `ceph-rook` | `storage/ceph-rook` | **Different procedure** — needs raw block devices and its own baseline checks. Follow the [Ceph/Rook runbook](./ceph-rook-runbook.md), not these steps |
+| `external-dns` | — | **Not installable today** — see below |
+| `gateway-api-istio` | — | **Not installable today** — same reason as `external-dns` |
+
+Each plugin's version is in its own `definition.yaml`, and `plugin-publish` prints it.
+
+`external-dns` and `gateway-api-istio` have source and a `definition.yaml`, but neither is
+registered as a module in `plugins/Justfile` nor present in `db/seed/0101-appstore-catalog.sql`.
+So `just external-dns test` does not resolve, and `just plugin-publish` on either fails with
+`no catalog entry`.
+

--- a/docs/developer/plugins/writing-a-plugin.md
+++ b/docs/developer/plugins/writing-a-plugin.md
@@ -1,7 +1,7 @@
 ---
 title: Writing a plugin
 sidebar:
-  order: 3
+  order: 5
 ---
 
 Writing a plugin consists of several steps, each described below.
@@ -170,18 +170,28 @@ ENTRYPOINT ["/my-plugin"]
 
 ### 5. Create a PluginInstallation
 
+A plugin is not installed by pointing at an image. You publish its **definition** to
+organization-api, then reference that:
+
+```bash
+just plugin-publish my-plugin      # from plugins/ — prints the version and hash
+```
+
 ```yaml
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
   name: my-plugin
 spec:
-  image: registry.example.com/my-plugin:v1.0.0
-  pluginName: my-plugin
-  # Only if your plugin needs cluster-wide access:
-  # clusterRoles:
-  #   - cluster-admin
+  definitionRef:
+    pluginName: my-plugin          # metadata.name from your definition.yaml
+    pluginVersion: v1.0.0          # metadata.version from your definition.yaml
+    definitionHash: sha256:…       # printed by plugin-publish
 ```
+
+The image and the cluster-wide RBAC come from the published definition, not from this CR. The
+full walkthrough, with the cluster setup it needs, is
+[Install a plugin](./install-a-plugin.md).
 
 ## Metadata API
 
@@ -199,6 +209,9 @@ service PluginMetadataService {
 | Plugin Controller | `GetStatus` | Poll phase, message, version → write to CR `.status` |
 | Console Frontend | `GetDefinition` | Fetch menu entries, UI hints, CRDs → render plugin UI |
 
-## Plugin sandbox
+## Next steps
 
-A self-contained development environment for plugin development. See [`plugins/README.md`](https://github.com/fundament-oss/fundament/blob/master/plugins/README.md) for setup instructions and available commands.
+- [Install a plugin](./install-a-plugin.md) — publish and install what you just built, on the
+  local two-cluster setup.
+- [`plugins/README.md`](https://github.com/fundament-oss/fundament/blob/master/plugins/README.md)
+  — the command reference for the sandbox.

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,8 @@ FUNCTL_DEBUG = "true"
 # Scripting & Meta
 just = "1.42.4"
 act = "0.2.84"
+jq = "1.7.1"
+yq = "4.44.3"
 
 # Database
 "go:github.com/printeers/trek" = "0.12.1"

--- a/plugins/Justfile
+++ b/plugins/Justfile
@@ -2,6 +2,9 @@ mod cert-manager
 mod openfsc
 mod envoy-gateway 'gateway-api/envoy-gateway'
 mod ceph-rook 'storage/ceph-rook'
+# TODO: external-dns and gateway-api/istio have source and a definition.yaml but are neither
+# registered here nor present in db/seed/0101-appstore-catalog.sql, so they cannot be published
+# or tested. Add the mod line and the catalog row.
 
 cluster := "fundament-plugin"
 registry := "plugin-registry.localhost"

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,38 +1,97 @@
 # Plugin Sandbox
 
-A self-contained development environment lives in `sandbox/`. It creates an isolated K3D cluster with only the plugin controller -- no database, auth services, or other Fundament components needed. The sandbox cluster (`fundament-plugin`) uses a separate registry on port `5112`, so it can coexist with the main Fundament cluster without conflicts.
+`sandbox/` holds a development environment for plugin work: the `k3d-fundament-plugin` sandbox
+cluster, running only the plugin-controller, with its own registry on port `5112` so it coexists
+with the `k3d-fundament` platform cluster.
 
-## Quick Start
+The sandbox is not self-contained. A plugin is installed by publishing its **definition** to
+organization-api and referencing it from a `PluginInstallation` (FUN-19), so the management
+cluster — database, organization-api, OpenFGA and a dex login — has to be running too. See
+[Install a plugin](../docs/developer/plugins/install-a-plugin.md) for the walkthrough, and
+[The two development clusters](../docs/developer/plugins/dev-environment.md) for how the two
+clusters fit together and which directory each command runs in. This file is the command
+reference.
+
+## Quick start
+
+Run these from `plugins/`:
 
 ```shell
-just cluster-create   # Create K3D cluster + registry (~10s)
-just dev              # Build + deploy plugin-controller with file watching
-just deploy           # One-time build without file watching
+just cluster-create   # K3D cluster + registry (~10s)
+just dev              # build + deploy plugin-controller, with file watching
+just deploy           # one-time build without file watching
+just plugin-sandbox-orgapi   # bridge the controller to organization-api
+```
 
-# In another terminal:
-just plugin-install cert-manager   # Build plugin, push to registry, apply CR
-just plugin-status                 # Check PluginInstallation status
-just logs                          # Watch controller logs
+Then publish a definition and install it. `plugin-publish` builds the image, pushes it and
+registers the definition, printing the `definitionHash` the `PluginInstallation` must pin:
 
-# Verify cert-manager actually works:
-just cert-manager test             # Creates a self-signed ClusterIssuer + Certificate
-just cert-manager test-cleanup     # Remove test resources
+```shell
+export PLUGIN_REGISTRY=localhost:5112
+export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
+export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
+export FUNDAMENT_TOKEN=$(../deploy/k3d/dev-token.sh)
 
-# Install and verify external-dns:
-just plugin-install external-dns   # Build plugin, push to registry, apply CR
-just external-dns test             # Creates a DNSEndpoint resource
-just external-dns test-cleanup     # Remove test resources
+just plugin-publish cert-manager
+# published plugin=cert-manager version=… hash=sha256:… id=… definition_id=…
+```
 
-# Install and verify OpenFSC (see plugins/openfsc/README.md):
-just openfsc operator-push         # Build the openfsc-operator image for the sandbox
-just plugin-install openfsc        # Installs prerequisites + the operator
-just openfsc test                  # Sample FSCInstallation reaches Active
-just openfsc test-cleanup          # Remove the sample installation
+```shell
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: plugins.fundament.io/v1
+kind: PluginInstallation
+metadata:
+  name: cert-manager
+spec:
+  definitionRef:
+    pluginName: cert-manager
+    pluginVersion: …             # printed by plugin-publish
+    definitionHash: sha256:PASTE_THE_HASH
+YAML
+```
 
-# Cleanup:
-just plugin-uninstall cert-manager
-just plugin-uninstall external-dns
+Republishing an existing `pluginVersion` needs `--replace`, which soft-deletes the previous
+definition. The printed hash covers the manifest *including the freshly built image's digest*, so
+it changes whenever the rebuild is not byte-identical — after a cold rebuild, update
+`definitionHash` in any `PluginInstallation` that pins it.
+
+Always set `definitionHash`. `pluginController.allowUnpinnedHash: true` in the sandbox implies it
+is optional, but an absent hash trips the CRD's `definitionRef` immutability rule on the
+controller's first update and the installation silently never reconciles.
+
+Each plugin has its own `pluginVersion`, and the `plugin-publish` argument is a **path** under
+`plugins/` rather than the plugin name. The table of both, per plugin, is in
+[Install a plugin](../docs/developer/plugins/install-a-plugin.md#other-plugins).
+
+## Working with an installed plugin
+
+```shell
+just plugin-status                 # all PluginInstallation CRs
+just plugin-logs cert-manager      # stream one plugin's logs
+just logs                          # plugin-controller logs
+just plugin-uninstall cert-manager # delete the PluginInstallation
 just cluster-delete
 ```
 
-All commands are defined in the `Justfile`. Run `just --list` to see available commands.
+Per-plugin verification lives in each plugin's own module:
+
+```shell
+just cert-manager test             # self-signed ClusterIssuer + Certificate
+just cert-manager test-cleanup
+just openfsc operator-push         # build the openfsc-operator image for the sandbox
+just openfsc test                  # sample FSCInstallation reaches Active
+just openfsc test-cleanup
+```
+
+For `ceph-rook`, which needs raw block devices and a longer setup, follow the
+[verification runbook](../docs/developer/plugins/ceph-rook-runbook.md).
+
+## external-dns is not installable
+
+`plugins/external-dns/` has source, a `Justfile` and test resources, but it is **not** registered
+as a `mod` in this directory's `Justfile` and has **no** entry in
+`db/seed/0101-appstore-catalog.sql`. So `just external-dns test` does not resolve, and
+`just plugin-publish external-dns` fails with `no catalog entry for "external-dns"`.
+
+
+All commands are defined in the `Justfile`; run `just --list` to see them.

--- a/plugins/sandbox/values.yaml
+++ b/plugins/sandbox/values.yaml
@@ -34,7 +34,11 @@ ingress:
 pluginController:
   enabled: true
   logLevel: debug
-  # `just plugin-install` sets an empty definitionHash; allow it in the sandbox.
+  # Allow a PluginInstallation that pins no definitionHash; the sandbox trusts its own registry.
+  # TODO: this cannot actually be used. The CRD marks definitionRef immutable (self == oldSelf)
+  # and the controller round-trips an absent definitionHash as "", so its first update is
+  # rejected and the installation never reconciles. Either make the rule tolerate an absent
+  # hash, or drop this flag.
   allowUnpinnedHash: true
   # The sandbox cluster is network-isolated from organization-api (which lives in
   # the management cluster). `just plugin-sandbox-orgapi` bridges the two via a


### PR DESCRIPTION
- **fix(k3d): wait for conditions instead of racing them**
- **fix(console): allow plugin-proxy as a frame source**
- **docs(developer): make the local plugin path followable end to end**
