### PR TITLE
feat(marketplace): catalog API plumbing (stack 1/3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,9 @@ jobs:
           - image-name: openfsc-operator
             dockerfile: openfsc-operator/Dockerfile
             context: "."
+          - image-name: marketplace-catalog-api
+            dockerfile: marketplace-api/Dockerfile
+            context: "."
     permissions:
       contents: read
       packages: write
@@ -230,6 +233,7 @@ jobs:
             | DCIM | https://dcim.pr${{ env.PR_NUMBER }}.${{ env.DOMAIN }} |
             | DCIM API | https://dcim-api.pr${{ env.PR_NUMBER }}.${{ env.DOMAIN }} |
             | DCIM Auth | https://dcim-authn.pr${{ env.PR_NUMBER }}.${{ env.DOMAIN }} |
+            | Marketplace Catalog API | https://marketplace-api.pr${{ env.PR_NUMBER }}.${{ env.DOMAIN }} |
 
             **Commit:** `${{ env.IMAGE_TAG }}`
             **Namespace:** `tn-fundament-pr-${{ env.PR_NUMBER }}`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,40 @@ jobs:
         working-directory: dcim-api
         run: go test ./... -count=1
 
+  marketplace-api:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Trek binary
+        id: cache-trek
+        uses: actions/cache@v5
+        with:
+          path: ~/go/bin/trek
+          key: trek-${{ runner.os }}-v0.12.1
+
+      - name: Cache embedded PostgreSQL
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.FUNDAMENT_TEST_CACHE_DIR }}
+          key: embedded-pg-${{ runner.os }}
+
+      - name: Install dependencies
+        run: go get ./...
+
+      - name: Install Trek
+        if: steps.cache-trek.outputs.cache-hit != 'true'
+        run: go install github.com/printeers/trek@v0.12.1
+
+      - name: Run tests (marketplace-api)
+        working-directory: marketplace-api
+        run: go test ./... -count=1
+
   test-other:
     runs-on: ubuntu-24.04
     steps:
@@ -216,7 +250,7 @@ jobs:
         run: go get ./...
 
       - name: Run tests
-        run: go test -count=1 $(go list ./... | grep -v -E '/(organization-api|authz-worker|cluster-worker|common|dcim-api)/')
+        run: go test -count=1 $(go list ./... | grep -v -E '/(organization-api|authz-worker|cluster-worker|common|dcim-api|marketplace-api)/')
 
   openfsc-console-ui:
     runs-on: ubuntu-24.04

--- a/charts/fundament/pr-overlay.yaml
+++ b/charts/fundament/pr-overlay.yaml
@@ -104,6 +104,7 @@ spec:
       dcimApi: ${IMAGE_PREFIX}/dcim-api:${IMAGE_TAG}
       dcimFrontend: ${IMAGE_PREFIX}/dcim-frontend:${IMAGE_TAG}
       dcimAuthnApi: ${IMAGE_PREFIX}/dcim-authn-api:${IMAGE_TAG}
+      marketplaceCatalogApi: ${IMAGE_PREFIX}/marketplace-catalog-api:${IMAGE_TAG}
 
     authnApi:
       replicas: 1
@@ -307,6 +308,22 @@ spec:
             sectionName: tn-fundament-pr-${PR_NUM}
         hostnames:
           - dcim-authn.pr${PR_NUM}.${DOMAIN}
+
+    # Anonymous storefront API: no auth, so no Dex client and no JWT secret.
+    marketplaceCatalogApi:
+      enabled: true
+      replicas: 1
+      logLevel: debug
+      httproute:
+        enabled: true
+        parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: ListenerSet
+            name: tn-fundament-pr-${PR_NUM}
+            namespace: istio-gateway
+            sectionName: tn-fundament-pr-${PR_NUM}
+        hostnames:
+          - marketplace-api.pr${PR_NUM}.${DOMAIN}
 
     ingress:
       enabled: false

--- a/charts/fundament/templates/db-cluster.yaml
+++ b/charts/fundament/templates/db-cluster.yaml
@@ -56,6 +56,10 @@ spec:
         login: true
         passwordSecret:
           name: db-fun-dcim-api
