### PR TITLE
fix(console): allow the plugin-proxy origin in frame-src

### DIFF
--- a/charts/fundament/templates/console-frontend.yaml
+++ b/charts/fundament/templates/console-frontend.yaml
@@ -37,8 +37,14 @@ spec:
         - name: console-frontend
           image: {{ $.Values.images.consoleFrontend }}
           env:
+            # connect-src in nginx.conf: origins the console calls with fetch/XHR.
             - name: CONNECT_SRC
               value: "{{ $.Values.externalUrls.authn }} {{ $.Values.externalUrls.organization }} {{ $.Values.externalUrls.kubeApiProxy }}"
+            # frame-src in nginx.conf. Plugin console UIs are iframed from the
+            # dedicated plugin-proxy origin (FUN-17); the console never fetches
+            # from it, so it stays out of connect-src.
+            - name: FRAME_SRC
+              value: "{{ $.Values.externalUrls.pluginProxy }}"
           ports:
             - name: http
               containerPort: 80

--- a/console-frontend/Dockerfile
+++ b/console-frontend/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=build /app/dist/fundament-console/browser /usr/share/nginx/html
 COPY console-frontend/nginx.conf /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 80
-CMD ["/bin/sh", "-c", "envsubst '${CONNECT_SRC}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${CONNECT_SRC} ${FRAME_SRC}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/console-frontend/nginx.conf
+++ b/console-frontend/nginx.conf
@@ -22,12 +22,15 @@ server {
     #   - style-src 'unsafe-inline'    Angular inlines component styles at runtime
     #   - connect-src ${CONNECT_SRC}   injected at container startup via envsubst;
     #                                  set via externalUrls.authn + externalUrls.organization + externalUrls.kubeApiProxy in Helm values
-    #   - frame-src ${CONNECT_SRC}     plugin custom UIs are served from the kube-api-proxy origin
-    #                                  and embedded here as iframes; without frame-src this falls
-    #                                  back to default-src 'self' and the browser blocks them
+    #   - frame-src ${FRAME_SRC}       plugin custom UIs are served from the dedicated plugin-proxy
+    #                                  origin (FUN-17) and embedded here as iframes; without
+    #                                  frame-src this falls back to default-src 'self' and the
+    #                                  browser blocks them. Separate from CONNECT_SRC because the
+    #                                  console only frames that origin, never fetches from it.
+    #                                  Set via externalUrls.pluginProxy in Helm values.
     #   - frame-ancestors 'none'       equivalent to X-Frame-Options DENY (superset)
     # -------------------------------------------------------------------------
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; frame-src 'self' ${CONNECT_SRC}; frame-ancestors 'none'; object-src 'none'; base-uri 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; frame-src 'self' ${FRAME_SRC}; frame-ancestors 'none'; object-src 'none'; base-uri 'self';" always;
 
     # Prevent the page from being embedded in a frame on any origin
     add_header X-Frame-Options "DENY" always;
@@ -49,7 +52,7 @@ server {
     # tags; this is acceptable because the iframe sandbox attribute already
     # provides the isolation boundary.
     location /plugin-ui/ {
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; frame-src 'self' ${CONNECT_SRC}; frame-ancestors 'self'; object-src 'none'; base-uri 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${CONNECT_SRC}; frame-src 'self' ${FRAME_SRC}; frame-ancestors 'self'; object-src 'none'; base-uri 'self';" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
Plugin console UIs are iframed from the dedicated plugin-proxy origin (FUN-17), but `frame-src` was fed from `CONNECT_SRC`, which lists authn, organization and kube-api-proxy only. The browser fell back to `default-src 'self'` and refused to frame them:

```
Refused to frame 'https://plugin-proxy.fundament.localhost:8443/' because it
violates the following Content Security Policy directive: "frame-src 'self'".
```

### Why `frame-src` gets its own variable

`FRAME_SRC` is new rather than widening `CONNECT_SRC`. The console builds iframe URLs against plugin-proxy (`plugin-console-url.utils.ts`) but never `fetch`es from it, so that origin does not belong in `connect-src`. Splitting them keeps each directive at what it actually needs.

`FRAME_SRC` joins the `envsubst` whitelist in the Dockerfile — without that, `${FRAME_SRC}` would reach nginx literally. Unset, it yields `frame-src 'self'`, which is correct for a deployment with no `externalUrls.pluginProxy`. `dcim-frontend` has its own `nginx.conf` and `Dockerfile` and is unaffected.

### Why this was easy to miss

`just dev-hotreload` swaps `console-frontend/Dockerfile` for `console-frontend/hotreload/Dockerfile`, which runs `ng serve` and **sets no security headers at all**. Plugin iframes therefore load fine under hotreload and fail under `just dev`.

`just dev` is the faithful one: CI builds the shipped image from `console-frontend/Dockerfile` (`build.yml:81-83`), which is what `images.consoleFrontend` points at. So this bug affects every deployed environment while being invisible to anyone developing in hotreload — as is any other security-header bug.

### Verified

On a wiped machine — both k3d clusters and registries deleted — then `just cluster-start`, `just dev`, sandbox cluster, both bridges, `plugin-publish cert-manager` (v1.17.2), install, open the console.

Served CSP after the change:

```
connect-src 'self' https://authn.fundament.localhost:8443 https://organization.fundament.localhost:8443 https://k8s-api.fundament.localhost:8443
frame-src   'self' https://plugin-proxy.fundament.localhost:8443
```

The cert-manager plugin UI renders in the console. Also checked that `envsubst` still leaves nginx's own `$uri` untouched, and that `helm template` emits the expected `FRAME_SRC`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
