### PR TITLE
feat(k3d): finish the sandbox bridge instead of half-doing it

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -174,8 +174,39 @@ plugin-sandbox-kubeconfig:
         --dry-run=client -o yaml | \
         kubectl --context k3d-fundament-plugin apply -f -
 
-    echo "plugin-sandbox-kubeconfig Secret updated. Restart plugin-proxy:"
-    echo "  kubectl --context k3d-fundament -n fundament rollout restart deployment/plugin-proxy"
+    # The console refuses a plugin install unless the cluster reports RUNNING, which
+    # organization-api derives from tenant.clusters.shoot_status = 'ready'. Locally there is
+    # no Gardener to set it, so the seeded row stays NULL and the cluster shows as
+    # provisioning forever. Every cluster id routes to the sandbox here (see
+    # kube-api-proxy/pkg/kube/sandbox_proxy.go), so the sandbox just wired up is what those
+    # rows stand for — which makes this the point where "ready" becomes true. A db.reset
+    # clears it again, and re-running this recipe is already the documented step after one.
+    echo "- marking the local cluster(s) ready so the console allows plugin installs"
+    kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+        psql -U postgres -d fundament -qc \
+        "UPDATE tenant.clusters SET shoot_status = 'ready', shoot_status_updated = now() \
+         WHERE deleted IS NULL AND shoot_status IS DISTINCT FROM 'ready';" \
+        || echo "  (could not reach the database — the console will still show provisioning)" >&2
+
+    # Both consumers read the Secret only at startup, and Reloader does not reliably pick
+    # this one up, so restart them here rather than leave a Secret that has no effect.
+    echo "- restarting plugin-proxy and kube-api-proxy to pick the Secret up"
+    kubectl --context k3d-fundament -n fundament rollout restart \
+        deployment/plugin-proxy deployment/kube-api-proxy > /dev/null
+    kubectl --context k3d-fundament -n fundament rollout status deployment/kube-api-proxy --timeout=180s > /dev/null
+
+    # Confirm the new pod actually switched off the in-memory mock. `rollout status`
+    # returns slightly before the logs are attached, so poll rather than read once.
+    for i in $(seq 1 30); do
+        if kubectl --context k3d-fundament -n fundament logs deployment/kube-api-proxy 2>/dev/null \
+            | grep -q "plugin sandbox cluster"; then
+            echo "- kube-api-proxy is proxying to the sandbox (mock disabled)"
+            exit 0
+        fi
+        sleep 2
+    done
+    echo "kube-api-proxy did not report the sandbox proxy; check: kubectl -n fundament logs deployment/kube-api-proxy" >&2
+    exit 1
 
 # Delete deployment, can also be used to remove the deployment created by `just dev`.
 undeploy env:

--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- include "fundament.labels" (dict "root" $ "name" "kube-api-proxy" "component" "backend") | nindent 4 }}
   annotations:
     reloader.stakater.com/auto: "true"
+    {{- if $.Values.kubeApiProxy.sandboxKubeconfigSecret }}
+    # `auto` only tracks what a pod actually references, and the sandbox kubeconfig is
+    # mounted optional: true — created out of band after this pod is already running, so
+    # the pod never referenced it and a later create goes unnoticed. Name it explicitly.
+    secret.reloader.stakater.com/reload: {{ $.Values.kubeApiProxy.sandboxKubeconfigSecret | quote }}
+    {{- end }}
 spec:
   replicas: {{ $.Values.kubeApiProxy.replicas }}
   selector:

--- a/charts/fundament/templates/plugin-proxy.yaml
+++ b/charts/fundament/templates/plugin-proxy.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- include "fundament.labels" (dict "root" $ "name" "plugin-proxy" "component" "backend") | nindent 4 }}
   annotations:
     reloader.stakater.com/auto: "true"
+    {{- if $.Values.pluginProxy.sandboxKubeconfigSecret }}
+    # `auto` only tracks what a pod actually references, and the sandbox kubeconfig is
+    # mounted optional: true — created out of band after this pod is already running, so
+    # the pod never referenced it and a later create goes unnoticed. Name it explicitly.
+    secret.reloader.stakater.com/reload: {{ $.Values.pluginProxy.sandboxKubeconfigSecret | quote }}
+    {{- end }}
 spec:
   replicas: {{ $.Values.pluginProxy.replicas }}
   selector:

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,8 @@ FUNCTL_DEBUG = "true"
 # Scripting & Meta
 just = "1.42.4"
 act = "0.2.84"
+jq = "1.7.1"
+yq = "4.44.3"
 
 # Database
 "go:github.com/printeers/trek" = "0.12.1"


### PR DESCRIPTION
`just plugin-sandbox-kubeconfig` wrote a Secret that both proxies only read at startup, then printed an instruction to restart one of them by hand. The common outcome was a Secret with no effect and a console that fails to load plugin pages, with nothing obviously wrong.

It now does the whole job:

- **restarts both consumers** (`plugin-proxy` and `kube-api-proxy`), not just the one named in the old message;
- **waits until `kube-api-proxy` reports it has left mock mode**, polling the log rather than reading it once, since `rollout status` returns slightly before logs attach;
- **fails loudly** if that line never appears, instead of exiting 0 on a bridge that is not in place.

### Marking the cluster ready

The console refuses a plugin install unless the cluster reports `RUNNING`, which `organization-api` derives from `tenant.clusters.shoot_status = 'ready'` (`cluster_convert.go`). Locally there is no Gardener to set it, so the seeded row stays `NULL` and the cluster shows as provisioning forever.

Every cluster id routes to the sandbox locally (`kube-api-proxy/pkg/kube/sandbox_proxy.go`), so the sandbox this recipe has just wired up is exactly what those rows stand for — which makes this the point where "ready" becomes true. A `db.reset` clears it again, and re-running this recipe is already the documented step after one.

### Reloader annotations

`reloader.stakater.com/auto` only tracks what a pod already references. The sandbox kubeconfig is mounted `optional: true` and created out of band after the pod is running, so the pod never referenced it and a later create goes unnoticed. Named explicitly on both deployments.

### mise

`jq` and `yq` are now declared. `deploy/k3d/dev-token.sh` (#380) pipes into `yq` and nothing declared it, so on a fresh checkout the script fails after the login request has already gone out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQaEdg2pvdMCYGQhj7Fm1i
