### PR TITLE
docs(developer): make the local plugin path followable end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,20 @@ The focus of the project is currently on research and ideation. Some initial PoC
 
 ## Documentation
 
+Published at **<https://docs.fundament.projects.digilab.network/docs>**. The pages below are the
+same content, rendered on GitHub.
+
 - [Overview](docs/user/overview.md)
 - [Infrastructure](docs/user/infrastructure.md)
 - [Organizations and projects](docs/user/organizations.md)
 - [Plugins](docs/user/plugins.md)
-- [Fundament development](docs/developer/fundament/getting-started.md)
-- [Plugin development](docs/developer/plugins/index.md)
+- [Run Fundament locally](docs/developer/fundament/getting-started.md)
+- [The two development clusters](docs/developer/plugins/dev-environment.md)
+- [Install and test a plugin](docs/developer/plugins/install-a-plugin.md)
+- [Plugin development reference](docs/developer/plugins/index.md)
+
+Once the platform is running locally, the same documentation is served from the cluster at
+<https://docs.fundament.localhost:8443>.
 
 ## Contributing
 

--- a/charts/fundament/values-local.yaml
+++ b/charts/fundament/values-local.yaml
@@ -19,6 +19,12 @@ db:
   enabled: true
   instances: 1
   storageSize: 1Gi
+  # Resetting on every deploy is what makes testdata re-appliable: db/testdata/*.sql use
+  # plain INSERTs, unlike db/seed/*.sql which upsert. The side effect is that published
+  # PluginDefinitions go too, while the PluginInstallations referencing them live in the
+  # sandbox cluster and are not reset — so they dangle, and keep reporting Running.
+  # TODO: make testdata idempotent (ON CONFLICT) so this can be opt-in, and surface an
+  # unresolvable definitionRef in PluginInstallation.status.
   reset: true
   insertTestData: true
   exposePort: 54328