+      - name: fun_marketplace_catalog_api
+        login: true
+        passwordSecret:
+          name: db-fun-marketplace-catalog-api
 {{- if $.Values.openfga.enabled }}
       - name: fun_openfga
         login: true

--- a/charts/fundament/templates/db-secrets.yaml
+++ b/charts/fundament/templates/db-secrets.yaml
@@ -116,6 +116,27 @@ stringData:
   uri: postgresql://fun_dcim_api:{{ $dcimApiPassword }}@{{ include "fundament.db.host" . }}:5432/fundament
 
 ---
+{{- $marketplaceCatalogApiSecretName := "db-fun-marketplace-catalog-api" }}
+{{- $marketplaceCatalogApiExisting := lookup "v1" "Secret" $.Release.Namespace $marketplaceCatalogApiSecretName }}
+{{- $marketplaceCatalogApiPassword := "" }}
+{{- if $marketplaceCatalogApiExisting }}
+{{- $marketplaceCatalogApiPassword = index $marketplaceCatalogApiExisting.data "password" | b64dec }}
+{{- else }}
+{{- $marketplaceCatalogApiPassword = randAlphaNum 32 }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $marketplaceCatalogApiSecretName }}
+  labels:
+    {{- include "fundament.labels" (dict "root" $ "name" "db" "component" "database") | nindent 4 }}
+type: kubernetes.io/basic-auth
+stringData:
+  username: fun_marketplace_catalog_api
+  password: {{ $marketplaceCatalogApiPassword | quote }}
+  uri: postgresql://fun_marketplace_catalog_api:{{ $marketplaceCatalogApiPassword }}@{{ include "fundament.db.host" . }}:5432/fundament
+
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/fundament/templates/marketplace-catalog-api-httproute.yaml
+++ b/charts/fundament/templates/marketplace-catalog-api-httproute.yaml
@@ -1,0 +1,18 @@
+{{- if $.Values.marketplaceCatalogApi.httproute.enabled }}
+{{- if not $.Values.marketplaceCatalogApi.httproute.parentRefs }}{{ fail "marketplaceCatalogApi.httproute.parentRefs is required when httproute is enabled" }}{{ end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $.Release.Name }}-marketplace-catalog-api
+  labels:
+    {{- include "fundament.labels" (dict "root" $ "name" "marketplace-catalog-api" "component" "gateway") | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml $.Values.marketplaceCatalogApi.httproute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml $.Values.marketplaceCatalogApi.httproute.hostnames | nindent 4 }}
+  rules:
+    - backendRefs:
+        - name: marketplace-catalog-api
+          port: 8080
+{{- end }}

