### PR TITLE
fix(console): disable kubeconfig download until the cluster is running

### DIFF
--- a/console-frontend/src/app/app.ts
+++ b/console-frontend/src/app/app.ts
@@ -29,6 +29,7 @@ import '@nldd/design-system/spacer';
 import '@nldd/design-system/switch-field';
 import '@nldd/design-system/text-field';
 import '@nldd/design-system/toggle-button';
+import '@nldd/design-system/tooltip';
 import '@nldd/design-system/pagination';
 import '@nldd/design-system/segmented-control';
 import '@nldd/design-system/navigation-split-view';

--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -51,7 +51,8 @@
           <nldd-button
             type="button"
             (click)="downloadKubeconfig()"
-            [disabled]="isDownloadingKubeconfig()"
+            [disabled]="isDownloadingKubeconfig() || !canDownloadKubeconfig()"
+            [attr.title]="canDownloadKubeconfig() ? null : 'Available once the cluster is running'"
             [text]="isDownloadingKubeconfig() ? 'Downloading…' : 'Download kubeconfig'"
             start-icon="arrow-down-in-bucket"
             variant="primary"

--- a/console-frontend/src/app/cluster-details/cluster-details.component.html
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.html
@@ -48,16 +48,22 @@
             start-icon="terminal"
             size="sm"
           ></nldd-button>
-          <nldd-button
-            type="button"
-            (click)="downloadKubeconfig()"
-            [disabled]="isDownloadingKubeconfig() || !canDownloadKubeconfig()"
-            [attr.title]="canDownloadKubeconfig() ? null : 'Available once the cluster is running'"
-            [text]="isDownloadingKubeconfig() ? 'Downloading…' : 'Download kubeconfig'"
-            start-icon="arrow-down-in-bucket"
-            variant="primary"
-            size="sm"
-          ></nldd-button>
+          <nldd-tooltip
+            [attr.text]="canDownloadKubeconfig() ? null : 'Available once the cluster is running'"
+            [attr.timing]="canDownloadKubeconfig() ? 'never' : 'default'"
+          >
+            <span class="inline-flex">
+              <nldd-button
+                type="button"
+                (click)="downloadKubeconfig()"
+                [disabled]="isDownloadingKubeconfig() || !canDownloadKubeconfig()"
+                [text]="isDownloadingKubeconfig() ? 'Downloading…' : 'Download kubeconfig'"
+                start-icon="arrow-down-in-bucket"
+                variant="primary"
+                size="sm"
+              ></nldd-button>
+            </span>
+          </nldd-tooltip>
         </div>
       </div>
     </div>

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { RouterLink, ActivatedRoute, Router } from '@angular/router';
 import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { firstValueFrom } from 'rxjs';
 import { TitleService } from '../title.service';
 import { ToastService } from '../toast.service';
@@ -291,7 +292,7 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
         this.loadResourceUsage(clusterId),
       ]);
 
-      this.updatePolling();
+      this.startPolling();
     } catch (error) {
       this.errorMessage.set(
         error instanceof Error
@@ -310,10 +311,7 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
       const response = await firstValueFrom(this.client.getCluster(request));
 
       if (!response.cluster) {
-        // Cluster has been deleted
-        this.stopPolling();
-        this.toastService.success(`Cluster '${this.clusterData.basics.name}' has been deleted`);
-        this.router.navigate(['/']);
+        this.handleClusterDeleted();
         return;
       }
 
@@ -326,21 +324,27 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
         this.loadResourceUsage(clusterId);
       }
       this.cdr.markForCheck();
-      this.updatePolling();
-    } catch {
-      // If the request fails with a not-found-like error, the cluster was deleted
-      this.stopPolling();
-      this.toastService.success(`Cluster '${this.clusterData.basics.name}' has been deleted`);
-      this.router.navigate(['/']);
+    } catch (error) {
+      // Anything else (network blip, API rollout, expired session) is
+      // transient as far as this page is concerned; the next tick retries.
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        this.handleClusterDeleted();
+      }
     }
   }
 
