### PR TITLE
fix(chart): gate openfga readiness on its store being provisioned

### DIFF
--- a/charts/fundament/templates/openfga.yaml
+++ b/charts/fundament/templates/openfga.yaml
@@ -228,6 +228,28 @@ spec:
           ports:
             - name: status
               containerPort: {{ $.Values.openfga.statusPort }}
+          # The status endpoint answers only once the store exists and carries
+          # this release's generation, so gating readiness on it keeps openfga out
+          # of its Service until consumers can resolve the store. The startup
+          # probe owns the provisioning window; the liveness probe restarts a
+          # provisioner whose HTTP server has stopped answering.
+          startupProbe:
+            httpGet:
+              path: /status.json
+              port: status
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /status.json
+              port: status
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /status.json
+              port: status
+            periodSeconds: 20
+            failureThreshold: 3
 
 ---
 apiVersion: v1


### PR DESCRIPTION
The provision sidecar carried no probes, so the openfga pod joined its Service as soon
as both containers were running — before the store existed. Gate readiness on the
status endpoint, which only answers once the store is provisioned.

## What changed

Three probes on the provision container, all against `/status.json`:

| probe | period | threshold | purpose |
|---|---|---|---|
| startup | 5s | 60 (5 min) | owns the provisioning window, matching the provisioner's own timeout |
| readiness | 10s | default | keeps openfga out of the Service until the store resolves |
| liveness | 20s | 3 | restarts a provisioner whose HTTP server stopped answering |

`db-migrations` polls the same endpoint through the Service, so it cannot reach it
until openfga is Ready. That is safe because the waiter treats every fetch error as
not-ready-yet and polls to its timeout rather than failing.

What this does **not** change: a model the server rejects still crash-loops the
sidecar and takes openfga out of its Service. That is unchanged from master, where
`setup` had no probes either and exited under `set -e` on the same failure; PR 3 keeps
that case out of a cluster by rejecting the model in CI. Whether a provisioning
failure *should* take the API offline differs by environment — where the datastore was
just wiped there is nothing to serve, but where the store persists it still holds the
previous working model — so it is left as it is rather than decided here.

## Verification

Deployed on k3d: provisioning completed at `06:00:24.625` and `Ready=True` at
`06:00:38`, so readiness is strictly after provisioning. No probe failure events,
zero restarts, `wait-for-store` satisfied in 18s, `just e2e test` 40/40.
