### PR TITLE
fix(authz): resolve the OpenFGA store by name instead of by id

### DIFF
--- a/authn-api/cmd/fun-authn-api/main.go
+++ b/authn-api/cmd/fun-authn-api/main.go
@@ -132,7 +132,7 @@ func run() error {
 
 	logger.Debug("connecting to OpenFGA",
 		"api_url", cfg.OpenFGA.APIURL,
-		"store_id", cfg.OpenFGA.StoreID,
+		"store_name", cfg.OpenFGA.StoreName,
 	)
 
 	authzClient, err := authz.New(cfg.OpenFGA)

--- a/authz-worker/cmd/fun-authz-worker/main.go
+++ b/authz-worker/cmd/fun-authz-worker/main.go
@@ -95,36 +95,20 @@ func run() error {
 
 	logger.Debug("connecting to OpenFGA",
 		"api_url", cfg.OpenFGA.APIURL,
-		"store_id", cfg.OpenFGA.StoreID,
-		"authorization_model_id", cfg.OpenFGA.AuthorizationModelID,
+		"store_name", cfg.OpenFGA.StoreName,
 	)
 
 	fgaClient, err := client.NewSdkClient(&client.ClientConfiguration{
-		ApiUrl:               cfg.OpenFGA.APIURL,
-		StoreId:              cfg.OpenFGA.StoreID,
-		AuthorizationModelId: cfg.OpenFGA.AuthorizationModelID,
+		ApiUrl: cfg.OpenFGA.APIURL,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create OpenFGA client: %w", err)
 	}
 
-	// Validate the store and authorization model exist - this ensures we have valid config
-	store, err := fgaClient.GetStore(ctx).Execute()
-	if err != nil {
-		return fmt.Errorf("failed to validate OpenFGA store: %w", err)
-	}
+	// The store may not exist yet (a reset deletes it before the reseed); Run waits for it.
+	store := authz.NewStoreResolver(fgaClient, cfg.OpenFGA.StoreName)
 
-	model, err := fgaClient.ReadAuthorizationModel(ctx).Execute()
-	if err != nil {
-		return fmt.Errorf("failed to validate OpenFGA authorization model: %w", err)
-	}
-
-	logger.Debug("OpenFGA client connected",
-		"store_name", store.GetName(),
-		"model_id", model.AuthorizationModel.GetId(),
-	)
-
-	w := worker.New(pool, fgaClient, logger, worker.Config{
+	w := worker.New(pool, fgaClient, store, logger, worker.Config{
 		PollInterval: cfg.PollInterval,
 		BatchSize:    cfg.BatchSize,
 		BaseBackoff:  cfg.BaseBackoff,

--- a/authz-worker/pkg/worker/handler/handler.go
+++ b/authz-worker/pkg/worker/handler/handler.go
@@ -14,12 +14,13 @@ import (
 // Handler contains all entity handlers for the authz worker.
 type Handler struct {
 	fga    *client.OpenFgaClient
+	store  *authz.StoreResolver
 	logger *slog.Logger
 }
 
 // New creates a new Handlers instance.
-func New(fga *client.OpenFgaClient, logger *slog.Logger) *Handler {
-	return &Handler{fga: fga, logger: logger}
+func New(fga *client.OpenFgaClient, store *authz.StoreResolver, logger *slog.Logger) *Handler {
+	return &Handler{fga: fga, store: store, logger: logger}
 }
 
 // writeTuplesIfNotExist writes tuples, ignoring errors if the tuples already
@@ -35,7 +36,12 @@ func (h *Handler) writeTuplesIfNotExist(ctx context.Context, tuples ...openfga.T
 			OnDuplicateWrites: client.CLIENT_WRITE_REQUEST_ON_DUPLICATE_WRITES_IGNORE,
 		},
 	}
-	if _, err := h.fga.WriteTuples(ctx).Body(tuples).Options(opts).Execute(); err != nil {
+	if err := h.store.Do(ctx, func(storeID string) error {
+		opts.StoreId = &storeID
+		_, err := h.fga.WriteTuples(ctx).Body(tuples).Options(opts).Execute()
+
+		return err //nolint:wrapcheck // Do inspects the raw SDK error
+	}); err != nil {
 		return fmt.Errorf("write tuples: %w", err)
 	}
 	return nil
@@ -52,7 +58,12 @@ func (h *Handler) deleteTuplesIfExist(ctx context.Context, tuples ...openfga.Tup
 			OnMissingDeletes: client.CLIENT_WRITE_REQUEST_ON_MISSING_DELETES_IGNORE,
 		},
 	}
-	if _, err := h.fga.DeleteTuples(ctx).Body(tuples).Options(opts).Execute(); err != nil {
+	if err := h.store.Do(ctx, func(storeID string) error {
+		opts.StoreId = &storeID
+		_, err := h.fga.DeleteTuples(ctx).Body(tuples).Options(opts).Execute()
+
+		return err //nolint:wrapcheck // Do inspects the raw SDK error
+	}); err != nil {
 		return fmt.Errorf("delete tuples: %w", err)
 	}
 	return nil

--- a/authz-worker/pkg/worker/verify_store_test.go
+++ b/authz-worker/pkg/worker/verify_store_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fundament-oss/fundament/common/authz"
+)
+
+// storeServer serves just enough of the store API for verifyStore.
+type storeServer struct {
+	mu     sync.Mutex
+	stores []openfga.Store
+}
+
+func (s *storeServer) set(stores ...openfga.Store) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stores = stores
+}
+
+func (s *storeServer) resolver(t *testing.T) *authz.StoreResolver {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openfga.ListStoresResponse{Stores: s.stores})
+	}))
+	t.Cleanup(srv.Close)
+
+	fga, err := client.NewSdkClient(&client.ClientConfiguration{ApiUrl: srv.URL})
+	require.NoError(t, err)
+
+	return authz.NewStoreResolver(fga, "fundament")
+}
+
+func newVerifyWorker(t *testing.T, srv *storeServer) *Worker {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	return New(nil, nil, srv.resolver(t), logger, Config{})
+}
+
+func store(id string, created time.Time) openfga.Store {
+	return openfga.Store{Id: id, Name: "fundament", CreatedAt: created, UpdatedAt: created}
+}
+
+func TestVerifyStoreHoldsWhenNoStoreExists(t *testing.T) {
+	err := newVerifyWorker(t, &storeServer{}).verifyStore(t.Context())
+
+	require.ErrorIs(t, err, errStoreUnavailable)
+	require.ErrorIs(t, err, authz.ErrStoreNotFound)
+}
+
+// A reset replaces the store; the worker must hold while none exists, then
+// follow the replacement without a restart.
+func TestVerifyStoreRecoversAgainstAReplacementStore(t *testing.T) {
+	now := time.Now()
+	srv := &storeServer{}
+	srv.set(store("01M0Y00000000000000000000A", now))
+	w := newVerifyWorker(t, srv)
+
+	require.NoError(t, w.verifyStore(t.Context()))
+
+	srv.set()
+	require.ErrorIs(t, w.verifyStore(t.Context()), errStoreUnavailable)
+
+	srv.set(store("01M0Y00000000000000000000B", now.Add(time.Hour)))
+	require.NoError(t, w.verifyStore(t.Context()))
+
+	id, err := w.store.ID(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "01M0Y00000000000000000000B", id, "the next drain must target the replacement")
+}

--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -16,6 +16,7 @@ import (
 
 	db "github.com/fundament-oss/fundament/authz-worker/pkg/db/gen"
 	"github.com/fundament-oss/fundament/authz-worker/pkg/worker/handler"
+	"github.com/fundament-oss/fundament/common/authz"
 	"github.com/fundament-oss/fundament/common/rollback"
 )
 
@@ -50,7 +51,7 @@ type Worker struct {
 	pool    *pgxpool.Pool
 	queries *db.Queries
 	handler *handler.Handler
-	fga     *client.OpenFgaClient
+	store   *authz.StoreResolver
 	logger  *slog.Logger
 	cfg     Config
 	ready   atomic.Bool
@@ -66,7 +67,7 @@ type Worker struct {
 }
 
 // New creates a new authz worker with sensible defaults.
-func New(pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, logger *slog.Logger, cfg Config) *Worker {
+func New(pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, store *authz.StoreResolver, logger *slog.Logger, cfg Config) *Worker {
 	cfg = applyDefaults(cfg)
 
 	hostname, _ := os.Hostname()
@@ -75,8 +76,8 @@ func New(pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, logger *slog.Logge
 	w := &Worker{
 		pool:    pool,
 		queries: db.New(pool),
-		handler: handler.New(fgaClient, logger),
-		fga:     fgaClient,
+		handler: handler.New(fgaClient, store, logger),
+		store:   store,
 		logger:  logger.With("worker_id", workerID),
 		cfg:     cfg,
 	}
@@ -179,14 +180,13 @@ func (w *Worker) runWithConnection(ctx context.Context) error {
 	}
 }
 
-// verifyStore gates a drain on the store existing: OpenFGA's Write does not
-// check store existence, so writes to a wiped store falsely succeed. GetStore
-// bypasses the typesystem cache and sees the wipe.
+// verifyStore gates a drain on the store existing, and picks up its id if a
+// reset replaced it.
 func (w *Worker) verifyStore(ctx context.Context) error {
 	checkCtx, cancel := context.WithTimeout(ctx, storeCheckTimeout)
 	defer cancel()
 
-	if _, err := w.fga.GetStore(checkCtx).Execute(); err != nil {
+	if _, err := w.store.Resolve(checkCtx); err != nil {
 		return fmt.Errorf("%w: %w", errStoreUnavailable, err)
 	}
 

--- a/charts/fundament/templates/_helpers.tpl
+++ b/charts/fundament/templates/_helpers.tpl
@@ -135,9 +135,6 @@ readinessProbe:
 {{- end }}
 
 {{/*
-Name of the OpenFGA store. Consumers resolve it to an id at runtime, because ids
-are server-generated and change whenever the store is replaced.
-
 Usage: include "fundament.openfga.storeName" $
 */}}
 {{- define "fundament.openfga.storeName" -}}

--- a/charts/fundament/templates/_helpers.tpl
+++ b/charts/fundament/templates/_helpers.tpl
@@ -133,3 +133,13 @@ readinessProbe:
   failureThreshold: 60
 {{- end }}
 {{- end }}
+
+{{/*
+Name of the OpenFGA store. Consumers resolve it to an id at runtime, because ids
+are server-generated and change whenever the store is replaced.
+
+Usage: include "fundament.openfga.storeName" $
+*/}}
+{{- define "fundament.openfga.storeName" -}}
+fundament
+{{- end }}

--- a/charts/fundament/templates/authn-api.yaml
+++ b/charts/fundament/templates/authn-api.yaml
@@ -60,17 +60,9 @@ spec:
               value: /etc/gardener/kubeconfig
             {{- end }}
             - name: OPENFGA_API_URL
-              value: http://openfga:{{ $.Values.openfga.apiPort | default 8080 }}
-            - name: OPENFGA_STORE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: store-id
-            - name: OPENFGA_AUTHORIZATION_MODEL_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: authorization-model-id
+              value: http://openfga:{{ $.Values.openfga.apiPort }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ include "fundament.openfga.storeName" $ | quote }}
           {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
           {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
           {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}

--- a/charts/fundament/templates/authz-worker.yaml
+++ b/charts/fundament/templates/authz-worker.yaml
@@ -11,14 +11,9 @@ metadata:
 spec:
   replicas: {{ $.Values.authzWorker.replicas }}
   {{- if $.Values.db.reset }}
-  # Local/dev only (db.reset ⇒ this environment wipes+reseeds and resets OpenFGA
-  # on every deploy). Recreate — not RollingUpdate — so the old pod is torn down
-  # before the new one starts. An overlapping old pod still holds the previous
-  # OpenFGA store/model (resolved from a ConfigMap at pod start) and would write
-  # freshly-seeded outbox rows to the now-deleted store, stranding them and
-  # tripping the consumer's circuit breaker. No overlap, no split-brain; a brief
-  # gap in outbox processing is harmless — rows just queue. Prod keeps the
-  # default RollingUpdate for zero-downtime rollouts.
+    # Recreate, so no old pod overlaps the new one and drains outbox rows into
+    # the store the next release replaces. A brief gap in outbox processing is
+    # harmless: rows queue.
   strategy:
     type: Recreate
   {{- end }}
@@ -51,17 +46,9 @@ spec:
             - name: MAX_RETRIES
               value: {{ $.Values.authzWorker.maxRetries | quote }}
             - name: OPENFGA_API_URL
-              value: http://openfga:{{ $.Values.openfga.apiPort | default 8080 }}
-            - name: OPENFGA_STORE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: store-id
-            - name: OPENFGA_AUTHORIZATION_MODEL_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: authorization-model-id
+              value: http://openfga:{{ $.Values.openfga.apiPort }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ include "fundament.openfga.storeName" $ | quote }}
           {{- include "fundament.livenessProbe" (dict "root" $ "port" "health") | nindent 10 }}
           {{- include "fundament.readinessProbe" (dict "root" $ "port" "health") | nindent 10 }}
 {{- end }}

--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -49,17 +49,9 @@ spec:
               value: /etc/plugin-sandbox/kubeconfig
             {{- end }}
             - name: OPENFGA_API_URL
-              value: http://openfga:{{ $.Values.openfga.apiPort | default 8080 }}
-            - name: OPENFGA_STORE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: store-id
-            - name: OPENFGA_AUTHORIZATION_MODEL_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: authorization-model-id
+              value: http://openfga:{{ $.Values.openfga.apiPort }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ include "fundament.openfga.storeName" $ | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/fundament/templates/organization-api.yaml
+++ b/charts/fundament/templates/organization-api.yaml
@@ -63,17 +63,9 @@ spec:
               value: "true"
             {{- end }}
             - name: OPENFGA_API_URL
-              value: http://openfga:{{ $.Values.openfga.apiPort | default 8080 }}
-            - name: OPENFGA_STORE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: store-id
-            - name: OPENFGA_AUTHORIZATION_MODEL_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: authorization-model-id
+              value: http://openfga:{{ $.Values.openfga.apiPort }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ include "fundament.openfga.storeName" $ | quote }}
             {{- if $.Values.organizationApi.prometheusCASecret }}
             - name: PROMETHEUS_CA_FILE
               value: /etc/prometheus-ca/ca.crt

--- a/charts/fundament/templates/plugin-proxy.yaml
+++ b/charts/fundament/templates/plugin-proxy.yaml
@@ -63,17 +63,9 @@ spec:
               value: /etc/plugin-sandbox/kubeconfig
             {{- end }}
             - name: OPENFGA_API_URL
-              value: http://openfga:{{ $.Values.openfga.apiPort | default 8080 }}
-            - name: OPENFGA_STORE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: store-id
-            - name: OPENFGA_AUTHORIZATION_MODEL_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: openfga-config
-                  key: authorization-model-id
+              value: http://openfga:{{ $.Values.openfga.apiPort }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ include "fundament.openfga.storeName" $ | quote }}
           {{- if or $.Values.pluginProxy.gardenerKubeconfigSecret $.Values.pluginProxy.sandboxKubeconfigSecret }}
           volumeMounts:
             {{- if $.Values.pluginProxy.gardenerKubeconfigSecret }}

--- a/charts/fundament/values.yaml
+++ b/charts/fundament/values.yaml
@@ -57,6 +57,8 @@ db:
   enabled: true
   instances: 1
   storageSize: 1Gi
+  # Wipes and reseeds both the fundament database and the OpenFGA store on every
+  # deploy. Local development and PR previews only.
   reset: false
   insertTestData: false
   exposePort: 0 # Expose postgres on this port via LoadBalancer (0 = disabled)
@@ -204,6 +206,7 @@ authzWorker:
 openfga:
   enabled: true
   image: openfga/openfga:v1.18.0
+  apiPort: 8080
   replicas: 1
   playground:
     enabled: false

--- a/common/authz/client.go
+++ b/common/authz/client.go
@@ -11,30 +11,35 @@ import (
 )
 
 // Config holds configuration for the OpenFGA client.
+//
+// The store is addressed by name: ids are server-generated and change when the
+// store is reset. No authorization model is pinned, so each request evaluates
+// the latest one.
 type Config struct {
-	APIURL               string `env:"OPENFGA_API_URL,required,notEmpty"`
-	StoreID              string `env:"OPENFGA_STORE_ID,required,notEmpty"`
-	AuthorizationModelID string `env:"OPENFGA_AUTHORIZATION_MODEL_ID"`
+	APIURL    string `env:"OPENFGA_API_URL,required,notEmpty"`
+	StoreName string `env:"OPENFGA_STORE_NAME,notEmpty" envDefault:"fundament"`
 }
 
 // Client wraps the OpenFGA SDK client with an AuthZEN-compatible interface.
 // See https://openid.github.io/authzen/ for the AuthZEN specification.
 type Client struct {
-	fga *client.OpenFgaClient
+	fga   *client.OpenFgaClient
+	store *StoreResolver
 }
 
 // New creates a new authorization client.
 func New(cfg Config) (*Client, error) {
 	fgaClient, err := client.NewSdkClient(&client.ClientConfiguration{
-		ApiUrl:               cfg.APIURL,
-		StoreId:              cfg.StoreID,
-		AuthorizationModelId: cfg.AuthorizationModelID,
+		ApiUrl: cfg.APIURL,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create OpenFGA client: %w", err)
 	}
 
-	return &Client{fga: fgaClient}, nil
+	return &Client{
+		fga:   fgaClient,
+		store: NewStoreResolver(fgaClient, cfg.StoreName),
+	}, nil
 }
 
 // CanViewCluster is a convenience wrapper around Evaluate for the frequently
@@ -59,8 +64,7 @@ func (c *Client) CanViewCluster(ctx context.Context, userID, clusterID uuid.UUID
 
 // Healthy checks that the OpenFGA store is reachable.
 func (c *Client) Healthy(ctx context.Context) error {
-	_, err := c.fga.GetStore(ctx).Execute()
-	if err != nil {
+	if _, err := c.store.Resolve(ctx); err != nil {
 		return fmt.Errorf("openfga: %w", err)
 	}
 	return nil
@@ -109,7 +113,17 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationRequest) (Decision,
 		checkReq.Context = &checkContext
 	}
 
-	resp, err := c.fga.Check(ctx).Body(checkReq).Execute()
+	var resp *client.ClientCheckResponse
+
+	err := c.store.Do(ctx, func(storeID string) error {
+		var checkErr error
+		resp, checkErr = c.fga.Check(ctx).
+			Body(checkReq).
+			Options(client.ClientCheckOptions{StoreId: &storeID}).
+			Execute()
+
+		return checkErr //nolint:wrapcheck // Do inspects the raw SDK error
+	})
 	if err != nil {
 		return Decision{Decision: false}, fmt.Errorf("check: %w", err)
 	}

--- a/common/authz/client.go
+++ b/common/authz/client.go
@@ -115,17 +115,20 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationRequest) (Decision,
 
 	var resp *client.ClientCheckResponse
 
-	err := c.store.Do(ctx, func(storeID string) error {
+	if err := c.store.Do(ctx, func(storeID string) error {
 		var checkErr error
+
 		resp, checkErr = c.fga.Check(ctx).
 			Body(checkReq).
 			Options(client.ClientCheckOptions{StoreId: &storeID}).
 			Execute()
+		if checkErr != nil {
+			return fmt.Errorf("check: %w", checkErr)
+		}
 
-		return checkErr //nolint:wrapcheck // Do inspects the raw SDK error
-	})
-	if err != nil {
-		return Decision{Decision: false}, fmt.Errorf("check: %w", err)
+		return nil
+	}); err != nil {
+		return Decision{Decision: false}, err
 	}
 
 	decision := false

--- a/common/authz/client_test.go
+++ b/common/authz/client_test.go
@@ -223,8 +223,8 @@ func TestEvaluations_ValidSemantics(t *testing.T) {
 func TestNew_InvalidConfig(t *testing.T) {
 	// Test that New returns an error for invalid configuration
 	cfg := Config{
-		APIURL:  "", // Empty URL should cause an error
-		StoreID: "",
+		APIURL:    "", // Empty URL should cause an error
+		StoreName: "fundament",
 	}
 
 	_, err := New(cfg)

--- a/common/authz/store.go
+++ b/common/authz/store.go
@@ -1,0 +1,162 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+)
+
+// ErrStoreNotFound reports that no store with the configured name exists.
+var ErrStoreNotFound = errors.New("openfga store not found")
+
+// StoreResolver maps a store name to its id, caching the id and re-resolving
+// when the store stops existing. Ids are server-generated and a reset replaces
+// the store, so the name is the only stable handle.
+type StoreResolver struct {
+	fga  *client.OpenFgaClient
+	name string
+
+	mu     sync.RWMutex
+	cached string
+}
+
+// NewStoreResolver returns a resolver for the store called name.
+func NewStoreResolver(fga *client.OpenFgaClient, name string) *StoreResolver {
+	return &StoreResolver{fga: fga, name: name}
+}
+
+// ID returns the store id, resolving it if nothing is cached yet.
+func (r *StoreResolver) ID(ctx context.Context) (string, error) {
+	r.mu.RLock()
+	id := r.cached
+	r.mu.RUnlock()
+
+	if id != "" {
+		return id, nil
+	}
+
+	return r.Resolve(ctx)
+}
+
+// Resolve looks the store up by name, bypassing the cache, so a store replaced
+// by a reset is noticed.
+func (r *StoreResolver) Resolve(ctx context.Context) (string, error) {
+	// The lookup runs outside the lock: holding it across a round trip would
+	// serialise every concurrent check behind one HTTP call whenever the cache is
+	// empty. Concurrent resolves are harmless — they agree on the same store.
+	var matches []openfga.Store
+
+	// Follow the pages: the name filter is a server-side convenience, and a server
+	// that ignores it puts the store on any page.
+	for token := ""; ; {
+		opts := client.ClientListStoresOptions{Name: &r.name}
+		if token != "" {
+			opts.ContinuationToken = &token
+		}
+
+		resp, err := r.fga.ListStores(ctx).Options(opts).Execute()
+		if err != nil {
+			return "", fmt.Errorf("list openfga stores: %w", err) // keep the cache: a transport failure says nothing about the store
+		}
+
+		for _, store := range resp.GetStores() {
+			// Fail closed: never resolve a mismatched or soft-deleted store.
+			if store.Name == r.name && store.DeletedAt == nil {
+				matches = append(matches, store)
+			}
+		}
+
+		if token = resp.GetContinuationToken(); token == "" {
+			break
+		}
+	}
+
+	if len(matches) == 0 {
+		r.mu.Lock()
+		r.cached = ""
+		r.mu.Unlock()
+
+		return "", fmt.Errorf("%w: %q", ErrStoreNotFound, r.name)
+	}
+
+	// Store names are not unique. Sort so every consumer independently picks the
+	// same store; oldest wins — it is the one already holding tuples.
+	slices.SortFunc(matches, func(a, b openfga.Store) int {
+		if byAge := a.CreatedAt.Compare(b.CreatedAt); byAge != 0 {
+			return byAge
+		}
+
+		return strings.Compare(a.Id, b.Id)
+	})
+
+	if len(matches) > 1 {
+		ids := make([]string, 0, len(matches))
+		for _, match := range matches {
+			ids = append(ids, match.Id)
+		}
+
+		slog.Default().Warn("multiple openfga stores share one name, using the oldest",
+			"name", r.name, "using", matches[0].Id, "found", strings.Join(ids, ","))
+	}
+
+	id := matches[0].Id
+
+	r.mu.Lock()
+	r.cached = id
+	r.mu.Unlock()
+
+	return id, nil
+}
+
+// Do runs op against the resolved store, re-resolving and retrying once if the
+// store turned out to be gone.
+func (r *StoreResolver) Do(ctx context.Context, op func(storeID string) error) error {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err = op(id); !storeGone(err) {
+		return err
+	}
+
+	gone := id
+
+	if id, err = r.Resolve(ctx); err != nil {
+		slog.Default().Error("openfga store is gone and no replacement resolved",
+			"name", r.name, "gone", gone, "error", err)
+
+		return err
+	}
+
+	// The one visible sign that a reset happened: without it a store swap is
+	// silent, and a consumer that failed to follow one looks identical to a
+	// consumer that never had a store.
+	slog.Default().Info("openfga store was replaced, following the new one",
+		"name", r.name, "was", gone, "now", id)
+
+	return op(id)
+}
+
+// storeGone reports whether err says the store id itself is unknown. OpenFGA
+// returns 404 for a missing authorization model too, and re-resolving would not
+// help there, so match on the response code rather than the status.
+func storeGone(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var notFound openfga.FgaApiNotFoundError
+	if !errors.As(err, &notFound) {
+		return false
+	}
+
+	return notFound.ResponseCode() == openfga.NOTFOUNDERRORCODE_STORE_ID_NOT_FOUND
+}

--- a/common/authz/store_test.go
+++ b/common/authz/store_test.go
@@ -1,0 +1,539 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Store ids must be well-formed ULIDs: the SDK rejects anything else before it
+// reaches the wire.
+const (
+	storeOldest = "01JMZ0000000000000000000AA"
+	storeNewer  = "01JMZ0000000000000000000BB"
+	storeOther  = "01JMZ0000000000000000000CC"
+)
+
+func store(id, name string, created time.Time) openfga.Store {
+	return openfga.Store{Id: id, Name: name, CreatedAt: created, UpdatedAt: created}
+}
+
+func deletedStore(id, name string, created time.Time) openfga.Store {
+	s := store(id, name, created)
+	at := created.Add(time.Minute)
+	s.DeletedAt = &at
+
+	return s
+}
+
+// fgaServer is a minimal stand-in for the store endpoints. The SDK retries a 404
+// several times internally, so check responses key on the store id in the path.
+type fgaServer struct {
+	mu     sync.Mutex
+	stores []openfga.Store
+	status map[string]int
+	// ignoreNameFilter models an older server that does not honour ?name=.
+	ignoreNameFilter bool
+	// pageSize splits the response across pages; 0 returns everything at once.
+	pageSize int
+
+	listCalls atomic.Int32
+}
+
+func (s *fgaServer) setStores(stores ...openfga.Store) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stores = stores
+}
+
+func (s *fgaServer) markGone(ids ...string) {
+	s.setStatus(http.StatusNotFound, ids...)
+}
+
+func (s *fgaServer) setStatus(code int, ids ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.status == nil {
+		s.status = map[string]int{}
+	}
+
+	for _, id := range ids {
+		s.status[id] = code
+	}
+}
+
+func (s *fgaServer) start(t *testing.T) *client.OpenFgaClient {
+	t.Helper()
+
+	fga, err := client.NewSdkClient(&client.ClientConfiguration{ApiUrl: s.url(t)})
+	require.NoError(t, err)
+
+	return fga
+}
+
+func (s *fgaServer) url(t *testing.T) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if id, ok := strings.CutSuffix(strings.TrimPrefix(r.URL.Path, "/stores/"), "/check"); ok {
+			s.mu.Lock()
+			code := s.status[id]
+			s.mu.Unlock()
+
+			switch code {
+			case 0, http.StatusOK:
+				_, _ = w.Write([]byte(`{"allowed":true}`))
+			case http.StatusNotFound:
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"code":"store_id_not_found","message":"store not found"}`))
+			default:
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"code":"internal_error","message":"boom"}`))
+			}
+
+			return
+		}
+
+		s.listCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(s.list(r))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+// list applies the name filter the way the real API does.
+func (s *fgaServer) list(r *http.Request) openfga.ListStoresResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	matching := []openfga.Store{}
+
+	for _, st := range s.stores {
+		if name := r.URL.Query().Get("name"); s.ignoreNameFilter || name == "" || st.Name == name {
+			matching = append(matching, st)
+		}
+	}
+
+	if s.pageSize <= 0 {
+		return openfga.ListStoresResponse{Stores: matching}
+	}
+
+	from, _ := strconv.Atoi(r.URL.Query().Get("continuation_token"))
+	to := min(from+s.pageSize, len(matching))
+
+	resp := openfga.ListStoresResponse{Stores: matching[from:to]}
+	if to < len(matching) {
+		resp.ContinuationToken = strconv.Itoa(to)
+	}
+
+	return resp
+}
+
+func newResolver(t *testing.T, srv *fgaServer) (*StoreResolver, *client.OpenFgaClient) {
+	t.Helper()
+	fga := srv.start(t)
+
+	return NewStoreResolver(fga, "fundament"), fga
+}
+
+func TestResolveNoStoreWithThatName(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOther, "something-else", time.Now())}}
+	r, _ := newResolver(t, srv)
+
+	_, err := r.Resolve(t.Context())
+
+	require.ErrorIs(t, err, ErrStoreNotFound)
+	assert.Contains(t, err.Error(), `"fundament"`)
+}
+
+func TestResolveEmptyStoreList(t *testing.T) {
+	r, _ := newResolver(t, &fgaServer{})
+
+	_, err := r.Resolve(t.Context())
+
+	require.ErrorIs(t, err, ErrStoreNotFound)
+}
+
+func TestResolveSkipsSoftDeletedStore(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{deletedStore(storeOldest, "fundament", time.Now())}}
+	r, _ := newResolver(t, srv)
+
+	_, err := r.Resolve(t.Context())
+
+	require.ErrorIs(t, err, ErrStoreNotFound, "a store deleted by a reset must never resolve")
+}
+
+func TestResolveSkipsSoftDeletedStoreAndTakesTheLiveOne(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{
+		deletedStore(storeOldest, "fundament", now),
+		store(storeNewer, "fundament", now.Add(time.Hour)),
+	}}
+	r, _ := newResolver(t, srv)
+
+	got, err := r.Resolve(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, storeNewer, got, "age must not outrank being alive")
+}
+
+func TestResolveDuplicateNamesPicksOldestDeterministically(t *testing.T) {
+	now := time.Now()
+	// Newest first, so first-match-wins would pick the wrong one.
+	srv := &fgaServer{stores: []openfga.Store{
+		store(storeNewer, "fundament", now.Add(time.Hour)),
+		store(storeOldest, "fundament", now),
+	}}
+	r, _ := newResolver(t, srv)
+
+	first, err := r.Resolve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, first)
+
+	second, err := r.Resolve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "every consumer must independently pick the same store")
+}
+
+func TestResolveDuplicateNamesTieBreakOnID(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{
+		store(storeNewer, "fundament", now),
+		store(storeOldest, "fundament", now),
+	}}
+	r, _ := newResolver(t, srv)
+
+	got, err := r.Resolve(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, got)
+}
+
+func TestIDCachesAndResolveBypassesTheCache(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	r, _ := newResolver(t, srv)
+
+	first, err := r.ID(t.Context())
+	require.NoError(t, err)
+	second, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Equal(t, int32(1), srv.listCalls.Load(), "a cached id must not cost a request")
+
+	_, err = r.Resolve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), srv.listCalls.Load())
+}
+
+func TestStaleIDDoesNotSurviveTheStoreItNames(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	r, _ := newResolver(t, srv)
+
+	_, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	srv.setStores() // the reset deleted it
+
+	_, err = r.Resolve(t.Context())
+	require.ErrorIs(t, err, ErrStoreNotFound)
+
+	_, err = r.ID(t.Context())
+	require.ErrorIs(t, err, ErrStoreNotFound)
+}
+
+func TestUnreachableServerKeepsTheCachedID(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	fga := srv.start(t)
+	r := NewStoreResolver(fga, "fundament")
+
+	_, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	// A cancelled context stands in for an unreachable server.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = r.Resolve(ctx)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrStoreNotFound, "a transport failure is not evidence the store is gone")
+
+	got, err := r.ID(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, got, "the cache must survive a blip")
+}
+
+// check drives a real SDK call so the retry path sees a genuine SDK error.
+func check(fga *client.OpenFgaClient, storeID string) error {
+	_, err := fga.Check(context.Background()).
+		Body(client.ClientCheckRequest{User: "user:a", Relation: "can_view", Object: "organization:b"}).
+		Options(client.ClientCheckOptions{StoreId: &storeID}).
+		Execute()
+
+	return err //nolint:wrapcheck // the resolver must see the raw SDK error
+}
+
+func TestDoRetriesOnceAgainstTheReplacementStore(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", now)}}
+	r, fga := newResolver(t, srv)
+
+	_, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	// A reset: the old store is gone, a new one has taken the name.
+	srv.setStores(store(storeNewer, "fundament", now.Add(time.Hour)))
+	srv.markGone(storeOldest)
+
+	var used []string
+
+	err = r.Do(t.Context(), func(storeID string) error {
+		used = append(used, storeID)
+
+		return check(fga, storeID)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{storeOldest, storeNewer}, used, "the retry must run against the new store")
+}
+
+func TestDoRetriesOnlyOnce(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", now)}}
+	r, fga := newResolver(t, srv)
+
+	_, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	srv.setStores(store(storeNewer, "fundament", now.Add(time.Hour)))
+	srv.markGone(storeOldest, storeNewer)
+
+	attempts := 0
+	err = r.Do(t.Context(), func(storeID string) error {
+		attempts++
+
+		return check(fga, storeID)
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 2, attempts)
+}
+
+func TestDoSurfacesNotFoundWhenTheStoreIsGoneForGood(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	r, fga := newResolver(t, srv)
+
+	_, err := r.ID(t.Context())
+	require.NoError(t, err)
+
+	srv.setStores()
+	srv.markGone(storeOldest)
+
+	err = r.Do(t.Context(), func(storeID string) error { return check(fga, storeID) })
+
+	require.ErrorIs(t, err, ErrStoreNotFound)
+}
+
+func TestResolveMatchesByNameWhenServerIgnoresTheFilter(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{
+		ignoreNameFilter: true,
+		stores: []openfga.Store{
+			store(storeOther, "something-else", now.Add(-time.Hour)),
+			store(storeOldest, "fundament", now),
+		},
+	}
+	r, _ := newResolver(t, srv)
+
+	got, err := r.Resolve(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, got, "an unrelated store must never be picked up")
+}
+
+func TestConcurrentResolversAgreeOnOneStore(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{
+		store(storeNewer, "fundament", now.Add(time.Hour)),
+		store(storeOldest, "fundament", now),
+	}}
+	r, _ := newResolver(t, srv)
+
+	const goroutines = 32
+
+	var (
+		wg  sync.WaitGroup
+		ids = make([]string, goroutines)
+	)
+
+	for i := range goroutines {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			id, err := r.ID(t.Context())
+			assert.NoError(t, err)
+			ids[i] = id
+		}()
+	}
+
+	wg.Wait()
+
+	for i, id := range ids {
+		assert.Equal(t, storeOldest, id, "goroutine %d disagreed", i)
+	}
+}
+
+func TestDoSucceedsWithoutRetrying(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	r, fga := newResolver(t, srv)
+
+	attempts := 0
+	err := r.Do(t.Context(), func(storeID string) error {
+		attempts++
+
+		return check(fga, storeID)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, int32(1), srv.listCalls.Load(), "a healthy call must not re-resolve")
+}
+
+func TestDoDoesNotRetryOnErrorsThatAreNotAMissingStore(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	r, fga := newResolver(t, srv)
+	srv.setStatus(http.StatusInternalServerError, storeOldest)
+
+	attempts := 0
+	err := r.Do(t.Context(), func(storeID string) error {
+		attempts++
+
+		return check(fga, storeID)
+	})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrStoreNotFound)
+	assert.Equal(t, 1, attempts, "a failing store is not a replaced store")
+}
+
+func TestClientHealthyReportsAMissingStore(t *testing.T) {
+	srv := &fgaServer{}
+	c, err := New(Config{APIURL: srv.url(t), StoreName: "fundament"})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, c.Healthy(t.Context()), ErrStoreNotFound)
+}
+
+func TestClientHealthyNoticesAReplacedStore(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", now)}}
+	c, err := New(Config{APIURL: srv.url(t), StoreName: "fundament"})
+	require.NoError(t, err)
+	require.NoError(t, c.Healthy(t.Context()))
+
+	srv.setStores()
+	require.ErrorIs(t, c.Healthy(t.Context()), ErrStoreNotFound, "readiness is what notices the swap")
+
+	srv.setStores(store(storeNewer, "fundament", now.Add(time.Hour)))
+	require.NoError(t, c.Healthy(t.Context()))
+
+	id, err := c.store.ID(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, storeNewer, id)
+}
+
+func TestClientEvaluateFollowsAReplacedStore(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", now)}}
+	c, err := New(Config{APIURL: srv.url(t), StoreName: "fundament"})
+	require.NoError(t, err)
+
+	_, err = c.store.ID(t.Context())
+	require.NoError(t, err)
+
+	srv.setStores(store(storeNewer, "fundament", now.Add(time.Hour)))
+	srv.markGone(storeOldest)
+
+	dec, err := c.Evaluate(t.Context(), EvaluationRequest{
+		Subject:  User(uuid.New()),
+		Action:   CanView(),
+		Resource: Cluster(uuid.New()),
+	})
+
+	require.NoError(t, err, "a check must survive a reset without a restart")
+	assert.True(t, dec.Decision)
+}
+
+func TestClientEvaluateDeniesWhenNoStoreExists(t *testing.T) {
+	c, err := New(Config{APIURL: (&fgaServer{}).url(t), StoreName: "fundament"})
+	require.NoError(t, err)
+
+	dec, err := c.Evaluate(t.Context(), EvaluationRequest{
+		Subject:  User(uuid.New()),
+		Action:   CanView(),
+		Resource: Cluster(uuid.New()),
+	})
+
+	require.ErrorIs(t, err, ErrStoreNotFound)
+	assert.False(t, dec.Decision, "a missing store must deny, never allow")
+}
+
+func TestResolveFollowsPagination(t *testing.T) {
+	now := time.Now()
+	// The match sits on the last page, and the pages arrive newest-first, so a
+	// resolver reading only the first page would both miss it and, once it read
+	// far enough, pick the wrong one.
+	srv := &fgaServer{
+		pageSize: 1,
+		stores: []openfga.Store{
+			store(storeOther, "something-else", now),
+			store(storeNewer, "fundament", now),
+			store(storeOldest, "fundament", now.Add(-time.Hour)),
+		},
+	}
+	r, _ := newResolver(t, srv)
+
+	id, err := r.Resolve(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, id)
+	assert.Equal(t, int32(2), srv.listCalls.Load()) // two matches, one per page
+}
+
+func TestResolveFollowsPaginationWhenServerIgnoresNameFilter(t *testing.T) {
+	now := time.Now()
+	srv := &fgaServer{
+		pageSize:         1,
+		ignoreNameFilter: true,
+		stores: []openfga.Store{
+			store(storeOther, "something-else", now.Add(-2*time.Hour)),
+			deletedStore(storeNewer, "fundament", now.Add(-3*time.Hour)),
+			store(storeOldest, "fundament", now),
+		},
+	}
+	r, _ := newResolver(t, srv)
+
+	id, err := r.Resolve(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, storeOldest, id)
+}