-  private updatePolling() {
-    const needsPolling = isTransitionalStatus(this.clusterData.status);
-    if (needsPolling && !this.pollingTimer) {
+  private handleClusterDeleted() {
+    this.stopPolling();
+    this.toastService.success(`Cluster '${this.clusterData.basics.name}' has been deleted`);
+    this.router.navigate(['/']);
+  }
+
+  // Poll in every status, not only transitional ones: a running cluster can
+  // drop to ERROR or be upgraded, and an errored one recovers on its own.
+  // Actions gated on status (kubeconfig download) rely on this staying fresh.
+  private startPolling() {
+    if (!this.pollingTimer) {
       this.pollingTimer = setInterval(() => this.pollClusterStatus(), 5000);
-    } else if (!needsPolling && this.pollingTimer) {
-      this.stopPolling();
     }
   }
 

--- a/console-frontend/src/app/cluster-details/cluster-details.component.ts
+++ b/console-frontend/src/app/cluster-details/cluster-details.component.ts
@@ -33,7 +33,12 @@ import { ListPluginsRequestSchema, type PluginSummary } from '../../generated/v1
 import PluginInstallationService from '../plugin-installation/plugin-installation.service';
 import { ClusterStatus, NodePoolStatus } from '../../generated/v1/common_pb';
 import { LoadingIndicatorComponent } from '../icons';
-import { getStatusTagColor, getStatusLabel, isTransitionalStatus } from '../utils/cluster-status';
+import {
+  getStatusTagColor,
+  getStatusLabel,
+  isKubeconfigAvailable,
+  isTransitionalStatus,
+} from '../utils/cluster-status';
 import DialogSyncDirective from '../dialog-sync.directive';
 import focusFirstModalInput from '../modal-focus';
 import { formatDateTime as formatDateTimeUtil } from '../utils/date-format';
@@ -362,8 +367,12 @@ export default class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   isDownloadingKubeconfig = signal<boolean>(false);
 
+  canDownloadKubeconfig(): boolean {
+    return isKubeconfigAvailable(this.clusterData.status);
+  }
+
   async downloadKubeconfig(): Promise<void> {
-    if (this.isDownloadingKubeconfig()) {
+    if (this.isDownloadingKubeconfig() || !this.canDownloadKubeconfig()) {
       return;
     }
     this.isDownloadingKubeconfig.set(true);

--- a/console-frontend/src/app/utils/cluster-status.spec.ts
+++ b/console-frontend/src/app/utils/cluster-status.spec.ts
@@ -1,0 +1,29 @@
+import { ClusterStatus } from '../../generated/v1/common_pb';
+import { isKubeconfigAvailable, isTransitionalStatus } from './cluster-status';
+
+describe('isKubeconfigAvailable', () => {
+  it('only offers a kubeconfig once the cluster is running', () => {
+    expect(isKubeconfigAvailable(ClusterStatus.RUNNING)).toBe(true);
+  });
+
+  it('withholds the kubeconfig in every other status', () => {
+    const others = [
+      ClusterStatus.UNSPECIFIED,
+      ClusterStatus.PROVISIONING,
+      ClusterStatus.STARTING,
+      ClusterStatus.UPGRADING,
+      ClusterStatus.ERROR,
+      ClusterStatus.STOPPING,
+      ClusterStatus.STOPPED,
+      ClusterStatus.DELETING,
+    ];
+    others.forEach((status) => {
+      expect(isKubeconfigAvailable(status)).toBe(false);
+    });
+  });
+
+  it('keeps polling while the cluster is still becoming available', () => {
+    expect(isTransitionalStatus(ClusterStatus.PROVISIONING)).toBe(true);
+    expect(isKubeconfigAvailable(ClusterStatus.PROVISIONING)).toBe(false);
+  });
+});

--- a/console-frontend/src/app/utils/cluster-status.ts
+++ b/console-frontend/src/app/utils/cluster-status.ts
@@ -89,3 +89,15 @@ export function getStatusLabel(status: ClusterStatus): string {
   };
   return labels[status];
 }
+
+/**
+ * Whether a kubeconfig can be downloaded for a cluster in this status.
+ *
+ * Mirrors the organization-api gate in `GetKubeconfig`: it only serves a
+ * kubeconfig once the shoot reports `ready`, which is the sole shoot status
+ * that maps to `RUNNING`. Any other status would be rejected with
+ * "cluster not ready yet", so the UI should not offer the download.
+ */
+export function isKubeconfigAvailable(status: ClusterStatus): boolean {
+  return status === ClusterStatus.RUNNING;
+}


### PR DESCRIPTION
The "Download kubeconfig" button on the cluster details page was clickable in every cluster status, but organization-api only serves a kubeconfig once the shoot reports `ready` and otherwise answers `FailedPrecondition "cluster not ready yet"` — so clicking during provisioning just produced an error toast. The console now mirrors that gate: the button is disabled (with a title explaining why) until the cluster is `RUNNING`, the only status `ready` maps to, and the existing status polling re-enables it once provisioning finishes.

- `isKubeconfigAvailable()` helper in `utils/cluster-status.ts`, with unit tests
- button disabled + explanatory title until available; `downloadKubeconfig()` no-ops as a guard

Closes https://gitlab.com/digilab.overheid.nl/miscellaneous/issues/-/work_items/1183