--- a/charts/fundament/templates/marketplace-catalog-api.yaml
+++ b/charts/fundament/templates/marketplace-catalog-api.yaml
@@ -1,0 +1,92 @@
+{{- if $.Values.marketplaceCatalogApi.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-catalog-api
+  labels:
+    {{- include "fundament.labels" (dict "root" $ "name" "marketplace-catalog-api" "component" "backend") | nindent 4 }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ $.Values.marketplaceCatalogApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "fundament.selectorLabels" (dict "root" $ "name" "marketplace-catalog-api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fundament.labels" (dict "root" $ "name" "marketplace-catalog-api" "component" "backend") | nindent 8 }}
+    spec:
+      containers:
+        - name: marketplace-catalog-api
+          image: {{ $.Values.images.marketplaceCatalogApi }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: db-fun-marketplace-catalog-api
+                  key: uri
+            - name: LOG_LEVEL
+              value: {{ .Values.marketplaceCatalogApi.logLevel }}
+            {{- if $.Values.externalUrls.corsAllowedOrigins }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ $.Values.externalUrls.corsAllowedOrigins }}
+            {{- end }}
+          {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+          {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketplace-catalog-api
+  labels:
+    {{- include "fundament.labels" (dict "root" $ "name" "marketplace-catalog-api" "component" "backend") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      name: http
+  selector:
+    {{- include "fundament.selectorLabels" (dict "root" $ "name" "marketplace-catalog-api") | nindent 4 }}
+
+{{- if $.Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: marketplace-catalog-api
+  labels:
+    {{- include "fundament.labels" (dict "root" $ "name" "marketplace-catalog-api" "component" "backend") | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    {{- if $.Values.ingress.tls.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.tls.clusterIssuer }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $.Values.ingress.className }}
+  {{- if $.Values.ingress.tls.clusterIssuer }}
+  tls:
+    - hosts:
+        - marketplace-catalog-api.{{ include "fundament.ingress.infix" . }}{{ $.Values.ingress.domain }}
+      secretName: marketplace-catalog-api-tls
+  {{- end }}
+  rules:
+    - host: marketplace-catalog-api.{{ include "fundament.ingress.infix" . }}{{ $.Values.ingress.domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: marketplace-catalog-api
+                port:
+                  name: http
+{{- end }}
+
+{{- end }}

--- a/charts/fundament/templates/marketplace-catalog-api.yaml
+++ b/charts/fundament/templates/marketplace-catalog-api.yaml
@@ -32,6 +32,11 @@ spec:
                   key: uri
             - name: LOG_LEVEL
               value: {{ .Values.marketplaceCatalogApi.logLevel }}
+            {{- if $.Values.deploymentVersion }}
+            # Served on /version so CI can tell which release is answering.
+            - name: DEPLOYMENT_VERSION
+              value: {{ $.Values.deploymentVersion | quote }}
+            {{- end }}
             {{- if $.Values.externalUrls.corsAllowedOrigins }}
             - name: CORS_ALLOWED_ORIGINS
               value: {{ $.Values.externalUrls.corsAllowedOrigins }}

--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -50,6 +50,7 @@ images:
   dcimApi: ghcr.io/fundament-oss/fundament/dcim-api:latest
   dcimAuthnApi: ghcr.io/fundament-oss/fundament/dcim-authn-api:latest
   dcimFrontend: ghcr.io/fundament-oss/fundament/dcim-frontend:latest
+  marketplaceCatalogApi: ghcr.io/fundament-oss/fundament/marketplace-catalog-api:latest
 
 # Database (CloudNativePG)
 db:
@@ -282,6 +283,16 @@ dexDcim:
 dcimFrontend:
   enabled: false
   replicas: 1
+  httproute:
+    enabled: false
+    parentRefs: []
+    hostnames: []
+
+# Marketplace Catalog API
+marketplaceCatalogApi:
+  enabled: false
+  replicas: 1
+  logLevel: info
   httproute:
     enabled: false
     parentRefs: []

--- a/marketplace-api/Dockerfile
+++ b/marketplace-api/Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY marketplace-api/ ./marketplace-api/
-COPY plugin-sdk/ ./plugin-sdk/
 COPY common/ ./common/
 RUN CGO_ENABLED=0 go build -o /build/bin/marketplace-catalog-api ./marketplace-api/cmd/fun-marketplace-catalog-api
 

--- a/marketplace-api/Dockerfile
+++ b/marketplace-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.26.6-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY marketplace-api/ ./marketplace-api/
+COPY plugin-sdk/ ./plugin-sdk/
+COPY common/ ./common/
+RUN CGO_ENABLED=0 go build -o /build/bin/marketplace-catalog-api ./marketplace-api/cmd/fun-marketplace-catalog-api
+
+FROM scratch
+COPY --from=builder /build/bin/marketplace-catalog-api /
+ENTRYPOINT ["/marketplace-catalog-api"]

--- a/marketplace-api/cmd/fun-marketplace-catalog-api/main.go
+++ b/marketplace-api/cmd/fun-marketplace-catalog-api/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/caarlos0/env/v11"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// No JWT_SECRET: the storefront is unauthenticated by design (FUN-20).
+type config struct {
+	ListenAddr string     `env:"LISTEN_ADDR" envDefault:":8080"`
+	LogLevel   slog.Level `env:"LOG_LEVEL" envDefault:"info"`
+	// Served on /version so callers outside the cluster can tell which release
+	// is answering; the previous one keeps serving until Flux reconciles.
+	DeploymentVersion string `env:"DEPLOYMENT_VERSION" envDefault:"unknown"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	var cfg config
+	if err := env.Parse(&cfg); err != nil {
+		return fmt.Errorf("env parse: %w", err)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: cfg.LogLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting marketplace-catalog-api",
+		"listen_addr", cfg.ListenAddr,
+		"log_level", cfg.LogLevel.String(),
+	)
+
+	// Health endpoints only for now. The database connection and the catalog.v1
+	// handlers land with the service implementation; until then this deploys
+	// green and reserves the image, chart and route.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(cfg.DeploymentVersion))
+	})
+
+	httpServer := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           h2c.NewHandler(mux, &http2.Server{}),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	logger.Info("server listening", "addr", cfg.ListenAddr)
+	if err := httpServer.ListenAndServe(); err != nil {
+		return fmt.Errorf("server failed: %w", err)
+	}
+
+	return nil
+}

--- a/marketplace-api/hotreload/.air.toml
+++ b/marketplace-api/hotreload/.air.toml
@@ -1,0 +1,13 @@
+root = "/src"
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o tmp/marketplace-catalog-api ./marketplace-api/cmd/fun-marketplace-catalog-api"
+entrypoint = "tmp/marketplace-catalog-api"
+include_ext = ["go", "mod", "sum"]
+include_dir = ["marketplace-api"]
+exclude_dir = ["tmp"]
+delay = 500
+
+[log]
+time = false

--- a/marketplace-api/hotreload/Dockerfile
+++ b/marketplace-api/hotreload/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY marketplace-api/ ./marketplace-api/
-COPY plugin-sdk/ ./plugin-sdk/
 COPY common/ ./common/
 # Bake $GOCACHE at build time so air's first in-container build is a cache hit
 # (compile happens here, throttled by skaffold concurrency — not as a runtime storm).

--- a/marketplace-api/hotreload/Dockerfile
+++ b/marketplace-api/hotreload/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.26.6-alpine
+RUN go install github.com/air-verse/air@v1.65.0
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY marketplace-api/ ./marketplace-api/
+COPY plugin-sdk/ ./plugin-sdk/
+COPY common/ ./common/
+# Bake $GOCACHE at build time so air's first in-container build is a cache hit
+# (compile happens here, throttled by skaffold concurrency — not as a runtime storm).
+RUN go build -o /dev/null ./marketplace-api/cmd/fun-marketplace-catalog-api
+CMD ["air", "-c", "marketplace-api/hotreload/.air.toml"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -85,6 +85,11 @@ build:
       docker:
         dockerfile: plugin-proxy/Dockerfile
 
+    - image: marketplace-catalog-api
+      context: .
+      docker:
+        dockerfile: marketplace-api/Dockerfile
+
 deploy:
   kubeContext: REQUIRES-PROFILE # kubeContext is intentionally invalid to prevent accidental deployments without a profile.
   statusCheck: true
@@ -111,6 +116,7 @@ deploy:
           images.dcimFrontend: "{{.IMAGE_FULLY_QUALIFIED_dcim_frontend}}"
           images.dcimAuthnApi: "{{.IMAGE_FULLY_QUALIFIED_dcim_authn_api}}"
           images.pluginProxy: "{{.IMAGE_FULLY_QUALIFIED_plugin_proxy}}"
+          images.marketplaceCatalogApi: "{{.IMAGE_FULLY_QUALIFIED_marketplace_catalog_api}}"
 
 profiles:
   - name: env-local
@@ -234,6 +240,12 @@ profiles:
         value: plugin-proxy/hotreload/Dockerfile
       - op: add
         path: /build/artifacts/13/sync
+        value: {}
+      - op: replace
+        path: /build/artifacts/14/docker/dockerfile
+        value: marketplace-api/hotreload/Dockerfile
+      - op: add
+        path: /build/artifacts/14/sync
         value: {}
 
   # Debug profile: rebuilds kube-api-proxy with dlv (port-forward handled by dev-debug in Justfile)


### PR DESCRIPTION
Stands up fun-marketplace-catalog-api as a deployable unit before it does any work: image, chart, route, hot-reload target and CI. main.go serves /livez, /readyz and /version only — no database connection, so this deploys green ahead of the schema it will eventually read.

db-cluster.yaml creates the fun_marketplace_catalog_api role via CNPG managed roles. That has to land before stack 2/3, whose migration grants to that role and would fail against a cluster where it does not exist yet.

Also adds the CI the service was missing: a build.yml matrix entry for the image, and a test.yml job with the trek and embedded-postgres caches the integration suite in stack 3/3 needs. marketplace-api is excluded from test-other so the suite runs once, in the job that has those caches.