### PR TITLE
feat(authz): pin the authorization model consumers evaluate

### DIFF
--- a/authz-worker/cmd/fun-authz-worker/main.go
+++ b/authz-worker/cmd/fun-authz-worker/main.go
@@ -111,7 +111,11 @@ func run() error {
 	// The gate that keeps seeded rows out of a store this release is replacing.
 	status := authz.NewStatusClient(cfg.OpenFGA.StatusURL)
 
-	w := worker.New(pool, fgaClient, store, status, logger, worker.Config{
+	// Writes are validated against a model too, so the worker pins the same one
+	// consumers evaluate against.
+	model := authz.NewModelPin(cfg.OpenFGA.StatusURL)
+
+	w := worker.New(pool, fgaClient, store, status, model, logger, worker.Config{
 		Generation:   cfg.OpenFGA.Generation,
 		PollInterval: cfg.PollInterval,
 		BatchSize:    cfg.BatchSize,

--- a/authz-worker/pkg/worker/handler/handler.go
+++ b/authz-worker/pkg/worker/handler/handler.go
@@ -15,12 +15,15 @@ import (
 type Handler struct {
 	fga    *client.OpenFgaClient
 	store  *authz.StoreResolver
+	model  *authz.ModelPin
 	logger *slog.Logger
 }
 
 // New creates a new Handlers instance.
-func New(fga *client.OpenFgaClient, store *authz.StoreResolver, logger *slog.Logger) *Handler {
-	return &Handler{fga: fga, store: store, logger: logger}
+func New(
+	fga *client.OpenFgaClient, store *authz.StoreResolver, model *authz.ModelPin, logger *slog.Logger,
+) *Handler {
+	return &Handler{fga: fga, store: store, model: model, logger: logger}
 }
 
 // writeTuplesIfNotExist writes tuples, ignoring errors if the tuples already
@@ -38,6 +41,10 @@ func (h *Handler) writeTuplesIfNotExist(ctx context.Context, tuples ...openfga.T
 	}
 	if err := h.store.Do(ctx, func(storeID string) error {
 		opts.StoreId = &storeID
+		if err := h.pin(ctx, storeID, &opts); err != nil {
+			return err
+		}
+
 		_, err := h.fga.WriteTuples(ctx).Body(tuples).Options(opts).Execute()
 
 		return err //nolint:wrapcheck // Do inspects the raw SDK error
@@ -60,6 +67,10 @@ func (h *Handler) deleteTuplesIfExist(ctx context.Context, tuples ...openfga.Tup
 	}
 	if err := h.store.Do(ctx, func(storeID string) error {
 		opts.StoreId = &storeID
+		if err := h.pin(ctx, storeID, &opts); err != nil {
+			return err
+		}
+
 		_, err := h.fga.DeleteTuples(ctx).Body(tuples).Options(opts).Execute()
 
 		return err //nolint:wrapcheck // Do inspects the raw SDK error
@@ -83,4 +94,21 @@ func tupleDelete(subject authz.Object, relation authz.ActionName, object authz.O
 		Relation: string(relation),
 		Object:   object.String(),
 	}
+}
+
+// pin selects the authorization model tuples are validated against. Writes are
+// checked against a model like any other request, so an unpinned write is
+// validated by whatever model is latest: one that drops a type rejects every
+// tuple of that type, and those rows exhaust their retries and go to failed.
+func (h *Handler) pin(ctx context.Context, storeID string, opts *client.ClientWriteOptions) error {
+	modelID, err := h.model.ID(ctx, storeID)
+	if err != nil {
+		return fmt.Errorf("resolve authorization model: %w", err)
+	}
+
+	if modelID != "" {
+		opts.AuthorizationModelId = &modelID
+	}
+
+	return nil
 }

--- a/authz-worker/pkg/worker/verify_store_test.go
+++ b/authz-worker/pkg/worker/verify_store_test.go
@@ -52,7 +52,7 @@ func newVerifyWorker(t *testing.T, srv *storeServer) *Worker {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	return New(nil, nil, srv.resolver(t), nil, logger, Config{})
+	return New(nil, nil, srv.resolver(t), nil, nil, logger, Config{})
 }
 
 // statusServer stands in for the provision sidecar's status endpoint.
@@ -74,7 +74,7 @@ func newGatedWorker(t *testing.T, srv *storeServer, release, served string) *Wor
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	return New(nil, nil, srv.resolver(t), statusServer(t, served), logger,
+	return New(nil, nil, srv.resolver(t), statusServer(t, served), nil, logger,
 		Config{Generation: release})
 }
 

--- a/authz-worker/pkg/worker/worker.go
+++ b/authz-worker/pkg/worker/worker.go
@@ -57,6 +57,7 @@ type Worker struct {
 	handler *handler.Handler
 	store   *authz.StoreResolver
 	status  *authz.StatusClient
+	model   *authz.ModelPin
 	logger  *slog.Logger
 	cfg     Config
 	ready   atomic.Bool
@@ -74,7 +75,7 @@ type Worker struct {
 // New creates a new authz worker with sensible defaults.
 func New(
 	pool *pgxpool.Pool, fgaClient *client.OpenFgaClient, store *authz.StoreResolver,
-	status *authz.StatusClient, logger *slog.Logger, cfg Config,
+	status *authz.StatusClient, model *authz.ModelPin, logger *slog.Logger, cfg Config,
 ) *Worker {
 	cfg = applyDefaults(cfg)
 
@@ -84,9 +85,10 @@ func New(
 	w := &Worker{
 		pool:    pool,
 		queries: db.New(pool),
-		handler: handler.New(fgaClient, store, logger),
+		handler: handler.New(fgaClient, store, model, logger),
 		store:   store,
 		status:  status,
+		model:   model,
 		logger:  logger.With("worker_id", workerID),
 		cfg:     cfg,
 	}

--- a/charts/fundament/templates/authn-api.yaml
+++ b/charts/fundament/templates/authn-api.yaml
@@ -63,6 +63,8 @@ spec:
               value: http://openfga:{{ $.Values.openfga.apiPort }}
             - name: OPENFGA_STORE_NAME
               value: {{ include "fundament.openfga.storeName" $ | quote }}
+            - name: OPENFGA_STATUS_URL
+              value: http://openfga:{{ $.Values.openfga.statusPort }}/status.json
           {{- include "fundament.livenessProbe" (dict "root" $ "port" "http") | nindent 10 }}
           {{- include "fundament.readinessProbe" (dict "root" $ "port" "http") | nindent 10 }}
           {{- if $.Values.clusterWorker.gardenerKubeconfigSecret }}

--- a/charts/fundament/templates/kube-api-proxy.yaml
+++ b/charts/fundament/templates/kube-api-proxy.yaml
@@ -52,6 +52,8 @@ spec:
               value: http://openfga:{{ $.Values.openfga.apiPort }}
             - name: OPENFGA_STORE_NAME
               value: {{ include "fundament.openfga.storeName" $ | quote }}
+            - name: OPENFGA_STATUS_URL
+              value: http://openfga:{{ $.Values.openfga.statusPort }}/status.json
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/fundament/templates/organization-api.yaml
+++ b/charts/fundament/templates/organization-api.yaml
@@ -66,6 +66,8 @@ spec:
               value: http://openfga:{{ $.Values.openfga.apiPort }}
             - name: OPENFGA_STORE_NAME
               value: {{ include "fundament.openfga.storeName" $ | quote }}
+            - name: OPENFGA_STATUS_URL
+              value: http://openfga:{{ $.Values.openfga.statusPort }}/status.json
             {{- if $.Values.organizationApi.prometheusCASecret }}
             - name: PROMETHEUS_CA_FILE
               value: /etc/prometheus-ca/ca.crt

--- a/charts/fundament/templates/plugin-proxy.yaml
+++ b/charts/fundament/templates/plugin-proxy.yaml
@@ -66,6 +66,8 @@ spec:
               value: http://openfga:{{ $.Values.openfga.apiPort }}
             - name: OPENFGA_STORE_NAME
               value: {{ include "fundament.openfga.storeName" $ | quote }}
+            - name: OPENFGA_STATUS_URL
+              value: http://openfga:{{ $.Values.openfga.statusPort }}/status.json
           {{- if or $.Values.pluginProxy.gardenerKubeconfigSecret $.Values.pluginProxy.sandboxKubeconfigSecret }}
           volumeMounts:
             {{- if $.Values.pluginProxy.gardenerKubeconfigSecret }}

--- a/common/authz/client.go
+++ b/common/authz/client.go
@@ -30,6 +30,7 @@ type Config struct {
 type Client struct {
 	fga   *client.OpenFgaClient
 	store *StoreResolver
+	model *ModelPin
 }
 
 // New creates a new authorization client.
@@ -44,6 +45,7 @@ func New(cfg Config) (*Client, error) {
 	return &Client{
 		fga:   fgaClient,
 		store: NewStoreResolver(fgaClient, cfg.StoreName),
+		model: NewModelPin(cfg.StatusURL),
 	}, nil
 }
 
@@ -121,11 +123,18 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationRequest) (Decision,
 	var resp *client.ClientCheckResponse
 
 	err := c.store.Do(ctx, func(storeID string) error {
+		modelID, modelErr := c.model.ID(ctx, storeID)
+		if modelErr != nil {
+			return modelErr
+		}
+
+		opts := client.ClientCheckOptions{StoreId: &storeID}
+		if modelID != "" {
+			opts.AuthorizationModelId = &modelID
+		}
+
 		var checkErr error
-		resp, checkErr = c.fga.Check(ctx).
-			Body(checkReq).
-			Options(client.ClientCheckOptions{StoreId: &storeID}).
-			Execute()
+		resp, checkErr = c.fga.Check(ctx).Body(checkReq).Options(opts).Execute()
 
 		return checkErr //nolint:wrapcheck // Do inspects the raw SDK error
 	})

--- a/common/authz/model.go
+++ b/common/authz/model.go
@@ -1,0 +1,80 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// ModelPin resolves the authorization model to evaluate against, as reported by
+// the provisioner that put it in force.
+//
+// OpenFGA evaluates the latest model when a request pins none, so any successful
+// WriteAuthorizationModel silently becomes the rules every service enforces. The
+// provisioner ships the model inside its own image and publishes the id it wrote,
+// so pinning that id means a model written by anything else does not take effect
+// merely by being newer.
+type ModelPin struct {
+	status *StatusClient
+
+	mu     sync.RWMutex
+	cached string
+	store  string
+}
+
+// NewModelPin returns a pin reading the provisioner's status document. A pin with
+// no status URL resolves to the empty id, which evaluates against the latest model.
+func NewModelPin(statusURL string) *ModelPin {
+	return &ModelPin{status: NewStatusClient(statusURL)}
+}
+
+// ID returns the model id to evaluate against for the given store, fetching it
+// once and reusing it until the store changes.
+func (p *ModelPin) ID(ctx context.Context, storeID string) (string, error) {
+	if p == nil || p.status == nil || p.status.url == "" {
+		return "", nil
+	}
+
+	p.mu.RLock()
+	cached, forStore := p.cached, p.store
+	p.mu.RUnlock()
+
+	if cached != "" && forStore == storeID {
+		return cached, nil
+	}
+
+	status, err := p.fetch(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// The published model belongs to the published store. Pinning it against a
+	// different store would name a model that store never had, so a consumer that
+	// has already moved on waits for the provisioner to catch up instead.
+	if status.StoreID != storeID {
+		return "", fmt.Errorf("%w: provisioner reports store %q, resolved %q",
+			ErrModelUnknown, status.StoreID, storeID)
+	}
+
+	if status.ModelID == "" {
+		return "", fmt.Errorf("%w: provisioner published no model id", ErrModelUnknown)
+	}
+
+	p.mu.Lock()
+	p.cached, p.store = status.ModelID, status.StoreID
+	p.mu.Unlock()
+
+	return status.ModelID, nil
+}
+
+// fetch reads the status document, reporting any failure as ErrModelUnknown:
+// to a caller deciding which model to evaluate against, an unreachable or
+// unreadable provisioner and one publishing nothing are the same answer.
+func (p *ModelPin) fetch(ctx context.Context) (ProvisionStatus, error) {
+	status, err := p.status.Status(ctx)
+	if err != nil {
+		return ProvisionStatus{}, fmt.Errorf("%w: %w", ErrModelUnknown, err)
+	}
+
+	return status, nil
+}

--- a/common/authz/model_test.go
+++ b/common/authz/model_test.go
@@ -1,0 +1,182 @@
+package authz
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	openfga "github.com/openfga/go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusServer stands in for the provision sidecar's status endpoint.
+type statusServer struct {
+	body  atomic.Value // string
+	code  atomic.Int32
+	calls atomic.Int32
+}
+
+// Model ids are ULIDs; the SDK rejects anything else before it reaches the wire.
+const (
+	modelOne = "01JMZ0000000000000000000M1"
+	modelTwo = "01JMZ0000000000000000000M2"
+)
+
+func newStatusServer(t *testing.T, storeID, modelID string) (*statusServer, string) {
+	t.Helper()
+
+	s := &statusServer{}
+	s.set(storeID, modelID)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		s.calls.Add(1)
+
+		if code := s.code.Load(); code != 0 {
+			w.WriteHeader(int(code))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(s.body.Load().(string)))
+	}))
+	t.Cleanup(srv.Close)
+
+	return s, srv.URL + "/status.json"
+}
+
+func (s *statusServer) set(storeID, modelID string) {
+	s.body.Store(fmt.Sprintf(`{"generation":"1","store":"fundament","id":%q,"model_id":%q}`, storeID, modelID))
+}
+
+func TestModelPinUsesThePublishedModel(t *testing.T) {
+	_, url := newStatusServer(t, storeOldest, modelOne)
+	pin := NewModelPin(url)
+
+	id, err := pin.ID(t.Context(), storeOldest)
+
+	require.NoError(t, err)
+	assert.Equal(t, modelOne, id)
+}
+
+// Without a status URL the pin is inert and OpenFGA evaluates the latest model,
+// which is the behaviour for any caller outside the chart.
+func TestModelPinWithoutStatusURLDoesNotPin(t *testing.T) {
+	id, err := NewModelPin("").ID(t.Context(), storeOldest)
+
+	require.NoError(t, err)
+	assert.Empty(t, id)
+}
+
+func TestNilModelPinDoesNotPin(t *testing.T) {
+	var pin *ModelPin
+
+	id, err := pin.ID(t.Context(), storeOldest)
+
+	require.NoError(t, err)
+	assert.Empty(t, id)
+}
+
+// A model id belongs to the store it was written in. Pinning one from a different
+// store would name a model that store never had, so the caller fails closed until
+// the provisioner catches up.
+func TestModelPinRejectsAModelFromAnotherStore(t *testing.T) {
+	_, url := newStatusServer(t, storeNewer, modelOne)
+	pin := NewModelPin(url)
+
+	_, err := pin.ID(t.Context(), storeOldest)
+
+	require.ErrorIs(t, err, ErrModelUnknown)
+	assert.Contains(t, err.Error(), storeOldest)
+}
+
+func TestModelPinRejectsAnEmptyModelID(t *testing.T) {
+	_, url := newStatusServer(t, storeOldest, "")
+	pin := NewModelPin(url)
+
+	_, err := pin.ID(t.Context(), storeOldest)
+
+	require.ErrorIs(t, err, ErrModelUnknown)
+}
+
+func TestModelPinRejectsANonOKStatus(t *testing.T) {
+	srv, url := newStatusServer(t, storeOldest, modelOne)
+	srv.code.Store(http.StatusServiceUnavailable)
+	pin := NewModelPin(url)
+
+	_, err := pin.ID(t.Context(), storeOldest)
+
+	require.ErrorIs(t, err, ErrModelUnknown)
+}
+
+func TestModelPinFetchesOncePerStore(t *testing.T) {
+	srv, url := newStatusServer(t, storeOldest, modelOne)
+	pin := NewModelPin(url)
+
+	for range 5 {
+		_, err := pin.ID(t.Context(), storeOldest)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), srv.calls.Load())
+}
+
+// A reset replaces the store, so the pin must not keep serving the model id of
+// the store that is gone.
+func TestModelPinRefreshesWhenTheStoreChanges(t *testing.T) {
+	srv, url := newStatusServer(t, storeOldest, modelOne)
+	pin := NewModelPin(url)
+
+	first, err := pin.ID(t.Context(), storeOldest)
+	require.NoError(t, err)
+
+	srv.set(storeNewer, modelTwo)
+
+	second, err := pin.ID(t.Context(), storeNewer)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, modelTwo, second)
+	assert.Equal(t, int32(2), srv.calls.Load())
+}
+
+// The pinned id has to reach OpenFGA, not merely be resolved: an unpinned check
+// evaluates whatever model is latest, which is the thing pinning exists to stop.
+func TestClientEvaluateSendsThePinnedModel(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+	_, statusURL := newStatusServer(t, storeOldest, modelOne)
+
+	c, err := New(Config{APIURL: srv.url(t), StoreName: "fundament", StatusURL: statusURL})
+	require.NoError(t, err)
+
+	_, err = c.Evaluate(t.Context(), EvaluationRequest{
+		Subject:  User(uuid.New()),
+		Action:   CanView(),
+		Resource: Cluster(uuid.New()),
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, srv.lastCheckBody(), modelOne)
+}
+
+func TestClientEvaluateWithoutAStatusURLSendsNoModel(t *testing.T) {
+	srv := &fgaServer{stores: []openfga.Store{store(storeOldest, "fundament", time.Now())}}
+
+	c, err := New(Config{APIURL: srv.url(t), StoreName: "fundament"})
+	require.NoError(t, err)
+
+	_, err = c.Evaluate(t.Context(), EvaluationRequest{
+		Subject:  User(uuid.New()),
+		Action:   CanView(),
+		Resource: Cluster(uuid.New()),
+	})
+	require.NoError(t, err)
+
+	// The SDK always emits the field; empty is what leaves the model unpinned.
+	assert.Contains(t, srv.lastCheckBody(), `"authorization_model_id":""`)
+}

--- a/common/authz/status.go
+++ b/common/authz/status.go
@@ -14,6 +14,11 @@ type ProvisionStatus struct {
 	// Generation names the release the datastore belongs to.
 	Generation string `json:"generation"`
 	StoreID    string `json:"id"`
+	// ModelID is the model the provisioner put in force, which is the one
+	// embedded in its own image. Consumers evaluate against it rather than
+	// against whatever model is latest, so a model written by anything else
+	// does not take effect by being newer.
+	ModelID string `json:"model_id"`
 }
 
 // StatusClient reads that document.

--- a/common/authz/store.go
+++ b/common/authz/store.go
@@ -13,6 +13,10 @@ import (
 	"github.com/openfga/go-sdk/client"
 )
 
+// ErrModelUnknown reports that the provisioner has not published a usable model
+// for the resolved store yet.
+var ErrModelUnknown = errors.New("openfga authorization model not published")
+
 // ErrStoreNotFound reports that no store with the configured name exists.
 var ErrStoreNotFound = errors.New("openfga store not found")
 

--- a/common/authz/store_test.go
+++ b/common/authz/store_test.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -51,6 +52,16 @@ type fgaServer struct {
 	pageSize int
 
 	listCalls atomic.Int32
+	// checkBody records the last check request, so tests can assert what went on
+	// the wire rather than only what came back.
+	checkBody atomic.Value
+}
+
+// lastCheckBody returns the body of the most recent check request.
+func (s *fgaServer) lastCheckBody() string {
+	body, _ := s.checkBody.Load().(string)
+
+	return body
 }
 
 func (s *fgaServer) setStores(stores ...openfga.Store) {
@@ -92,6 +103,10 @@ func (s *fgaServer) url(t *testing.T) string {
 		w.Header().Set("Content-Type", "application/json")
 
 		if id, ok := strings.CutSuffix(strings.TrimPrefix(r.URL.Path, "/stores/"), "/check"); ok {
+			if raw, err := io.ReadAll(r.Body); err == nil {
+				s.checkBody.Store(string(raw))
+			}
+
 			s.mu.Lock()
 			code := s.status[id]
 			s.mu.Unlock()

--- a/openfga/setup/cmd/fun-openfga-setup/provision.go
+++ b/openfga/setup/cmd/fun-openfga-setup/provision.go
@@ -20,6 +20,11 @@ type Status struct {
 	Generation string `json:"generation"`
 	Store      string `json:"store"`
 	StoreID    string `json:"id"`
+	// ModelID is the model this provisioner put in force, which is the one
+	// embedded in its own image. Consumers evaluate against it rather than
+	// against whatever model is latest, so a model written by anything else
+	// does not take effect by being newer.
+	ModelID string `json:"model_id"`
 }
 
 // ProvisionConfig configures the provisioning role.
@@ -64,16 +69,19 @@ func Provision(ctx context.Context, cfg *ProvisionConfig) error {
 		return err
 	}
 
-	if err := ensureModel(ctx, fga, storeID, &want); err != nil {
+	modelID, err := ensureModel(ctx, fga, storeID, &want)
+	if err != nil {
 		return err
 	}
 
-	slog.Info("datastore provisioned", "store", cfg.StoreName, "id", storeID, "generation", cfg.Generation)
+	slog.Info("datastore provisioned",
+		"store", cfg.StoreName, "id", storeID, "model_id", modelID, "generation", cfg.Generation)
 
 	return serveStatus(ctx, cfg.StatusAddr, Status{
 		Generation: cfg.Generation,
 		Store:      cfg.StoreName,
 		StoreID:    storeID,
+		ModelID:    modelID,
 	})
 }
 

--- a/openfga/setup/cmd/fun-openfga-setup/store.go
+++ b/openfga/setup/cmd/fun-openfga-setup/store.go
@@ -91,10 +91,12 @@ func listStoresNamed(ctx context.Context, fga *client.OpenFgaClient, name string
 	return matches, nil
 }
 
-// ensureModel writes the authorization model only when the store's latest one
-// differs. OpenFGA never dedupes: every write appends a version with a fresh id,
-// and since no consumer pins a model id they would all silently follow it.
-func ensureModel(ctx context.Context, fga *client.OpenFgaClient, storeID string, want *openfga.AuthorizationModel) error {
+// ensureModel brings the store's authorization model up to date and returns the
+// id of the model now in force. It writes only when the latest model differs:
+// OpenFGA never dedupes, so every write appends a version with a fresh id.
+func ensureModel(
+	ctx context.Context, fga *client.OpenFgaClient, storeID string, want *openfga.AuthorizationModel,
+) (string, error) {
 	current, err := fga.ReadLatestAuthorizationModel(ctx).Options(
 		client.ClientReadLatestAuthorizationModelOptions{StoreId: &storeID},
 	).Execute()
@@ -109,18 +111,18 @@ func ensureModel(ctx context.Context, fga *client.OpenFgaClient, storeID string,
 	// A read that failed for any other reason must not pass for "no model yet":
 	// writing then appends a version every consumer immediately evaluates against.
 	case err != nil && !errors.As(err, &notFound):
-		return fmt.Errorf("read latest authorization model: %w", err)
+		return "", fmt.Errorf("read latest authorization model: %w", err)
 
 	case err == nil && current.AuthorizationModel != nil:
 		same, err := sameModel(current.AuthorizationModel, want)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		if same {
 			slog.Info("authorization model unchanged", "model_id", current.AuthorizationModel.Id)
 
-			return nil
+			return current.AuthorizationModel.Id, nil
 		}
 
 		reason = "shipped model differs from the store's latest, " + current.AuthorizationModel.Id
@@ -139,12 +141,12 @@ func ensureModel(ctx context.Context, fga *client.OpenFgaClient, storeID string,
 		Options(client.ClientWriteAuthorizationModelOptions{StoreId: &storeID}).
 		Execute()
 	if err != nil {
-		return fmt.Errorf("write authorization model: %w", err)
+		return "", fmt.Errorf("write authorization model: %w", err)
 	}
 
 	slog.Info("authorization model written", "model_id", written.AuthorizationModelId)
 
-	return nil
+	return written.AuthorizationModelId, nil
 }
 
 // sameModel reports whether the store's latest model means the same as the one the


### PR DESCRIPTION
OpenFGA evaluates the *latest* authorization model when a request pins none, so any
successful `WriteAuthorizationModel` becomes the rules every service enforces,
immediately and without a restart. Pin the model the provisioner put in force.

## What changed

- The provisioner's status document (added in PR 2) gains the id of the model it
  wrote — the one embedded in its own image:
  `{"generation":"20","store":"fundament","id":"…","model_id":"…"}`
- Consumers read that id and pass it on every check. The worker passes it on every
  tuple write.

PR 1 deliberately stopped pinning a model id, because the id it had been pinning lived
in a ConfigMap read once at pod start and went stale. This restores pinning from a
source that cannot go stale: the id travels over HTTP from the process that wrote it,
and refreshes when the store changes.

**Writes need this as much as checks do.** Tuple writes are validated against a model
too. Left unpinned they are validated by whatever model is latest, and a model that
drops a type rejects every tuple of that type:

```
Invalid tuple 'api_key:…#owner@organization:…'. Reason: type 'api_key' not found
outbox item exceeded max retries, marking as failed
```

Those rows reach `failed`, which the pending query excludes, so nothing retries them.

A published id is refused when it names a store other than the one resolved — model
ids are per store, so pinning across stores would name a model that store never had.
Without `OPENFGA_STATUS_URL` the pin is inert and behaviour is unchanged. PR 2 already
sets it for authz-worker; this adds it for the four read-path consumers.

OpenFGA's docs strongly recommend pinning `authorization_model_id` in production.
Their flow has CI deploy the model and inject the id into configuration; this has a
CI-validated image publish it, which needs no configuration round-trip to stay current.

**Scope:** this guards the *rules*, not the *data*. Anyone who can reach the API can
still write tuples directly, which is a full authorization bypass. That is
pre-existing and tracked separately.

## Verification

`go test ./common/authz/...` — eight tests on the pin, including one asserting the id
actually reaches the wire rather than only being resolved.

Behaviour under attack, on k3d, with a model granting viewers `can_edit` planted as
latest:

| check | result |
|---|---|
| unpinned — evaluates latest | `allowed: true`, escalation succeeds |
| pinned to the provisioned model | `allowed: false` |

Same attack with all consumers cold-restarted so no cache helps them:

| | before pinning writes | after |
|---|---|---|
| `just e2e test` | 26/40 scenarios, 14 failed | **40/40** |
| outbox | `failed: 3` | **`completed: 54`, none failed** |

The next deploy restores the sanctioned model as latest, since the provisioner
compares the shipped model against latest and writes on a difference.