--- a/kube-api-proxy/README.md
+++ b/kube-api-proxy/README.md
@@ -40,8 +40,7 @@ kubectl ──(JWT)──> kube-api-proxy ──(SA token)──> shoot API serv
 | `LOG_LEVEL` | no | `info` | Log level (debug, info, warn, error) |
 | `CORS_ALLOWED_ORIGINS` | no | | Comma-separated allowed origins |
 | `OPENFGA_API_URL` | yes | | OpenFGA API endpoint |
-| `OPENFGA_STORE_ID` | yes | | OpenFGA store ID |
-| `OPENFGA_AUTHORIZATION_MODEL_ID` | yes | | OpenFGA authorization model ID |
+| `OPENFGA_STORE_NAME` | no | `fundament` | OpenFGA store name, resolved to an id at runtime |
 
 ## Caching
 

--- a/organization-api/cmd/fun-organization-api/main.go
+++ b/organization-api/cmd/fun-organization-api/main.go
@@ -95,7 +95,7 @@ func run() error {
 
 	logger.Debug("connecting to OpenFGA",
 		"api_url", cfg.OpenFGA.APIURL,
-		"store_id", cfg.OpenFGA.StoreID,
+		"store_name", cfg.OpenFGA.StoreName,
 	)
 
 	authzClient, err := authz.New(cfg.OpenFGA)

--- a/plugin-proxy/pkg/config/config_test.go
+++ b/plugin-proxy/pkg/config/config_test.go
@@ -10,7 +10,7 @@ import (
 func TestFromEnv_MockModeDefaultsOrigins(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "mock")
 	t.Setenv("PLUGIN_SDK_DIR", t.TempDir())
 	// Explicitly clear origin envs so we test the default behavior.
@@ -29,7 +29,7 @@ func TestFromEnv_MockModeDefaultsOrigins(t *testing.T) {
 func TestFromEnv_MockModePreservesOrigins(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "mock")
 	t.Setenv("PLUGIN_SDK_DIR", t.TempDir())
 	t.Setenv("PLUGIN_PROXY_ORIGIN", "https://pp.example")
@@ -78,7 +78,7 @@ func TestFromEnv_RealModeRequiresAllOrigins(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("JWT_SECRET", "test-secret")
 			t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-			t.Setenv("OPENFGA_STORE_ID", "test-store")
+			t.Setenv("OPENFGA_STORE_NAME", "test-store")
 			t.Setenv("PLUGIN_PROXY_MODE", "real")
 			tc.setup(t)
 
@@ -92,7 +92,7 @@ func TestFromEnv_RealModeRequiresAllOrigins(t *testing.T) {
 func TestFromEnv_RealModeWithAllOriginsSucceeds(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "real")
 	t.Setenv("PLUGIN_PROXY_ORIGIN", "https://pp.example")
 	t.Setenv("KUBE_API_PROXY_ORIGIN", "https://kap.example")
@@ -109,7 +109,7 @@ func TestFromEnv_RealModeWithAllOriginsSucceeds(t *testing.T) {
 func TestFromEnv_RealModeRequiresGardenerKubeconfig(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "real")
 	t.Setenv("PLUGIN_PROXY_ORIGIN", "https://pp.example")
 	t.Setenv("KUBE_API_PROXY_ORIGIN", "https://kap.example")
@@ -124,7 +124,7 @@ func TestFromEnv_RealModeRequiresGardenerKubeconfig(t *testing.T) {
 func TestFromEnv_UnknownModeErrors(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "weird")
 
 	_, err := FromEnv()
@@ -135,7 +135,7 @@ func TestFromEnv_UnknownModeErrors(t *testing.T) {
 func TestFromEnv_MissingJWTSecretErrors(t *testing.T) {
 	t.Setenv("JWT_SECRET", "")
 	t.Setenv("OPENFGA_API_URL", "http://openfga:8080")
-	t.Setenv("OPENFGA_STORE_ID", "test-store")
+	t.Setenv("OPENFGA_STORE_NAME", "test-store")
 	t.Setenv("PLUGIN_PROXY_MODE", "mock")
 
 	_, err := FromEnv()


### PR DESCRIPTION
Environments with `db.reset` came up with an empty OpenFGA store after a redeploy —
every permission check false, every pod healthy — because consumers held a store id
that a reset had replaced. Address the store by name, which is stable.

## What changed

- `common/authz` resolves the store name to an id and caches it. authz-worker
  re-resolves before every drain, so it follows a replaced store without a restart.
- The authorization model id is dropped rather than pinned: model ids rotate on every
  write and went stale the same way. An unset id evaluates the latest model.
- Removes `openfga-config`, its `kubectl patch`, the configmaps RBAC and six
  `configMapKeyRef` pairs.

Store ids cannot be chosen — `CreateStoreRequest` takes only a `Name` — and there is
no call to empty a store, only delete-and-recreate, which changes the id. So the id
was discovered at runtime and frozen into pod environments by `configMapKeyRef`,
which resolves once at pod start. Only Stakater Reloader rebound them, and that is
installed in local k3d alone; PR previews had nothing.

Two decisions worth a look:

- Store names are not unique, so resolution takes the **oldest live** store. Every
  consumer then independently picks the same one; disagreement would let some checks
  pass and others fail against different tuples.
- **The read path does not yet follow a replaced store.** It re-resolves only when a
  call reports `store_id_not_found`, and a reset never produces that: dropping the
  schema takes the store row, but Check resolves the model first, so v1.18.0 answers
  HTTP 400 `latest_authorization_model_not_found`. This is no worse than master, where
  a frozen id from the ConfigMap never recovered either — but it is not complete.

  Rather than harden the classification, PR 2 has the provisioner publish
  `{generation, store, id}` and has consumers read the id from there. That removes the
  derivation and the error-matching together, and stops the same
  pagination/oldest-wins/deleted-filter logic existing both here and in the
  provisioner.

This also fixes a production bug unrelated to resets: a model update patched a
ConfigMap that nothing without Reloader ever re-read.

## Verification

`go test ./common/authz/...` — covers a missing store, an empty list, a soft-deleted
store, duplicate names (oldest wins, id tie-break), pagination including a server that
ignores the name filter, 32-goroutine concurrent resolution, cache retained on
transport failure, retry-once, and non-404 errors not retried.

Deployed on a k3d cluster: `helm template` renders against all four values files,
all deployments ready, migrations succeeded, one live store with 30 tuples, login OK.

## Breaking change

`OPENFGA_STORE_ID` and `OPENFGA_AUTHORIZATION_MODEL_ID` are replaced by
`OPENFGA_STORE_NAME` (default `fundament`).