--- a/docs/developer/fundament/getting-started.md
+++ b/docs/developer/fundament/getting-started.md
@@ -12,6 +12,11 @@ sidebar:
 - [Docker](https://www.docker.com)
 - `certutil` (part of NSS tools). Required for `mkcert` to install the CA into system trust stores
 
+Every other tool these docs use is provided by mise — see `mise.toml` for the list. The
+commands throughout assume an activated mise environment; without one they are not on `PATH`.
+Either [activate mise in your shell](https://mise.jdx.dev/getting-started.html) or prefix
+commands with `mise x --`.
+
 ### Installing certutil
 
 **macOS:**
@@ -57,18 +62,82 @@ mise install
 
 ## Run cluster
 
+From the repository root:
+
 ```shell
 just cluster-start
 just dev
 ```
 
-## Console frontend
+`cluster-start` creates the **platform** cluster `k3d-fundament` and installs the mkcert CA as a
+cert-manager issuer.
+On a machine with no mkcert CA yet, `mkcert -install` asks for sudo to add it to the system
+trust store.
 
-The Console frontend should now be available at https://console.fundament.localhost:8443/. See
+`just dev` is `skaffold dev`. It builds the platform images, pushes them to the local registry,
+deploys the chart, and then **stays attached to your terminal watching your source files** —
+edit a Go file and it rebuilds that one image and redeploys it, streaming the pods' logs
+meanwhile. On a cold Docker cache expect about ten minutes: roughly a minute for the cluster,
+six to build the images, and a few more for them to roll out. Nothing is pulled from a registry;
+every image is built locally.
+
+Once the deployments are stable you can **stop it with Ctrl-C** — the recipe passes
+`--cleanup=false`, so nothing is torn down. The cluster keeps running and the console keeps
+serving. Leave it running only if you are editing Fundament's own source and want your changes
+rebuilt automatically; if you are here to work on plugins, you do not need it.
+
+:::caution[Stopping is safe — restarting is not]
+Running `just dev` again re-runs the database migrations, and `values-local.yaml` sets
+`db.reset: true`, so it **wipes and re-seeds the platform database**. Every published plugin
+definition goes with it, and the installed plugin keeps reporting `Running` until its controller
+next restarts. Once you have published a plugin, avoid re-running `just dev` unless you mean to
+start over — see
+[Install a plugin](../plugins/install-a-plugin.md#known-issues-on-this-path).
+:::
+
+## What you just started
+
+`k3d-fundament` is the **platform** cluster. It runs the Fundament services themselves: a
+CloudNativePG Postgres, `authn-api`, `organization-api`, `authz-worker` with OpenFGA, `dex`, the
+console and docs frontends, `kube-api-proxy`, `plugin-proxy`, `plugin-controller` and
+ingress-nginx.
+
+Plugins do **not** run here. They run on a second, separate k3d cluster that you create later —
+in production that is a managed tenant cluster, and locally it is `k3d-fundament-plugin`. See
+[The two development clusters](../plugins/dev-environment.md).
+
+## Where things are
+
+Once `just dev` reports the deployments stable:
+
+| | URL | Sign in with |
+|---|---|---|
+| Console | <https://console.fundament.localhost:8443> | `alice@acme-corp.com` / `password` |
+| Documentation | <https://docs.fundament.localhost:8443> | — |
+
+Other services follow the same pattern — `authn`, `organization`, `dex` and `plugin-proxy` are
+each at `https://<name>.fundament.localhost:8443`. Publishing plugins uses a different identity,
+`platform-admin@fundament.io`, minted by `deploy/k3d/dev-token.sh`.
+
+These docs are served from the cluster you just started, so the documentation URL above is your
+branch's content. The published site — built from `master` — is at
+<https://docs.fundament.projects.digilab.network/docs>. To work on the docs themselves, `just docs-dev` runs a live
+dev server on <http://localhost:4321>, and `just docs-build` validates every internal link and
+fails on a broken one. The pages live in `docs/`; the link-writing rules are in
+[`docs-frontend/README.md`](https://github.com/fundament-oss/fundament/blob/master/docs-frontend/README.md).
+
+## Next: install a plugin
+
+Working on the console frontend itself? See
 [`console-frontend/README.md`](https://github.com/fundament-oss/fundament/blob/master/console-frontend/README.md)
 for linting, formatting and the other frontend commands.
 
+Otherwise the next step is [Install a plugin](../plugins/install-a-plugin.md), which takes you
+from the running platform to `cert-manager` installed and visible in the console. Read
+[The two development clusters](../plugins/dev-environment.md) first if you have not already.
+
 ## Storage
 
-Working on the `ceph-rook` plugin needs raw block devices, which a k3d node does not have.
-See [Block devices for k3d](./k3d-block-devices.md).
+Only if you are working on the `ceph-rook` plugin: it needs raw block devices, which a k3d node
+does not have. See [Block devices for k3d](./k3d-block-devices.md). This is not part of the
+plugin walkthrough.

--- a/docs/developer/fundament/k3d-block-devices.md
+++ b/docs/developer/fundament/k3d-block-devices.md
@@ -1,6 +1,7 @@
 ---
 title: Block devices for k3d
 sidebar:
+  label: Block devices for k3d
   order: 2
 ---
 
@@ -18,27 +19,29 @@ A k3d node has no raw block devices, so a storage plugin that needs one cannot r
 
 ## Quick start
 
+Run these from the repository root — the sandbox recipes are the root `Justfile`'s `plugins`
+module:
+
 ```bash
-cd plugins
-just cluster-create-storage        # binds the host block devices in
-just storage-disks doctor          # check the kernel Docker runs on
-just storage-disks attach          # creates /dev/loop0p1 .. /dev/loop2p1
+just plugins cluster-create-storage        # binds the host block devices in
+just plugins storage-disks doctor          # check the kernel Docker runs on
+just plugins storage-disks attach          # creates /dev/loop0p1 .. /dev/loop2p1
 ```
 
 Then verify the disks really work, independently of any plugin:
 
 ```bash
-../deploy/k3d/rook-smoke.sh up     # upstream Rook chart + a minimal CephCluster
-../deploy/k3d/rook-smoke.sh status # expect HEALTH_OK
-../deploy/k3d/rook-smoke.sh test   # 1Gi PVC + a pod that writes to it -> SMOKE-OK
-../deploy/k3d/rook-smoke.sh down   # frees the rook-ceph namespace
+./deploy/k3d/rook-smoke.sh up     # upstream Rook chart + a minimal CephCluster
+./deploy/k3d/rook-smoke.sh status # expect HEALTH_OK
+./deploy/k3d/rook-smoke.sh test   # 1Gi PVC + a pod that writes to it -> SMOKE-OK
+./deploy/k3d/rook-smoke.sh down   # frees the rook-ceph namespace
 ```
 
 `rook-smoke.sh` uses no fundament code, so it separates a broken environment from a broken plugin.
 
 ## Requirements
 
-The cluster must bind `/dev` and `/run/udev` into its node, which is off by default so a cluster only exposes the host's devices when someone is working on storage: use `just cluster-create-storage` instead of `just cluster-create`. Docker fixes a container's mounts at creation, so an existing cluster has to be recreated — `just cluster-delete && just cluster-create-storage`.
+The cluster must bind `/dev` and `/run/udev` into its node, which is off by default so a cluster only exposes the host's devices when someone is working on storage: use `just plugins cluster-create-storage` instead of `just plugins cluster-create`. Docker fixes a container's mounts at creation, so an existing cluster has to be recreated — `just plugins cluster-delete && just plugins cluster-create-storage`.
 
 Neither bind is optional. Without `/dev` the OSDs come up and Ceph reports `HEALTH_OK`, but no PVC can mount: a node container's `/dev` is then a private snapshot taken at container start rather than the host's live one, so the `/dev/rbdN` that Ceph CSI creates when it maps a volume never appears there.
 
@@ -47,8 +50,10 @@ Do not try to tell the two apart by filesystem type. It is tempting — devtmpfs
 ```bash
 docker inspect k3d-fundament-plugin-server-0 \
   --format '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' | grep -qx /dev && echo bound
-just storage-disks attach && docker exec k3d-fundament-plugin-server-0 ls /dev/loop0p1
-``` Ceph checks for exactly this and says so — `rbd: mapping succeeded but /dev/rbd0 is not accessible, is host /dev mounted?` (`ceph/src/krbd.cc`, `do_map`). There is no way around it: rbd-nbd has the same dependency, and Rook's own RBD node plugin hardcodes a hostPath mount of `/dev`.
+just plugins storage-disks attach && docker exec k3d-fundament-plugin-server-0 ls /dev/loop0p1
+```
+
+Ceph checks for exactly this and says so — `rbd: mapping succeeded but /dev/rbd0 is not accessible, is host /dev mounted?` (`ceph/src/krbd.cc`, `do_map`). There is no way around it: rbd-nbd has the same dependency, and Rook's own RBD node plugin hardcodes a hostPath mount of `/dev`.
 
 `/run/udev` is mounted because Rook mounts it into every OSD pod, the prepare job and the discover daemon, and it is a documented prerequisite from Rook v1.20 on. Running without it here wedged the prepare job with a process in uninterruptible I/O wait; the cause was not established, and the plausible explanations point at device probing rather than at udev itself.
 
@@ -58,18 +63,18 @@ Ceph needs roughly 2 GiB per OSD plus its own daemons, so give the VM at least 8
 
 ## After a reboot
 
-The backing files are ordinary files on the Docker data disk, so they survive a Docker daemon restart, a VM restart and a laptop reboot. The loop devices do not — those are kernel state. Recovery is `just storage-disks attach`, and nothing else: `/dev` is bound into the node as a live devtmpfs, so the devices reappear there immediately.
+The backing files are ordinary files on the Docker data disk, so they survive a Docker daemon restart, a VM restart and a laptop reboot. The loop devices do not — those are kernel state. Recovery is `just plugins storage-disks attach`, and nothing else: `/dev` is bound into the node as a live devtmpfs, so the devices reappear there immediately.
 
 ## Stopping a cluster that has Ceph volumes mounted
 
 Stopping the cluster kills the OSDs while the kernel still has the volume mapped, so the filesystem's journal thread blocks forever on a device that will never answer. The node container then cannot be stopped and cannot be entered.
 
-`just cluster-stop` handles this by itself: a mapped device is the signal that storage is in play, so it evicts the Ceph consumers first — while Ceph is still up to service the unmounts — and skips straight to stopping when nothing is mapped. `just cluster-delete` does the same. Nothing extra to remember, and a cluster that never used storage pays nothing. Nothing can intercept `k3d cluster stop` run directly, a `docker stop`, a `kill -9` or closing the laptop lid. For those the StorageClass sets `mapOptions: "krbd:osd_request_timeout=90"`, which turns krbd's endless retry into an I/O error and so keeps the filesystem's journal thread out of uninterruptible sleep. It is deliberately dev-only: it aborts *all* requests once they exceed the timeout, which is the wrong trade for a real cluster.
+`just plugins cluster-stop` handles this by itself: a mapped device is the signal that storage is in play, so it evicts the Ceph consumers first — while Ceph is still up to service the unmounts — and skips straight to stopping when nothing is mapped. `just plugins cluster-delete` does the same. Nothing extra to remember, and a cluster that never used storage pays nothing. Nothing can intercept `k3d cluster stop` run directly, a `docker stop`, a `kill -9` or closing the laptop lid. For those the StorageClass sets `mapOptions: "krbd:osd_request_timeout=90"`, which turns krbd's endless retry into an I/O error and so keeps the filesystem's journal thread out of uninterruptible sleep. It is deliberately dev-only: it aborts *all* requests once they exceed the timeout, which is the wrong trade for a real cluster.
 
 That bounds the damage without removing it. Measured on the bypass path: the filesystem unmounts, but the mapping stays and the node container will not exit — `k3d cluster stop` fails at its own 30s timeout, repeated `docker stop` calls fail too, and the node can no longer be entered. What holds it is a kernel worker retrying the rbd watch, a wait with no timeout of its own. Removing the device ends it:
 
 ```bash
-just storage-disks unmap-stale
+just plugins storage-disks unmap-stale
 ```
 
 The container then stops immediately, and a normal start brings the cluster back with its data intact. This works only because the timeout already aborted the in-flight I/O; without it the removal blocks for the same reason `rbd unmap -o force` does, and only restarting the host clears it.
@@ -78,11 +83,11 @@ After any restart, an OSD can come back with a PG stuck in `laggy`, which blocks
 
 ## Cleaning up
 
-Nothing removes the images on its own — `k3d cluster delete` knows nothing about the volume, and `reset` deletes them only to recreate them empty. `just storage-disks purge` detaches and deletes the volume, which is the only way to get the space back. This matters more on Linux than on macOS, where deleting the VM takes the disks with it.
+Nothing removes the images on its own — `k3d cluster delete` knows nothing about the volume, and `reset` deletes them only to recreate them empty. `just plugins storage-disks purge` detaches and deletes the volume, which is the only way to get the space back. This matters more on Linux than on macOS, where deleting the VM takes the disks with it.
 
 Deleting an image while its loop device is still attached frees nothing, because the kernel keeps the deleted inode alive until the device goes away. `purge` and `reset` therefore refuse while anything still holds a device; stop the consumer first.
 
-Use `just storage-disks reset` to start over from clean disks, which is needed after deleting the cluster: the images keep their on-disk state while the node that referenced them is gone.
+Use `just plugins storage-disks reset` to start over from clean disks, which is needed after deleting the cluster: the images keep their on-disk state while the node that referenced them is gone.
 
 The volume is never attached to a container, so Docker counts it as unused: `docker volume prune -a` and `docker system prune --volumes` will delete the images. Plain `docker volume prune` will not, as it only removes anonymous volumes.
 

--- a/docs/developer/plugins/ceph-rook-runbook.md
+++ b/docs/developer/plugins/ceph-rook-runbook.md
@@ -1,19 +1,29 @@
 ---
 title: "Runbook: verifying the Ceph/Rook plugin"
 sidebar:
-  order: 5
+  label: Ceph/Rook runbook
+  order: 9
 ---
 
-End-to-end verification of the `ceph-rook` plugin against a local k3d sandbox, from an
-empty machine to a pod writing to a Ceph-backed volume.
+End-to-end verification of the `ceph-rook` plugin against the local `k3d-fundament-plugin`
+sandbox cluster, from an empty machine to a pod writing to a Ceph-backed volume.
+
+**Advanced.** This is the longest path in the repo. For the standard plugin flow, start with
+[Install a plugin](./install-a-plugin.md).
 
 The unit tests cover the plugin's decision logic and its reconcilers against a fake
 client. They cannot tell you whether Rook actually builds an OSD out of a real block
 device, whether the CSI driver can map an RBD image, or whether the console pages render.
 That is what this runbook is for.
 
-Budget 45–60 minutes for a first run; most of it is Ceph pulling images and waiting for
-OSDs.
+Budget 45–60 minutes for a first run on a warm Docker cache; most of it is Ceph pulling
+images and waiting for OSDs. From no images at all, closer to two hours — the platform
+cluster and its 14 images account for most of the difference.
+
+New to the two-cluster setup? Read
+[The two development clusters](./dev-environment.md) first, and ideally do the shorter
+[Install a plugin](./install-a-plugin.md) walkthrough before this one. This runbook assumes both
+clusters already exist.
 
 ## What each phase proves
 
@@ -39,13 +49,21 @@ nothing you learn in phases 4–8 means anything.
   [Block devices for k3d](../fundament/k3d-block-devices.md).
 - **At least 8 GiB of VM memory.** Ceph needs roughly 2 GiB per OSD plus its daemons. On
   colima: `colima start --cpus 4 --memory 8`. Memory cannot be changed on a running VM.
-- **The management cluster (`k3d-fundament`) must be up**, because publishing goes through
-  organization-api. The sandbox cluster (`k3d-fundament-plugin`) is where the plugin runs.
+- **The `k3d-fundament` platform cluster must be up**, because publishing goes through
+  organization-api. The `k3d-fundament-plugin` sandbox cluster is where the plugin runs.
+- **An activated mise environment.** `just`, `skaffold`, `jq` and `yq` come from mise and are
+  otherwise not on `PATH`.
 
-:::caution[Check your kubectl context]
-`just dev` and skaffold deploy to the *current* context, and they do not switch for you.
-Every command below passes `--context` explicitly for that reason. If you drop the flag,
-confirm your context first.
+:::caution[Watch the `plugins` prefix]
+Every command below runs from the **repository root**. `just dev` and `just plugins dev` are
+different recipes deploying different things to different clusters — the root one deploys the
+platform to `k3d-fundament`, the `plugins` module one deploys the plugin-controller to
+`k3d-fundament-plugin`. `cd`-ing into `plugins/` does not select the latter: `mod.just` is not a
+`Justfile`, so `just` walks up and finds the root recipe anyway.
+
+Your kubectl context does not disambiguate them: both skaffold configurations pin
+`kubeContext`, so `kubectl config use-context` has no effect on where they deploy. Every
+`kubectl` command below passes `--context` explicitly for the same reason.
 :::
 
 ## Phase 0 · Clean slate
@@ -71,10 +89,9 @@ If a previous Ceph cluster is still running, take it down in Rook's order *befor
 deleting the k3d cluster, so its finalizers get cleared:
 
 ```bash
-cd plugins
-../deploy/k3d/rook-smoke.sh down     # if the leftovers came from the smoke script
-just plugin-uninstall ceph-rook      # if they came from the plugin
-just cluster-delete
+./deploy/k3d/rook-smoke.sh down     # if the leftovers came from the smoke script
+just plugins uninstall system--ceph-rook      # if they came from the plugin
+just plugins cluster-delete
 ```
 
 `cluster-delete` drains Ceph consumers first, so it is safe even mid-experiment.
@@ -82,11 +99,16 @@ just cluster-delete
 ## Phase 1 · Environment
 
 ```bash
-cd plugins
-just cluster-create-storage    # binds /dev and /run/udev into the node
-just storage-disks doctor      # inspect the kernel Docker actually runs on
-just storage-disks attach      # 3 × 20 GiB sparse images -> /dev/loop0p1 .. /dev/loop2p1
+just plugins cluster-create-storage    # binds /dev and /run/udev into the node
+just plugins storage-disks doctor      # inspect the kernel Docker actually runs on
+just plugins storage-disks attach      # 3 × 20 GiB sparse images -> /dev/loop0p1 .. /dev/loop2p1
+just plugins dev                       # plugin-controller into the sandbox; leave it running
 ```
+
+`just plugins dev` deploys the plugin-controller to `k3d-fundament-plugin` — note the prefix; a
+bare `just dev` deploys the platform instead. Without it the sandbox has the
+`PluginInstallation` CRD but nothing that reconciles it, and phase 4 will apply a CR that never
+progresses.
 
 `doctor` is worth reading rather than skimming. The line that matters most:
 
@@ -102,7 +124,7 @@ phases 4–6 remain testable and only phase 7 is blocked. On macOS, colima provi
 Confirm the devices reached the node:
 
 ```bash
-just storage-disks status
+just plugins storage-disks status
 ```
 
 Expect `/dev/loop0p1`, `/dev/loop1p1`, `/dev/loop2p1` both on the host and in the node.
@@ -110,15 +132,15 @@ Three is the useful floor — it is what lets a pool hold 3 replicas across OSDs
 
 :::note[After a reboot]
 The backing files survive reboots; the loop devices do not, because those are kernel
-state. Recovery is `just storage-disks attach` and nothing else.
+state. Recovery is `just plugins storage-disks attach` and nothing else.
 :::
 
 ## Phase 2 · Baseline without the plugin
 
 ```bash
-../deploy/k3d/rook-smoke.sh up      # upstream chart + a hand-written CephCluster
-../deploy/k3d/rook-smoke.sh status  # expect HEALTH_OK (or HEALTH_WARN about redundancy)
-../deploy/k3d/rook-smoke.sh test    # 1Gi PVC + a pod that writes and verifies -> SMOKE-OK
+./deploy/k3d/rook-smoke.sh up      # upstream chart + a hand-written CephCluster
+./deploy/k3d/rook-smoke.sh status  # expect HEALTH_OK (or HEALTH_WARN about redundancy)
+./deploy/k3d/rook-smoke.sh test    # 1Gi PVC + a pod that writes and verifies -> SMOKE-OK
 ```
 
 `rook-smoke.sh` contains no Fundament code, so it cleanly separates "the environment is
@@ -136,7 +158,7 @@ and says so rather than failing:
     unaffected, so this is not a failure of the environment.
 ```
 
-This plugin is block-only, so RBD is the whole story. `just storage-disks has-module ceph`
+This plugin is block-only, so RBD is the whole story. `just plugins storage-disks has-module ceph`
 answers the question on its own.
 :::
 
@@ -156,8 +178,8 @@ missing `/dev` bind fails every time. Confirm with
 Then free the namespace — the plugin wants the same one:
 
 ```bash
-../deploy/k3d/rook-smoke.sh down
-just storage-disks reset            # wipe stale OSD metadata, reattach
+./deploy/k3d/rook-smoke.sh down
+just plugins storage-disks reset            # wipe stale OSD metadata, reattach
 ```
 
 `reset` is not optional between installs. Stale BlueStore metadata on the images, or Rook
@@ -165,22 +187,22 @@ state under `dataDirHostPath`, is the usual reason a second install fails.
 
 ## Phase 3 · Build and publish
 
-Publishing resolves the plugin's catalog id by name, so the appstore seed must be applied
-in the management cluster. This PR adds the `ceph-rook` catalog entry and a `Storage`
-category, so **the seed must be re-applied** — it is idempotent (`ON CONFLICT DO UPDATE`),
-and the `db-migrations` Job runs it:
+Publishing resolves the plugin's catalog id by name, so the appstore seed must be present in
+the `k3d-fundament` platform cluster. The seed carries the `ceph-rook` catalog entry and its `Storage`
+category, is idempotent (`ON CONFLICT DO UPDATE`), and is applied by the `db-migrations` Job. If
+the database predates that entry, re-run the Job:
+
+This is the root `dev`, without the `plugins` prefix — see the caution above:
 
 ```bash
-kubectl config use-context k3d-fundament
-just dev                            # or: just deploy — re-runs db-migrations
+just dev                            # or: just deploy local — re-runs db-migrations
 ```
 
 Bridge the sandbox controller to organization-api (re-run after recreating either cluster,
 since it resolves the node IP fresh):
 
 ```bash
-cd plugins
-just plugin-sandbox-orgapi
+just plugins sandbox-orgapi
 ```
 
 Now build, push and publish:
@@ -213,13 +235,12 @@ One `admin`/`accepted` row is what you need. If it is missing, re-run the migrat
 `db.reset: true`, or insert `db/testdata/033_0101-content.sql` by hand.
 :::
 
-```bash
-export PLUGIN_REGISTRY=localhost:5112
-export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
-export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
-export FUNDAMENT_TOKEN=...      # a token for platform-admin@fundament.io — required
+Set the four publish variables exactly as in
+[Install a plugin, step 3](./install-a-plugin.md#3-publish-the-plugin-definition) — that page is
+canonical for them — then:
 
-just plugin-publish storage/ceph-rook
+```bash
+just plugins publish storage/ceph-rook
 ```
 
 Authorization also depends on two OpenFGA tuples, written by the authz-worker from the
@@ -245,7 +266,7 @@ Republishing the same `v0.1.0` needs `--replace`, which soft-deletes the previou
 definition:
 
 ```bash
-just plugin-publish storage/ceph-rook --replace
+just plugins publish storage/ceph-rook --replace
 ```
 
 If it fails with `no catalog entry for "ceph-rook"`, the seed did not reach the database —
@@ -261,9 +282,10 @@ kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
-  name: ceph-rook
+  name: system--ceph-rook
 spec:
   definitionRef:
+    organizationName: system
     pluginName: ceph-rook
     pluginVersion: v0.1.0
     definitionHash: sha256:PASTE_THE_HASH_FROM_PHASE_3
@@ -290,8 +312,8 @@ OSD. With this flag the filter is *replaced* by loop-partitions-only, not extend
 Watch it come up:
 
 ```bash
-just plugin-status
-just plugin-logs ceph-rook
+just plugins status
+just plugins logs system--ceph-rook
 ```
 
 Expect `PHASE=Running`, `READY=true`, and a log line `rook-ceph storage plugin running`.
@@ -316,8 +338,8 @@ kubectl --context k3d-fundament-plugin get disks
 Expect exactly three, one per loop partition:
 
 ```
-NAME                                  NODE                            SIZE          AVAILABLE
-k3d-fundament-plugin-server-0-1a2b3c  k3d-fundament-plugin-server-0   21472739328   true
+NAME                                      NODE                            PATH           SIZE          AVAILABLE
+k3d-fundament-plugin-server-0-2e7309e042  k3d-fundament-plugin-server-0   /dev/loop0p1   21472739328   true
 ...
 ```
 
@@ -370,6 +392,10 @@ Watch it provision — the first OSD takes a few minutes:
 ```bash
 kubectl --context k3d-fundament-plugin get storagepool test-pool -w
 ```
+
+The pool stays `Provisioning` for another 60–90 seconds after its `CephBlockPool` reports
+`Ready`; the reconciler picks the change up on its next pass. That wait is normal, not a
+stall.
 
 ```bash
 kubectl --context k3d-fundament-plugin get storagepool test-pool -o yaml | yq .status
@@ -480,8 +506,8 @@ them to confirm they hold against a real API server.
 Previously the pages were embedded but never routed, and the iframe 404'd.
 
 ```bash
-kubectl --context k3d-fundament-plugin -n plugin-ceph-rook \
-  port-forward deploy/ceph-rook 8080:8080 &
+kubectl --context k3d-fundament-plugin -n plugin-system--ceph-rook \
+  port-forward deploy/plugin 8080:8080 &
 curl -sS -o /dev/null -w '%{http_code}\n' localhost:8080/console/storagepools-list.html
 curl -sS -o /dev/null -w '%{http_code}\n' localhost:8080/console/storagepools-create.html
 kill %1
@@ -494,6 +520,22 @@ and that clicking a pool row navigates — the previous version's inline styles 
 ```
 https://console.fundament.localhost:8443/
 ```
+
+The console reaches the plugin through plugin-proxy in the `k3d-fundament` platform cluster,
+which needs a
+kubeconfig for the sandbox. Create it once per cluster pair, with the root recipe:
+
+```bash
+just plugin-sandbox-kubeconfig
+```
+
+The recipe restarts plugin-proxy and kube-api-proxy and waits until the switch is confirmed,
+ending with `- kube-api-proxy is proxying to the sandbox (mock disabled)`.
+
+The Secret is mounted optionally, so plugin-proxy starts and reports healthy without it and
+fails only when a plugin page is opened. A blank or erroring plugin iframe with a healthy
+plugin pod usually means this step is missing, or that the sandbox cluster was recreated
+since it last ran.
 
 Check the browser console for CSP violations. There should be none.
 
@@ -523,46 +565,7 @@ violation anywhere here is a failure, not cosmetic.
    `Claimed by` is set for a pooled disk (plain text — cross-kind links are not
    expressible in the host contract).
 
-### 8b · Foreign objects are not adopted
-
-The old code would adopt a same-named StorageClass and delete it when the pool went away.
-
-```bash
-kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-squatter
-provisioner: rancher.io/local-path
-YAML
-
-kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
-apiVersion: storage.fundament.io/v1alpha1
-kind: StoragePool
-metadata:
-  name: squatter
-spec:
-  replication: auto
-  disks: []
-YAML
-
-kubectl --context k3d-fundament-plugin get storagepool squatter -o jsonpath='{.status.phase}{"\n"}{.status.message}{"\n"}'
-```
-
-Expect `Degraded` and a message naming the conflict. Critically, the foreign object must be
-untouched:
-
-```bash
-kubectl --context k3d-fundament-plugin get storageclass ceph-squatter \
-  -o jsonpath='{.provisioner}{" owners="}{.metadata.ownerReferences}{"\n"}'
-# rancher.io/local-path owners=      <- unchanged, no owner reference
-
-kubectl --context k3d-fundament-plugin delete storagepool squatter
-kubectl --context k3d-fundament-plugin get storageclass ceph-squatter   # must still exist
-kubectl --context k3d-fundament-plugin delete storageclass ceph-squatter
-```
-
-### 8c · `claimedBy` updates immediately
+### 8b · `claimedBy` updates immediately
 
 It used to wait for the discovery daemon's next sweep (~60m), long enough to hand one disk
 to two pools through the UI.
@@ -576,7 +579,7 @@ Every disk in `test-pool` must already show `claimedBy=test-pool` — no waiting
 also what makes the create form's picker correct, so re-open it and confirm it offers no
 disks.
 
-### 8d · Deleting a pool shrinks the CephCluster
+### 8c · Deleting a pool shrinks the CephCluster
 
 Nothing else recomputes this: the CephCluster carries no owner reference.
 
@@ -598,25 +601,117 @@ explicit Ceph purge. `kubectl -n rook-ceph get pods -l app=rook-ceph-osd` will s
 them. This is expected and documented; it is why disk removal is a two-step operation.
 :::
 
+### 8d · Foreign objects are not adopted
+
+The old code would adopt a same-named StorageClass and delete it when the pool went away.
+
+This check runs last on purpose. The guard only fires once the reconciler actually reaches
+the StorageClass write, which needs the pool to resolve at least one disk — a pool with
+`disks: []` goes `Degraded` with `no disks selected` and never gets that far. Step 8c freed
+the disks, so they can be reused here.
+
+```bash
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-squatter
+provisioner: rancher.io/local-path
+YAML
+
+DISKS=$(kubectl --context k3d-fundament-plugin get disks -o jsonpath='{range .items[*]}      - {.metadata.name}{"\n"}{end}')
+kubectl --context k3d-fundament-plugin apply -f - <<YAML
+apiVersion: storage.fundament.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: squatter
+spec:
+  replication: auto
+  disks:
+$DISKS
+YAML
+
+kubectl --context k3d-fundament-plugin get storagepool squatter -o jsonpath='{.status.phase}{"\n"}{.status.message}{"\n"}'
+```
+
+Expect `Degraded`, and a message naming the conflict:
+
+```
+apply StorageClass ceph-squatter: terminal error: StorageClass "ceph-squatter" already
+exists and is not owned by this StoragePool; refusing to adopt it (deleting the pool would
+then delete that object). Rename the StoragePool or remove the conflicting StorageClass
+```
+
+Critically, the foreign object must be untouched:
+
+```bash
+kubectl --context k3d-fundament-plugin get storageclass ceph-squatter \
+  -o jsonpath='{.provisioner}{" owners="}{.metadata.ownerReferences}{"\n"}'
+# rancher.io/local-path owners=      <- unchanged, no owner reference
+
+kubectl --context k3d-fundament-plugin delete storagepool squatter
+kubectl --context k3d-fundament-plugin get storageclass ceph-squatter   # must still exist
+kubectl --context k3d-fundament-plugin delete storageclass ceph-squatter
+```
+
 ## Phase 9 · Teardown
 
 Order matters. Ceph consumers must release volumes while Ceph is still running to service
 the unmounts:
 
 ```bash
-cd plugins
-just plugin-uninstall ceph-rook
-just cluster-delete            # drains first
-just storage-disks purge       # detach and delete the backing images, freeing the space
+just plugins uninstall system--ceph-rook
+just plugins cluster-delete    # drains first
+just plugins storage-disks purge       # detach and delete the backing images, freeing the space
 ```
 
-To keep the disks for a future run, use `just storage-disks reset` instead of `purge`.
+To keep the disks for a future run, use `just plugins storage-disks reset` instead of `purge`.
+
+`cluster-stop` and `cluster-delete` drain the node first, which evicts pods — a bare
+verification pod is deleted, not restarted. Only its PersistentVolumeClaim survives a
+stop/start cycle.
+
+## When the platform cluster changes under you
+
+Both failure modes below are described in full, with recovery, under
+[Install a plugin → Known issues on this path](./install-a-plugin.md#known-issues-on-this-path).
+That page is canonical; this section adds only what is specific to a mid-runbook redeploy.
+
+A `just dev` at the repository root re-seeds the platform database and drops every published
+`PluginDefinition`, so it invalidates what phase 3 published. `just plugins status` will not tell
+you — the CR keeps reporting `Running`/`READY=true`. The controller log is where it shows:
+
+```bash
+kubectl --context k3d-fundament-plugin -n fundament logs deploy/fundament-plugin-controller | tail
+# fetch definition: GetPluginDefinition RPC: not_found: plugin definition ceph-rook@v0.1.0 not found
+```
+
+Redo phase 3, then delete and re-apply the `PluginInstallation` with the new hash —
+`definitionRef` is immutable, so it cannot be edited in place. Deleting runs the uninstall path,
+which for `ceph-rook` tears down the CephCluster; on a verification run that is usually what you
+want anyway, but do not do it to a pool holding data you care about.
+
+If publishing then fails with `permission_denied` while both checks in phase 3 look right —
+the `admin`/`accepted` row present and both OpenFGA tuples present — the OpenFGA store was
+recreated during the reset and the tuples belong to the previous one:
+
+```bash
+kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+  psql -U postgres -d openfga -c "SELECT store, count(*) FROM tuple GROUP BY 1;"
+kubectl --context k3d-fundament -n fundament exec db-1 -c postgres -- \
+  psql -U postgres -d openfga -c "SELECT id FROM store;"
+```
+
+The two store ids must match. When they do not, every authorization decision resolves to
+false while every pod looks healthy. Restarting `organization-api`, `kube-api-proxy` or
+`authz-worker` does not repair it — the tuples are already written and the outbox is
+drained. Another platform redeploy does.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `REFUSING: the Docker host is not a virtual machine`, `Detected: unknown`, on macOS | VM probes could not answer | Fixed — an aarch64 guest has no DMI and often no systemd, so detection now also reads the device tree and the virtio bus. If it recurs, `just storage-disks doctor` prints what was detected |
+| `REFUSING: the Docker host is not a virtual machine`, `Detected: unknown`, on macOS | VM probes could not answer | Fixed — an aarch64 guest has no DMI and often no systemd, so detection now also reads the device tree and the virtio bus. If it recurs, `just plugins storage-disks doctor` prints what was detected |
 | `losetup: unrecognized option: show` (or `: j`) | Docker host ships BusyBox, not util-linux | Fixed — association no longer uses `--show`/`-j`. OrbStack and colima both ship BusyBox |
 | `attach` exits 1 printing nothing | A failing test as a loop body's last command, under `set -e` | Fixed. If a similar silent exit appears, re-run with `bash -x` |
 | Smoke test times out; events show `modprobe args: [ceph]` repeating | No `ceph` kernel module — CephFS cannot mount | Not a failure. The plugin is block-only; the smoke test now skips CephFS automatically |
@@ -627,11 +722,15 @@ To keep the disks for a future run, use `just storage-disks reset` instead of `p
 | OSD prepare job: `unsupported diskType loop` | `allowLoopDevices` did not take | Confirm `DEV_LOOP_DEVICES` is set on the PluginInstallation |
 | Mons never reach quorum | 3 mons on one node | Set `MON_COUNT: "1"` and `ALLOW_MULTIPLE_PER_NODE: "true"` |
 | CephCluster rejected on version | Ceph release outside Rook's table | Only if you overrode `CEPH_IMAGE`: set `ALLOW_UNSUPPORTED_CEPH: "true"` (default `false`) |
-| `csi-rbdplugin` CrashLoopBackOff | `rbd` kernel module missing | `just storage-disks doctor`; use colima |
+| `csi-rbdplugin` CrashLoopBackOff | `rbd` kernel module missing | `just plugins storage-disks doctor`; use colima |
 | PVC Pending, provisioner logs quiet | No OSD is up | `kubectl -n rook-ceph get pods -l app=rook-ceph-osd` |
-| `rbd: mapping succeeded but /dev/rbd0 is not accessible` | No `/dev` bind | Recreate with `just cluster-create-storage` |
-| Second install fails after a first attempt | Stale OSD metadata | `just storage-disks reset` |
-| Node container will not stop | Stale RBD mapping | `just storage-disks unmap-stale` |
+| `rbd: mapping succeeded but /dev/rbd0 is not accessible` | No `/dev` bind | Recreate with `just plugins cluster-create-storage` |
+| Second install fails after a first attempt | Stale OSD metadata | `just plugins storage-disks reset` |
+| `PluginInstallation` never leaves `Deploying`, no plugin namespace appears | No plugin-controller in the sandbox | `just plugins dev` (phase 1) |
+| `GetPluginDefinition … not found` after a platform redeploy | `db.reset: true` wiped the published definition | Redo phase 3 — see "When the platform cluster changes under you" |
+| `permission_denied` on publish, but both phase 3 checks look right | OpenFGA store recreated; tuples in the old store | Redeploy the platform again — same section |
+| Plugin iframe blank in the console, plugin pod healthy | `plugin-sandbox-kubeconfig` Secret missing or stale | `just plugin-sandbox-kubeconfig` from the root, then restart plugin-proxy |
+| Node container will not stop | Stale RBD mapping | `just plugins storage-disks unmap-stale` |
 | Pool stuck `Provisioning` | CephBlockPool not Ready | `kubectl -n rook-ceph describe cephblockpool ceph-<pool>` |
 | Pool `Degraded` | Conflict or drift | Read `status.message` — it names the action |
 

--- a/docs/developer/plugins/console-integration.md
+++ b/docs/developer/plugins/console-integration.md
@@ -1,7 +1,7 @@
 ---
 title: Console integration
 sidebar:
-  order: 6
+  order: 7
 ---
 
 How a Fundament plugin renders inside the Console: the iframe boundary, the
@@ -12,7 +12,7 @@ This document is the architecture reference for anyone working on the
 Console-plugin boundary. For a plugin author's how-to, start with
 [Writing a plugin](writing-a-plugin) and [Custom UI](custom-ui). For the
 container lifecycle (controller, RBAC, install/uninstall), see the
-[Plugins overview](.).
+[Plugins overview](/docs/developer/plugins).
 
 ## Overview
 

--- a/docs/developer/plugins/custom-ui.md
+++ b/docs/developer/plugins/custom-ui.md
@@ -1,7 +1,7 @@
 ---
 title: Custom UI
 sidebar:
-  order: 4
+  order: 6
 ---
 
 Custom UI is optional. When a plugin omits `customComponents` for a CRD it

--- a/docs/developer/plugins/dev-environment.md
+++ b/docs/developer/plugins/dev-environment.md
@@ -1,0 +1,94 @@
+---
+title: The two development clusters
+sidebar:
+  label: Dev environment
+  order: 2
+---
+
+Plugin development uses **two k3d clusters**: the `k3d-fundament` platform cluster and the
+`k3d-fundament-plugin` sandbox cluster. Knowing which is which, and which `just` recipe targets
+which, is most of what makes the rest of these pages make sense.
+
+Throughout these docs a cluster is named by its kubectl context — `k3d-fundament` or
+`k3d-fundament-plugin` — with "platform" or "sandbox" as a descriptor. The context name is the
+unambiguous part, and it is what every `kubectl --context` command already uses.
+
+```
+  ┌─ k3d-fundament ─────────────────┐        ┌─ k3d-fundament-plugin ─────────┐
+  │ the platform                    │        │ the sandbox                    │
+  │ just <recipe>                   │        │ just plugins <recipe>          │
+  ├─────────────────────────────────┤        ├────────────────────────────────┤
+  │ fundament namespace             │        │ fundament namespace            │
+  │   organization-api              ◄──(1)───┤   plugin-controller            │
+  │   authn-api · dex               │        │        │ creates               │
+  │   authz-worker + OpenFGA        │        │        ▼                       │
+  │   CloudNativePG (db)            │        │ plugin-<org>--<name> namespace │
+  │   console-frontend              │        │   the plugin's Deployment      │
+  │   docs-frontend                 │        │   + what the plugin installs   │
+  │   plugin-proxy · kube-api-proxy ├──(2)───►     (cert-manager, Rook, …)    │
+  │ ingress-nginx                   │        │                                │
+  │   *.fundament.localhost:8443    │        │ no ingress                     │
+  │ registry  localhost:5111        │        │ registry  localhost:5112       │
+  └─────────────────────────────────┘        └────────────────────────────────┘
+```
+
+The clusters sit on separate Docker networks, so the two links between them are created by
+hand. **Both must be re-run after recreating either cluster** — each resolves a container IP
+that changes.
+
+**(1) `just plugins sandbox-orgapi`** — the plugin-controller resolves a
+`PluginInstallation` by fetching its published definition from organization-api (FUN-19).
+
+**(2) `just plugin-sandbox-kubeconfig`** — a root recipe, then restart
+plugin-proxy and kube-api-proxy. One Secret, read by both: it is what lets the console see and
+manage what is installed in the sandbox (FUN-17). It does more than it sounds like — locally
+kube-api-proxy runs in `mock` mode serving an in-memory fake cluster, and this Secret replaces
+that mock with a real proxy to the sandbox. Until it exists the console shows fabricated data
+and plugin pages fail to load. It is mounted optionally, so plugin-proxy starts and reports
+healthy without it.
+
+This mirrors production: Fundament manages *other* clusters, and a plugin runs on the managed
+cluster, not on the platform itself.
+
+## Which `just dev` am I running?
+
+Every recipe is run from the **repository root**. The sandbox ones live in `plugins/mod.just`,
+which the root `Justfile` registers as the `plugins` module, so they carry a `plugins` prefix.
+Both files define a `dev`, and they deploy different things to different clusters:
+
+| Recipe | Deploys | To |
+|---|---|---|
+| `just dev` | the full platform | `k3d-fundament` |
+| `just plugins dev` | plugin-controller only | `k3d-fundament-plugin` |
+
+The prefix is the only thing that distinguishes them, and `cd`-ing into `plugins/` does **not**
+select the sandbox one: `mod.just` is not a `Justfile`, so `just` keeps walking up and finds the
+root recipe. A bare `just cluster-create` from anywhere in the tree builds the *platform*
+cluster.
+
+Nor does your kubectl context matter — both skaffold configurations pin `kubeContext`, so
+`kubectl config use-context` has no effect on where they deploy.
+
+`just --list plugins` shows what the module offers.
+
+## How long it takes
+
+On a cold Docker cache, from no images at all:
+
+| Step | Time |
+|---|---|
+| `just cluster-start` (platform) | ~1 min |
+| `just dev` (platform, 14 images) | ~6 min to build, a few more to roll out |
+| sandbox cluster + `just plugins dev` | ~1 min |
+| `just plugins publish` (first plugin) | ~4 min |
+
+Measured on an 8-CPU macOS VM after `docker system prune -a`, so nothing was cached. Around
+fifteen minutes in total before a plugin is installable; later runs reuse the build cache and are
+much quicker. There is no prebuilt-image path — every platform image is built locally.
+
+## Next
+
+- Prerequisites and the platform cluster: [Getting started](../fundament/getting-started.md)
+- The commands, in order: [Install a plugin](./install-a-plugin.md)
+- Raw block devices, for the `ceph-rook` plugin only:
+  [Block devices for k3d](../fundament/k3d-block-devices.md)

--- a/docs/developer/plugins/example-ceph-rook.md
+++ b/docs/developer/plugins/example-ceph-rook.md
@@ -1,10 +1,15 @@
 ---
 title: "Example: Ceph Storage (Rook)"
 sidebar:
-  order: 5
+  label: Ceph/Rook plugin
+  order: 8
 ---
 
 The ceph-rook plugin provides block storage for in-cluster workloads by installing and managing the Rook-Ceph operator and a singleton CephCluster.
+
+**Advanced.** Storage is the most demanding plugin to run locally — it needs raw block devices
+and a virtualised Docker host. It is not part of the standard
+[plugin walkthrough](./install-a-plugin.md).
 
 :::tip[Verifying it works]
 This page describes the design. To actually exercise the plugin against a local
@@ -226,12 +231,13 @@ in-cluster config, which never traverses it. There is no separate `clusterRoles`
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
-  name: ceph-rook
+  name: system--ceph-rook
 spec:
   definitionRef:
+    organizationName: system
     pluginName: ceph-rook
     pluginVersion: v0.1.0
-    definitionHash: sha256:<hash printed by `just plugin-publish storage/ceph-rook`>
+    definitionHash: sha256:<hash printed by `just plugins publish storage/ceph-rook`>
 ```
 
 ## Host prerequisites

--- a/docs/developer/plugins/example-cert-manager.md
+++ b/docs/developer/plugins/example-cert-manager.md
@@ -1,10 +1,18 @@
 ---
 title: "Example: cert-manager"
 sidebar:
-  order: 5
+  label: cert-manager plugin
+  order: 4
 ---
 
-The cert-manager plugin is a reference implementation that installs and manages cert-manager.
+The cert-manager plugin is a reference implementation that installs and manages cert-manager. It
+The version a `PluginInstallation` pins is the plugin's own `metadata.version`, from
+`plugins/cert-manager/definition.yaml`.
+
+:::tip[Install and test it]
+This page describes the design. To run it locally, follow
+[Install a plugin](./install-a-plugin.md) — cert-manager is the plugin that walkthrough uses.
+:::
 
 ## What it does
 
@@ -43,7 +51,7 @@ helpers — copy it as a starting point for new plugins. See
 [Custom UI](custom-ui) for the pattern and
 [Console integration](console-integration) for the architecture.
 
-## Why it needs `cluster-admin`
+## Why it needs cluster-wide RBAC
 
 cert-manager installs cluster-scoped resources that require broad permissions:
 - CRDs (`certificates.cert-manager.io`, etc.)
@@ -53,8 +61,9 @@ cert-manager installs cluster-scoped resources that require broad permissions:
 
 The default namespace-admin RoleBinding only covers the plugin's own namespace. The additional cluster-wide access comes from `definition.yaml`'s `spec.permissions.rbac`, which `plugin-controller` materialises into a ClusterRole bound to the plugin's ServiceAccount — see [Plugin Controller](/docs/developer/plugins/#plugin-controller).
 
+The installation itself therefore carries no permissions at all:
+
 ```yaml
-# plugins/cert-manager/install.yaml
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
 metadata:
@@ -63,8 +72,8 @@ spec:
   definitionRef:
     organizationName: system
     pluginName: cert-manager
-    pluginVersion: v1.17.2
-    definitionHash: sha256:...
+    pluginVersion: v1.17.2      # metadata.version from definition.yaml
+    definitionHash: sha256:…    # required — from `just plugins publish`
 ```
 
 ## Plugin lifecycle

--- a/docs/developer/plugins/index.md
+++ b/docs/developer/plugins/index.md
@@ -2,16 +2,27 @@
 title: Plugins
 sidebar:
   label: Overview
-  order: 2
+  order: 1
 ---
 
 The plugin system allows extending Fundament with installable plugins that integrate into the platform's console UI, RBAC, and lifecycle management.
+
+## Start here
+
+This page is reference material. To actually do something:
+
+| I want to… | Go to |
+|---|---|
+| Run Fundament on my machine | [Getting started](/docs/developer/fundament/getting-started) |
+| Understand the local setup | [The two development clusters](/docs/developer/plugins/dev-environment) |
+| **Install and test a plugin** | [Install a plugin](/docs/developer/plugins/install-a-plugin) |
+| Write a plugin of my own | [Writing a plugin](/docs/developer/plugins/writing-a-plugin) |
 
 ## System overview
 
 ```
   ┌──────────────────────────────────────────────────────────────────────────┐
-  │                         Fundament Cluster                                │
+  │              Managed cluster (locally: k3d-fundament-plugin)             │
   │                                                                          │
   │  PluginInstallation CRs (cluster-scoped)                                 │
   │  ┌──────────────────────┐                                                │
@@ -197,18 +208,28 @@ kind: PluginInstallation
 metadata:
   name: system--cert-manager
 spec:
-  definitionRef:
+  definitionRef:                # Which published definition to install
     organizationName: system
     pluginName: cert-manager
-    pluginVersion: v1.17.2
-    definitionHash: sha256:...
-  config:                # Optional: extra env vars (injected with FUNP_ prefix)
-    LOG_LEVEL: debug     # → becomes FUNP_LOG_LEVEL in the container
+    pluginVersion: v1.17.2      # the plugin's own version, not the platform's
+    definitionHash: sha256:…    # the admin's consent record; see below
+  config:                       # Optional: extra env vars (injected with FUNP_ prefix)
+    LOG_LEVEL: debug            # → becomes FUNP_LOG_LEVEL in the container
 ```
 
 A plugin's identity is the pair `(organizationName, pluginName)`, and
 `metadata.name` must equal `<organizationName>--<pluginName>` — see
 [FUN-17](/funs/fun-17#plugin-identity-and-naming) for why.
+
+`definitionRef` and `config` are the only fields you set. The container image and the plugin's
+RBAC are **not** in the CR — they come from the published definition the reference resolves to
+(FUN-19). `definitionRef` is immutable once set: to move a plugin to a new version, delete and
+recreate the installation.
+
+`definitionHash` records exactly which definition an admin approved. Always set it: although
+`pluginController.allowUnpinnedHash` suggests otherwise, the CRD's immutability rule rejects the
+controller's first update when the hash is absent, and the installation never reconciles — see
+[Install a plugin](/docs/developer/plugins/install-a-plugin).
 
 ### What the controller creates
 
@@ -229,6 +250,10 @@ For each `PluginInstallation`, the controller creates:
 Every namespace-scoped child is named `plugin` — not `plugin-<installationName>`
 — because the namespace already disambiguates installations; see
 [FUN-17](/funs/fun-17#plugin-identity-and-naming).
+
+The cluster-scoped permissions are always derived from the published definition, never requested
+by the CR. That is what lets an admin see, at install time, exactly what a plugin will be able to
+do.
 
 ### RBAC model
 

--- a/docs/developer/plugins/install-a-plugin.md
+++ b/docs/developer/plugins/install-a-plugin.md
@@ -1,0 +1,237 @@
+---
+title: Install a plugin
+sidebar:
+  order: 3
+---
+
+Install `cert-manager` into the local `k3d-fundament-plugin` sandbox cluster, prove it works,
+and see it in the console. This is the standard path for working with plugins locally, and the
+one to follow first.
+
+About fifteen minutes from a cold Docker cache, much less with a warm one — see the
+[timings](./dev-environment.md#how-long-it-takes).
+
+**Before you start:** the platform must be running —
+[Getting started](../fundament/getting-started.md) — and it is worth reading
+[The two development clusters](./dev-environment.md) first, because every step below touches one
+of the two clusters and they mean different things.
+
+## 1. Create the `k3d-fundament-plugin` sandbox cluster
+
+Every command on this page runs from the **repository root**. The sandbox recipes live in
+`plugins/mod.just`, which the root `Justfile` registers as the `plugins` module — hence the
+`plugins` prefix:
+
+```bash
+just plugins cluster-create
+just plugins dev
+```
+
+The prefix is not cosmetic. `just plugins dev` deploys the plugin-controller into
+`k3d-fundament-plugin` and then watches for changes; a bare `just dev` is the root recipe and
+deploys the whole platform to `k3d-fundament`.
+
+Like the platform one it passes `--cleanup=false`, so once the controller is available you can
+stop it with Ctrl-C and everything stays deployed. Keep it running only while you are editing
+plugin-controller source.
+
+## 2. Bridge the two clusters
+
+```bash
+just plugins sandbox-orgapi
+```
+
+This lets the controller reach organization-api to fetch plugin definitions.
+
+The second bridge is what makes the console real: locally kube-api-proxy runs in `mock` mode and
+serves an in-memory fake cluster, and this replaces that mock with a proxy to the real sandbox.
+It is a root recipe, so it takes no prefix:
+
+```bash
+just plugin-sandbox-kubeconfig
+```
+
+That writes a Secret holding a kubeconfig for the sandbox, restarts the two consumers that
+mount it, and waits until one of them confirms the switch. It ends with:
+
+```
+- kube-api-proxy is proxying to the sandbox (mock disabled)
+```
+
+If you do not see that line the bridge is not in place, and plugin pages in the console will
+fail to load.
+
+Re-run both bridges after recreating either cluster.
+
+## 3. Publish the plugin definition
+
+A plugin is installed by reference: you publish its **definition** to organization-api, then
+point a `PluginInstallation` at it:
+
+```bash
+export PLUGIN_REGISTRY=localhost:5112
+export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
+export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
+export FUNDAMENT_TOKEN=$(./deploy/k3d/dev-token.sh)
+just plugins publish cert-manager
+```
+
+Expect a last line like:
+
+```
+published plugin=cert-manager version=… hash=sha256:… id=… definition_id=…
+```
+
+`dev-token.sh` logs in as `platform-admin@fundament.io`. That identity matters: publishing
+requires admin of the organization that owns the plugin, first-party plugins are owned by the
+seeded `system` org, and the ordinary dev logins are not members of it. Republishing the same
+version needs `--replace`.
+
+## 4. Install it
+
+`pluginVersion` and `definitionHash` must both match what step 3 printed — the version is the
+plugin's own (`metadata.version` in its `definition.yaml`), not a Fundament version, and it
+differs per plugin. Copy both from that output rather than from here:
+
+```bash
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: plugins.fundament.io/v1
+kind: PluginInstallation
+metadata:
+  name: system--cert-manager
+spec:
+  definitionRef:
+    organizationName: system
+    pluginName: cert-manager
+    pluginVersion: PASTE_THE_VERSION_FROM_STEP_3
+    definitionHash: PASTE_THE_HASH_FROM_STEP_3
+YAML
+```
+
+The `PluginInstallation` goes in the **sandbox**, not the platform. `definitionHash` is the
+admin's record of exactly which definition was approved.
+
+A plugin's identity is the pair `(organizationName, pluginName)`, so `metadata.name` must equal
+`<organizationName>--<pluginName>` — here `system--cert-manager`, because first-party plugins are
+owned by the seeded `system` org. See
+[FUN-17](/funs/fun-17#plugin-identity-and-naming).
+
+:::caution[Always set `definitionHash`, even locally]
+The sandbox sets `pluginController.allowUnpinnedHash: true`, which suggests the hash can be
+omitted. It cannot. The CRD marks `definitionRef` immutable with a `self == oldSelf` rule, and an
+absent `definitionHash` does not survive the controller's round-trip, so its very first update is
+rejected:
+
+```
+add finalizer: PluginInstallation … spec.definitionRef: Invalid value: definitionRef is immutable once set
+```
+
+The CR is created but never reconciles: `PHASE` stays empty and no namespace appears. Delete it,
+re-apply with the hash, and it proceeds.
+
+:::
+
+## 5. Watch it come up
+
+```bash
+just plugins status
+just plugins logs system--cert-manager
+```
+
+Expect `PHASE=Running` and `READY=true`. The first install pulls the cert-manager images and
+takes a few minutes; the controller polls plugin status every 30 seconds, so the CR lags a
+little behind reality.
+
+```bash
+kubectl --context k3d-fundament-plugin get plugininstallations
+kubectl --context k3d-fundament-plugin -n cert-manager get pods
+```
+
+## 6. Prove it works
+
+```bash
+just plugins cert-manager test
+```
+
+This creates a self-signed `ClusterIssuer` and a `Certificate` and waits for cert-manager to
+issue it. Clean up with `just plugins cert-manager test-cleanup`.
+
+## 7. See it in the console
+
+Open <https://console.fundament.localhost:8443> and sign in as `alice@acme-corp.com` with
+password `password`. Go to **Clusters → acme-cluster → cert-manager → ClusterIssuers**.
+
+A blank or erroring panel here almost always means step 2 was skipped, or a cluster was recreated
+after the bridges were made.
+
+## Clean up
+
+```bash
+just plugins uninstall system--cert-manager
+just plugins cluster-delete
+```
+
+## Known issues on this path
+
+### A platform redeploy invalidates published plugin definitions
+
+`charts/fundament/values-local.yaml` sets `db.reset: true`, so every `just dev` at the repository
+root re-seeds the platform database and drops every published `PluginDefinition`.
+
+`just plugins status` will not show it: the `PluginInstallation` keeps reporting `Running` and
+`READY=true`, because that status reflects the plugin's own health rather than the controller's
+ability to resolve its definition. It surfaces in the controller log:
+
+```
+fetch definition: GetPluginDefinition RPC: not_found: plugin definition cert-manager@… not found
+```
+
+**Recovery:** redo step 3, then **delete and re-apply** the `PluginInstallation` with the newly
+printed hash. It cannot be edited in place — the whole of `definitionRef` is immutable, so
+`kubectl apply`/`edit` is rejected with `definitionRef is immutable once set`.
+
+Deleting runs the plugin's uninstall path, so whatever it manages goes with it — for
+cert-manager that means cert-manager itself leaves the sandbox and is reinstalled by the new CR.
+
+The hash covers the published manifest, and `publish` injects the freshly built image's
+digest into that manifest before hashing. So the hash only stays the same if the rebuild
+reproduces a byte-identical image — which a warm Docker cache does, and a cold one does not.
+Observed: the same `definition.yaml` published as `sha256:7c9dcb61…` from a warm cache and
+`sha256:782914be…` after `docker system prune -a`. Do not assume it is stable.
+
+
+### `permission_denied` when publishing after a redeploy
+
+The same reset recreates the OpenFGA store, and the authorization tuples written earlier can be
+left behind in the previous one. Every authorization decision then resolves to false while every
+pod looks healthy — including when the seeded admin row and the tuples themselves look correct.
+Restarting `organization-api`, `kube-api-proxy` or `authz-worker` does **not** repair it.
+
+**Recovery:** redeploy the platform again, then republish.
+
+
+## Other plugins
+
+Steps 3 to 6 work for any plugin that has a catalog entry — only the name and version change.
+Steps 1 and 2 are one-time setup, and `ceph-rook` is the exception: it needs block devices on
+the node and has its own verification procedure.
+
+`publish` takes a **path** under `plugins/`, while `pluginName` in the CR is the
+`metadata.name` from that plugin's `definition.yaml`. They differ for the gateway plugin.
+
+| Plugin (`pluginName`) | `publish` argument | Notes |
+|---|---|---|
+| `cert-manager` | `cert-manager` | This walkthrough. Has `just plugins cert-manager test` |
+| `openfsc` | `openfsc` | Extra setup first; see `plugins/openfsc/README.md` |
+| `gateway-api-envoy` | `gateway-api/envoy-gateway` | — |
+| `ceph-rook` | `storage/ceph-rook` | **Different procedure** — needs raw block devices and its own baseline checks. Follow the [Ceph/Rook runbook](./ceph-rook-runbook.md), not these steps |
+| `external-dns` | — | **Not installable today** — see below |
+| `gateway-api-istio` | — | **Not installable today** — same reason as `external-dns` |
+
+Each plugin's version is in its own `definition.yaml`, and `publish` prints it.
+
+`external-dns` and `gateway-api-istio` have source and a `definition.yaml`, but neither is
+registered as a module in `plugins/mod.just` nor present in `db/seed/0101-appstore-catalog.sql`.
+So `just plugins external-dns test` does not resolve, and `just plugins publish` on either fails
+with `no catalog entry`.
+

--- a/docs/developer/plugins/writing-a-plugin.md
+++ b/docs/developer/plugins/writing-a-plugin.md
@@ -1,7 +1,7 @@
 ---
 title: Writing a plugin
 sidebar:
-  order: 3
+  order: 5
 ---
 
 Writing a plugin consists of several steps, each described below.
@@ -170,6 +170,13 @@ ENTRYPOINT ["/my-plugin"]
 
 ### 5. Create a PluginInstallation
 
+A plugin is not installed by pointing at an image. You publish its **definition** to
+organization-api, then reference that:
+
+```bash
+just plugins publish my-plugin      # from the repository root — prints the version and hash
+```
+
 ```yaml
 apiVersion: plugins.fundament.io/v1
 kind: PluginInstallation
@@ -177,15 +184,19 @@ metadata:
   name: acme--my-plugin
 spec:
   definitionRef:
-    organizationName: acme
-    pluginName: my-plugin
-    pluginVersion: v1.0.0
-    definitionHash: sha256:...
+    organizationName: acme         # the organization that published the definition
+    pluginName: my-plugin          # metadata.name from your definition.yaml
+    pluginVersion: v1.0.0          # metadata.version from your definition.yaml
+    definitionHash: sha256:…       # from `just plugins publish`
 ```
 
 `metadata.name` must equal `<organizationName>--<pluginName>` — a plugin's
 identity is that pair, not the plugin name alone (see
 [FUN-17](/funs/fun-17#plugin-identity-and-naming)).
+
+The image and the cluster-wide RBAC come from the published definition, not from this CR. The
+full walkthrough, with the cluster setup it needs, is
+[Install a plugin](./install-a-plugin.md).
 
 ## Metadata API
 
@@ -203,6 +214,9 @@ service PluginMetadataService {
 | Plugin Controller | `GetStatus` | Poll phase, message, version → write to CR `.status` |
 | Console Frontend | `GetDefinition` | Fetch menu entries, UI hints, CRDs → render plugin UI |
 
-## Plugin sandbox
+## Next steps
 
-A self-contained development environment for plugin development. See [`plugins/README.md`](https://github.com/fundament-oss/fundament/blob/master/plugins/README.md) for setup instructions and available commands.
+- [Install a plugin](./install-a-plugin.md) — publish and install what you just built, on the
+  local two-cluster setup.
+- [`plugins/README.md`](https://github.com/fundament-oss/fundament/blob/master/plugins/README.md)
+  — the command reference for the sandbox.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,38 +1,103 @@
 # Plugin Sandbox
 
-A self-contained development environment lives in `sandbox/`. It creates an isolated K3D cluster with only the plugin controller -- no database, auth services, or other Fundament components needed. The sandbox cluster (`fundament-plugin`) uses a separate registry on port `5112`, so it can coexist with the main Fundament cluster without conflicts.
+`sandbox/` holds a development environment for plugin work: the `k3d-fundament-plugin` sandbox
+cluster, running only the plugin-controller, with its own registry on port `5112` so it coexists
+with the `k3d-fundament` platform cluster.
 
-## Quick Start
+The sandbox is not self-contained. A plugin is installed by publishing its **definition** to
+organization-api and referencing it from a `PluginInstallation` (FUN-19), so the management
+cluster — database, organization-api, OpenFGA and a dex login — has to be running too. See
+[Install a plugin](../docs/developer/plugins/install-a-plugin.md) for the walkthrough, and
+[The two development clusters](../docs/developer/plugins/dev-environment.md) for how the two
+clusters fit together. This file is the command reference.
+
+## Quick start
+
+The recipes here live in `mod.just`, which the repository root's `Justfile` registers as the
+`plugins` module. So they are **run from the repository root**, prefixed with `plugins` — a bare
+`just cluster-create` from any directory resolves to the root recipe and builds the *platform*
+cluster instead.
 
 ```shell
-just cluster-create   # Create K3D cluster + registry (~10s)
-just dev              # Build + deploy plugin-controller with file watching
-just deploy           # One-time build without file watching
-
-# In another terminal:
-just plugin-install cert-manager   # Build plugin, push to registry, apply CR
-just plugins status                 # Check PluginInstallation status
-just logs                          # Watch controller logs
-
-# Verify cert-manager actually works:
-just cert-manager test             # Creates a self-signed ClusterIssuer + Certificate
-just cert-manager test-cleanup     # Remove test resources
-
-# Install and verify external-dns:
-just plugin-install external-dns   # Build plugin, push to registry, apply CR
-just external-dns test             # Creates a DNSEndpoint resource
-just external-dns test-cleanup     # Remove test resources
-
-# Install and verify OpenFSC (see plugins/openfsc/README.md):
-just openfsc operator-push         # Build the openfsc-operator image for the sandbox
-just plugin-install openfsc        # Installs prerequisites + the operator
-just openfsc test                  # Sample FSCInstallation reaches Active
-just openfsc test-cleanup          # Remove the sample installation
-
-# Cleanup:
-just plugins uninstall cert-manager
-just plugins uninstall external-dns
-just cluster-delete
+just plugins cluster-create   # K3D cluster + registry (~10s)
+just plugins dev              # build + deploy plugin-controller, with file watching
+just plugins deploy           # one-time build without file watching
+just plugins sandbox-orgapi   # bridge the controller to organization-api
 ```
 
-All commands are defined in the `Justfile`. Run `just --list` to see available commands.
+Then publish a definition and install it. `publish` builds the image, pushes it and
+registers the definition, printing the `definitionHash` the `PluginInstallation` must pin:
+
+```shell
+export PLUGIN_REGISTRY=localhost:5112
+export FUNDAMENT_ORG_API_URL=https://organization.fundament.localhost:8443
+export FUNDAMENT_ORGANIZATION_ID=019b4000-0000-7000-8000-000000000000   # seeded "system" org
+export FUNDAMENT_TOKEN=$(./deploy/k3d/dev-token.sh)
+
+just plugins publish cert-manager
+# published plugin=cert-manager version=… hash=sha256:… id=… definition_id=…
+```
+
+```shell
+kubectl --context k3d-fundament-plugin apply -f - <<'YAML'
+apiVersion: plugins.fundament.io/v1
+kind: PluginInstallation
+metadata:
+  name: system--cert-manager     # must be <organizationName>--<pluginName>
+spec:
+  definitionRef:
+    organizationName: system
+    pluginName: cert-manager
+    pluginVersion: …             # printed by publish
+    definitionHash: sha256:PASTE_THE_HASH
+YAML
+```
+
+Republishing an existing `pluginVersion` needs `--replace`, which soft-deletes the previous
+definition. The printed hash covers the manifest *including the freshly built image's digest*, so
+it changes whenever the rebuild is not byte-identical — after a cold rebuild, update
+`definitionHash` in any `PluginInstallation` that pins it.
+
+Always set `definitionHash`. `pluginController.allowUnpinnedHash: true` in the sandbox implies it
+is optional, but an absent hash trips the CRD's `definitionRef` immutability rule on the
+controller's first update and the installation silently never reconciles.
+
+Each plugin has its own `pluginVersion`, and the `publish` argument is a **path** under
+`plugins/` rather than the plugin name. The table of both, per plugin, is in
+[Install a plugin](../docs/developer/plugins/install-a-plugin.md#other-plugins).
+
+## Working with an installed plugin
+
+`logs` and `uninstall` take the installation's `metadata.name` — the `<organization>--<plugin>`
+pair, not the plugin name alone.
+
+```shell
+just plugins status                          # all PluginInstallation CRs
+just plugins logs system--cert-manager       # stream one plugin's logs
+just plugins logs                            # plugin-controller logs
+just plugins uninstall system--cert-manager  # delete the PluginInstallation
+just plugins cluster-delete
+```
+
+Per-plugin verification lives in each plugin's own module:
+
+```shell
+just plugins cert-manager test             # self-signed ClusterIssuer + Certificate
+just plugins cert-manager test-cleanup
+just plugins openfsc operator-push         # build the openfsc-operator image for the sandbox
+just plugins openfsc test                  # sample FSCInstallation reaches Active
+just plugins openfsc test-cleanup
+```
+
+For `ceph-rook`, which needs raw block devices and a longer setup, follow the
+[verification runbook](../docs/developer/plugins/ceph-rook-runbook.md).
+
+## external-dns is not installable
+
+`plugins/external-dns/` has source, a `Justfile` and test resources, but it is **not** registered
+as a `mod` in this directory's `mod.just` and has **no** entry in
+`db/seed/0101-appstore-catalog.sql`. So `just plugins external-dns test` does not resolve, and
+`just plugins publish external-dns` fails with `no catalog entry for "external-dns"`.
+
+
+All commands are defined in `mod.just`; run `just --list plugins` to see them.

--- a/plugins/mod.just
+++ b/plugins/mod.just
@@ -2,6 +2,9 @@ mod cert-manager
 mod openfsc
 mod envoy-gateway 'gateway-api/envoy-gateway'
 mod ceph-rook 'storage/ceph-rook'
+# TODO: external-dns and gateway-api/istio have source and a definition.yaml but are neither
+# registered here nor present in db/seed/0101-appstore-catalog.sql, so they cannot be published
+# or tested. Add the mod line and the catalog row.
 
 cluster := "fundament-plugin"
 registry := "plugin-registry.localhost"

--- a/plugins/sandbox/values.yaml
+++ b/plugins/sandbox/values.yaml
@@ -34,7 +34,11 @@ ingress:
 pluginController:
   enabled: true
   logLevel: debug
-  # `just plugin-install` sets an empty definitionHash; allow it in the sandbox.
+  # Allow a PluginInstallation that pins no definitionHash; the sandbox trusts its own registry.
+  # TODO: this cannot actually be used. The CRD marks definitionRef immutable (self == oldSelf)
+  # and the controller round-trips an absent definitionHash as "", so its first update is
+  # rejected and the installation never reconciles. Either make the rule tolerate an absent
+  # hash, or drop this flag.
   allowUnpinnedHash: true
   # The sandbox cluster is network-isolated from organization-api (which lives in
   # the management cluster). `just plugins sandbox-orgapi` bridges the two via a


### PR DESCRIPTION
The developer docs could not be followed to completion by someone new to Fundament. This was found while testing the `ceph-rook` plugin and verified by executing every documented command on a cold machine, not by review.

### What was wrong

- The reader's path crosses `docs/developer/fundament/` and `docs/developer/plugins/` within the first ten minutes, and nothing said so. Both directories define a `just dev` recipe that does different things.
- The `PluginInstallation` examples used `spec.image`, `spec.pluginName` and `spec.clusterRoles`. The CRD accepts only `spec.definitionRef` and `spec.config`; a server dry-run rejects the documented example.
- `just plugin-sandbox-kubeconfig` — the step that switches `kube-api-proxy` off its in-memory mock and is what makes the console show a real installation — was documented nowhere.

### What this adds

- **`install-a-plugin.md`** — the cert-manager walkthrough, from creating the sandbox cluster through to the plugin visible in the console, with a known-issues section and a table of the other plugins.
- **`dev-environment.md`** — the two-cluster model the walkthrough assumes, with the `just dev` directory table and measured timings.

Known local-dev defects are now recorded next to the code they affect rather than in prose: `db.reset` dropping published definitions (`values-local.yaml`), `allowUnpinnedHash` being unusable against the CRD's immutability rule (`plugins/sandbox/values.yaml`), and `external-dns` having source but no catalog entry (`plugins/Justfile`).

### Open point — step 7

Step 7 ("See it in the console") is **not confirmed working**. Loading a plugin UI hits a CSP violation: `plugin-proxy` is absent from `frame-src`, and there is a further inline-script violation inside the plugin iframe that is not yet diagnosed. A candidate `CONNECT_SRC` fix was deliberately left out of this PR pending agreement on whether it is needed. The rest of the walkthrough (steps 1–6) is verified end to end.

### Base

Targets `split/7-registration-docs` because it edits `ceph-rook-runbook.md` and `example-ceph-rook.md`, which exist only there. It will retarget to `master` automatically once #378 merges. It also documents `deploy/k3d/dev-token.sh` from #380.

`just docs-build` passes: no broken links across 74 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQaEdg2pvdMCYGQhj7Fm1i
