### PR TITLE
fix(authz-worker): stop draining the outbox into a wiped OpenFGA store

### DIFF
--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -22,6 +22,8 @@ import (
 const (
 	listenChannel = "authz_outbox"
 
+	storeCheckTimeout = 5 * time.Second
+
 	// finalizeTimeout bounds the post-dispatch DB work (mark processed/retry
 	// + commit) when running on a context that may already have been cancelled
 	// by SIGTERM. The OpenFGA write has already happened at that point; if we
@@ -29,6 +31,9 @@ const (
 	// OpenFGA rejects it as a duplicate.
 	finalizeTimeout = 10 * time.Second
 )
+
+// errStoreUnavailable lets Run distinguish a failed store check from a lost DB connection.
+var errStoreUnavailable = errors.New("openfga store unavailable")
 
 // Config holds configuration for the outbox worker.
 type Config struct {
@@ -45,6 +50,7 @@ type Worker struct {
 	pool    *pgxpool.Pool
 	queries *db.Queries
 	handler *handler.Handler
+	fga     *client.OpenFgaClient
 	logger  *slog.Logger
 	cfg     Config
 	ready   atomic.Bool
@@ -53,6 +59,10 @@ type Worker struct {
 	// dispatchItem and exists as a field so tests can substitute failure
 	// scenarios, including ones that abort tx (SQLSTATE 25P02).
 	dispatch func(ctx context.Context, tx pgx.Tx, qtx *db.Queries, item *db.GetAndLockNextOutboxRowRow) error
+
+	// verify gates each drain on the OpenFGA store. Defaults to verifyStore and
+	// exists as a field so tests can stub it.
+	verify func(ctx context.Context) error
 }
 
 // New creates a new authz worker with sensible defaults.
@@ -66,12 +76,14 @@ func New(pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, logger *slog.Logge
 		pool:    pool,
 		queries: db.New(pool),
 		handler: handler.New(fgaClient, logger),
+		fga:     fgaClient,
 		logger:  logger.With("worker_id", workerID),
 		cfg:     cfg,
 	}
 	w.dispatch = func(ctx context.Context, _ pgx.Tx, qtx *db.Queries, item *db.GetAndLockNextOutboxRowRow) error {
 		return w.dispatchItem(ctx, qtx, item)
 	}
+	w.verify = w.verifyStore
 
 	return w
 }
@@ -115,7 +127,11 @@ func (w *Worker) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return fmt.Errorf("worker stopped: %w", ctx.Err())
 		}
-		w.logger.Error("connection lost, reconnecting", "error", err, "delay", w.cfg.BackoffDelay)
+		if errors.Is(err, errStoreUnavailable) {
+			w.logger.Error("openfga store unavailable, holding outbox", "error", err, "delay", w.cfg.BackoffDelay)
+		} else {
+			w.logger.Error("connection lost, reconnecting", "error", err, "delay", w.cfg.BackoffDelay)
+		}
 		w.ready.Store(false)
 		select {
 		case <-ctx.Done():
@@ -131,6 +147,11 @@ func (w *Worker) runWithConnection(ctx context.Context) error {
 		return err
 	}
 	defer conn.Release()
+
+	// Ready only once the store checks out — a worker without its store makes no progress.
+	if err := w.verify(ctx); err != nil {
+		return err
+	}
 
 	w.ready.Store(true)
 
@@ -151,8 +172,25 @@ func (w *Worker) runWithConnection(ctx context.Context) error {
 		if _, err := w.waitForNotification(ctx, conn); err != nil {
 			return err
 		}
+		if err := w.verify(ctx); err != nil {
+			return err
+		}
 		w.processBatch(ctx)
 	}
+}
+
+// verifyStore gates a drain on the store existing: OpenFGA's Write does not
+// check store existence, so writes to a wiped store falsely succeed. GetStore
+// bypasses the typesystem cache and sees the wipe.
+func (w *Worker) verifyStore(ctx context.Context) error {
+	checkCtx, cancel := context.WithTimeout(ctx, storeCheckTimeout)
+	defer cancel()
+
+	if _, err := w.fga.GetStore(checkCtx).Execute(); err != nil {
+		return fmt.Errorf("%w: %w", errStoreUnavailable, err)
+	}
+
+	return nil
 }
 
 func (w *Worker) setupListener(ctx context.Context) (*pgxpool.Conn, error) {

--- a/authz-worker/pkg/worker/worker_test.go
+++ b/authz-worker/pkg/worker/worker_test.go
@@ -40,6 +40,7 @@ func TestProcessesRetryingRowOnPollTimeoutWithoutNotify(t *testing.T) {
 	w.dispatch = func(context.Context, pgx.Tx, *db.Queries, *db.GetAndLockNextOutboxRowRow) error {
 		return nil
 	}
+	w.verify = func(context.Context) error { return nil }
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -114,6 +115,7 @@ func TestProcessOneItem_DispatchAbortsTx(t *testing.T) {
 		queries: db.New(pool),
 		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 		cfg:     applyDefaults(Config{}),
+		verify:  func(context.Context) error { return nil },
 	}
 
 	// Simulate a handler whose SQL statement fails mid-transaction: the failing
@@ -149,4 +151,49 @@ func TestProcessOneItem_DispatchAbortsTx(t *testing.T) {
 	require.NotNil(t, statusInfo)
 	assert.Contains(t, *statusInfo, "boom")
 	assert.NotNil(t, retryAfter, "retry backoff must be scheduled")
+}
+
+// TestHoldsOutboxWhenStoreUnavailable verifies the worker refuses to drain when
+// the OpenFGA store check fails. OpenFGA accepts writes to a store that no
+// longer exists, so a drain in that state marks rows processed against nothing
+// and they are never replayed.
+func TestHoldsOutboxWhenStoreUnavailable(t *testing.T) {
+	pool := createTestDB(t)
+
+	_, err := pool.Exec(t.Context(), `DELETE FROM authz.outbox`)
+	require.NoError(t, err)
+
+	var itemID uuid.UUID
+	err = pool.QueryRow(t.Context(),
+		`INSERT INTO authz.outbox (cluster_id) VALUES ($1) RETURNING id`,
+		seededClusterID,
+	).Scan(&itemID)
+	require.NoError(t, err)
+
+	w := &Worker{
+		pool:    pool,
+		queries: db.New(pool),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:     applyDefaults(Config{PollInterval: 50 * time.Millisecond}),
+		verify:  func(context.Context) error { return errStoreUnavailable },
+	}
+	// Fails the test if reached: a failed store check must stop the drain.
+	w.dispatch = func(context.Context, pgx.Tx, *db.Queries, *db.GetAndLockNextOutboxRowRow) error {
+		t.Error("dispatched an outbox row while the store was unavailable")
+
+		return nil
+	}
+
+	err = w.runWithConnection(t.Context())
+	require.ErrorIs(t, err, errStoreUnavailable)
+	assert.False(t, w.IsReady(), "must not report ready without its store")
+
+	var status string
+	var processed *time.Time
+	err = pool.QueryRow(t.Context(),
+		`SELECT status, processed FROM authz.outbox WHERE id = $1`, itemID,
+	).Scan(&status, &processed)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", status, "row must be held, not consumed")
+	assert.Nil(t, processed, "row must not be marked processed")
 }


### PR DESCRIPTION
`authz-worker` marks outbox rows processed on the strength of a write that cannot fail.

OpenFGA's `Write` never checks that the store exists, and it resolves the authorization model from an in-process cache with a 168h TTL. So a worker that was running before the datastore was wiped reports success for every tuple it writes into the rebuilt, empty schema. The rows are marked `completed` and nothing replays them — authorization stays empty while every pod reports healthy, including login, since `authn-api` gates `/readyz` on the same store.

Validating once at startup (`main.go:112`) does not help: the store is dropped *underneath* a worker that has already validated it.

This gates each drain on `GetStore` — which reads the store table directly rather than the typesystem cache, so it sees the wipe — and reports ready only once that has passed.

## Seen in the wild

Caught on master during testing today, before any deliberate provocation:

```
configured store:  01M0HZJA6YYR07GNRYTECWATVV
tuples:            0
authz.outbox:      29 completed
authz-worker:      1/1 Running
```

All 29 rows consumed into a store that no longer existed. The user could log in as
`alice@acme-corp.com` — password auth needs no tuple — and got `permission denied` on
clusters, which needs `organization#can_list_clusters`. Zero organization tuples existed. The
worker's own log reads `"OpenFGA client connected" store_name=fundament`: it validated at
startup, then the store was replaced underneath it.

## Demonstrated

Same test on the same cluster, an hour apart. Delete the store from under a running worker, then generate one outbox row:

| | master | this branch |
|---|---|---|
| outbox | `completed=30` | `completed=29` **`pending=1`** |
| tuples | 29, unchanged | 29, unchanged |
| worker | **1/1 Ready** | **0/1 NotReady** |
| the row | consumed and lost | preserved |

On master the row is marked done against a store that does not exist, and that permission is gone for good with no error anywhere. On this branch it is held, the pod leaves its Service endpoints, and the log says `openfga store unavailable, holding outbox`.

Recovery verified: once a valid store exists the held rows drain normally.

## Scope, stated plainly

This stops the loss. It does **not** stop the race — recovery still needs the pod restarted to pick up the new store id. Reloader does that in k3d (`deploy/k3d/resources/reloader.yaml`); it is not installed in PR environments, where recovery degrades to the `rollout restart` that `build.yml:298` already documents. A manual step instead of silent corruption.

It also covers cases the companion chart PR cannot: a restore, a lost volume, or a migration in an environment that never resets.

## Review notes

Reviewed adversarially twice before opening. From the first pass, four fixes applied:

- `verify` is a field alongside the existing `dispatch` seam, so `worker_test.go:33` — which builds `&Worker{}` directly — does not nil-deref. Without it the panic happens inside a goroutine and takes the test binary down.
- 5s timeout on the check, mirroring `verifyConnection` (`:230`). The run context has no deadline and the SDK's default client has none either, so a black-holed endpoint would otherwise wedge the loop.
- A distinct `errStoreUnavailable` path, so a missing store no longer logs as `"connection lost, reconnecting"` and point operators at Postgres.
- Comment trimmed to the invariant rather than the incident.

A second pass raised two more, both applied: the nil-guard on the seam was removed — it would
have silently disabled the check if the wiring in `New` ever regressed, which is the exact
failure this branch exists to prevent, so a regression now panics loudly the way the `dispatch`
precedent does — and `TestHoldsOutboxWhenStoreUnavailable` was added, asserting the row stays
`pending` with `processed IS NULL`, the worker never reports ready, and dispatch is never
reached.

`ReadAuthorizationModel` is deliberately **not** also checked: in a reset the store and model die together and `GetStore` catches it first, and old models are immutable and retained, so a surviving store with a new model produces a brief semantic skew rather than silent loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
