### PR TITLE
feat(marketplace): registry API schema (stack 2/3)

### DIFF
--- a/common/dbconst/constraints.go
+++ b/common/dbconst/constraints.go
@@ -259,6 +259,10 @@ const (
 	ConstraintPlacementsCkSlotType = "placements_ck_slot_type"
 	// ConstraintPlacementsCkUnitStart is defined on dcim.placements.
 	ConstraintPlacementsCkUnitStart = "placements_ck_unit_start"
+	// ConstraintPluginAllowedOrganizationsFkOrganization is defined on appstore.plugin_allowed_organizations.
+	ConstraintPluginAllowedOrganizationsFkOrganization = "plugin_allowed_organizations_fk_organization"
+	// ConstraintPluginAllowedOrganizationsFkPlugin is defined on appstore.plugin_allowed_organizations.
+	ConstraintPluginAllowedOrganizationsFkPlugin = "plugin_allowed_organizations_fk_plugin"
 	// ConstraintPluginDefinitionsCkStatus is defined on appstore.plugin_definitions.
 	ConstraintPluginDefinitionsCkStatus = "plugin_definitions_ck_status"
 	// ConstraintPluginDefinitionsFkPlugin is defined on appstore.plugin_definitions.
@@ -359,6 +363,16 @@ const (
 	ConstraintRoomsUqSiteName = "rooms_uq_site_name"
 	// ConstraintSitesUqName is defined on dcim.sites.
 	ConstraintSitesUqName = "sites_uq_name"
+	// ConstraintSubmissionsCkClosed is defined on appstore.submissions.
+	ConstraintSubmissionsCkClosed = "submissions_ck_closed"
+	// ConstraintSubmissionsCkRejectionReason is defined on appstore.submissions.
+	ConstraintSubmissionsCkRejectionReason = "submissions_ck_rejection_reason"
+	// ConstraintSubmissionsCkReviewed is defined on appstore.submissions.
+	ConstraintSubmissionsCkReviewed = "submissions_ck_reviewed"
+	// ConstraintSubmissionsFkPluginDefinition is defined on appstore.submissions.
+	ConstraintSubmissionsFkPluginDefinition = "submissions_fk_plugin_definition"
+	// ConstraintSubmissionsUqOpen is defined on appstore.submissions.
+	ConstraintSubmissionsUqOpen = "submissions_uq_open"
 	// ConstraintTagsUqName is defined on appstore.tags.
 	ConstraintTagsUqName = "tags_uq_name"
 	// ConstraintTaskStepsUqTaskOrdinal is defined on dcim.task_steps.

--- a/common/dbconst/constraints.go
+++ b/common/dbconst/constraints.go
@@ -371,6 +371,8 @@ const (
 	ConstraintSubmissionsCkReviewed = "submissions_ck_reviewed"
 	// ConstraintSubmissionsFkPluginDefinition is defined on appstore.submissions.
 	ConstraintSubmissionsFkPluginDefinition = "submissions_fk_plugin_definition"
+	// ConstraintSubmissionsFkSubmitterUser is defined on appstore.submissions.
+	ConstraintSubmissionsFkSubmitterUser = "submissions_fk_submitter_user"
 	// ConstraintSubmissionsUqOpen is defined on appstore.submissions.
 	ConstraintSubmissionsUqOpen = "submissions_uq_open"
 	// ConstraintTagsUqName is defined on appstore.tags.

--- a/common/dbconst/enums.go
+++ b/common/dbconst/enums.go
@@ -305,6 +305,18 @@ const (
 	ProjectMemberRole_Viewer ProjectMemberRole = "viewer"
 )
 
+// SubmissionRejectionReason represents valid values for appstore.submissions.rejection_reason.
+type SubmissionRejectionReason string
+
+const (
+	SubmissionRejectionReason_IncompleteMetadata SubmissionRejectionReason = "incomplete_metadata"
+	SubmissionRejectionReason_Duplicate          SubmissionRejectionReason = "duplicate"
+	SubmissionRejectionReason_SecurityConcerns   SubmissionRejectionReason = "security_concerns"
+	SubmissionRejectionReason_NamingGuidelines   SubmissionRejectionReason = "naming_guidelines"
+	SubmissionRejectionReason_OutOfScope         SubmissionRejectionReason = "out_of_scope"
+	SubmissionRejectionReason_Other              SubmissionRejectionReason = "other"
+)
+
 // TaskCategory represents valid values for dcim.tasks.category.
 type TaskCategory string
 

--- a/common/dbversion/version.go
+++ b/common/dbversion/version.go
@@ -1,4 +1,4 @@
 package dbversion
 
 // LatestVersion is the latest version for the db migrations.
-const LatestVersion = 37
+const LatestVersion = 38

--- a/common/testdb/roles.go
+++ b/common/testdb/roles.go
@@ -29,6 +29,7 @@ var Roles = []Role{
 	{Name: "fun_authz_worker", BypassRLS: true},
 	{Name: "fun_dcim_api"},
 	{Name: "fun_marketplace_catalog_api"},
+	{Name: "fun_marketplace_registry_api"},
 }
 
 // CreateRoles ensures every role in [Roles] exists with the configured

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -52,6 +52,10 @@ CAUTION: Do not modify this file unless you know what you are doing.
  sql-disabled="true">
 </role>
 
+<role name="fun_marketplace_registry_api"
+ sql-disabled="true">
+</role>
+
 <database name="fundament" is-template="false" allow-conns="true" sql-disabled="true">
 </database>
 
@@ -1359,7 +1363,11 @@ END;]]> </definition>
 	</column>
 	<column name="visibility" not-null="true" default-value="'public'">
 		<type name="text" length="0"/>
-		<comment> <![CDATA[RESTRICTED listings are hidden from the public catalog entirely. Nothing writes this until the registry API lands.]]> </comment>
+		<comment> <![CDATA[RESTRICTED listings are hidden from the public catalog entirely. Written by the registry API's UpdatePlugin.]]> </comment>
+	</column>
+	<column name="updated" not-null="true" default-value="now()">
+		<type name="timestamptz" length="0"/>
+		<comment> <![CDATA[Set by the application on every UpdatePlugin; there is no trigger.]]> </comment>
 	</column>
 	<column name="created" not-null="true" default-value="now()">
 		<type name="timestamptz" length="0"/>
@@ -1390,6 +1398,11 @@ END;]]> </definition>
 </policy>
 
 <policy name="plugins_update_owner" table="appstore.plugins" command="UPDATE" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+</policy>
+
+<policy name="plugins_all_registry" table="appstore.plugins" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
 	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 </policy>
@@ -1539,6 +1552,94 @@ END;]]> </definition>
 			<column name="published"/>
 		</idxelement>
 	<predicate> <![CDATA[published IS NOT NULL AND deleted IS NULL]]> </predicate>
+</index>
+
+<table name="submissions" layers="0" collapse-mode="1" rls-enabled="true" max-obj-count="10" z-value="0">
+	<schema name="appstore"/>
+	<role name="fun_owner"/>
+	<comment> <![CDATA[One review round for one plugin version. The version's own status column stays authoritative; this table records who submitted, who decided, when and why.]]> </comment>
+	<position x="1560" y="2200"/>
+	<column name="id" not-null="true" default-value="uuidv7()">
+		<type name="uuid" length="0"/>
+	</column>
+	<column name="plugin_definition_id" not-null="true">
+		<type name="uuid" length="0"/>
+	</column>
+	<column name="submitter_user_id" not-null="true">
+		<type name="uuid" length="0"/>
+	</column>
+	<column name="reviewer_user_id">
+		<type name="uuid" length="0"/>
+		<comment> <![CDATA[Which store reviewers authenticate against is undecided, so this carries no foreign key.]]> </comment>
+	</column>
+	<column name="rejection_reason">
+		<type name="text" length="0"/>
+	</column>
+	<column name="feedback" not-null="true" default-value="''">
+		<type name="text" length="0"/>
+	</column>
+	<column name="submitted" not-null="true" default-value="now()">
+		<type name="timestamptz" length="0"/>
+		<comment> <![CDATA[A submission is created by being submitted, so this is also its creation timestamp and there is no separate created column.]]> </comment>
+	</column>
+	<column name="reviewed">
+		<type name="timestamptz" length="0"/>
+	</column>
+	<column name="closed">
+		<type name="timestamptz" length="0"/>
+		<comment> <![CDATA[Set by any terminal outcome. A withdrawal closes a round without a reviewer, which is why this is separate from reviewed.]]> </comment>
+	</column>
+	<column name="deleted">
+		<type name="timestamptz" length="0"/>
+	</column>
+	<constraint name="submissions_pk" type="pk-constr" table="appstore.submissions">
+		<columns names="id" ref-type="src-columns"/>
+	</constraint>
+	<constraint name="submissions_ck_rejection_reason" type="ck-constr" table="appstore.submissions">
+			<expression> <![CDATA[rejection_reason IS NULL OR rejection_reason IN ('incomplete_metadata', 'duplicate', 'security_concerns', 'naming_guidelines', 'out_of_scope', 'other')]]> </expression>
+	</constraint>
+	<constraint name="submissions_ck_reviewed" type="ck-constr" table="appstore.submissions">
+			<expression> <![CDATA[(reviewed IS NULL) = (reviewer_user_id IS NULL)]]> </expression>
+	</constraint>
+	<constraint name="submissions_ck_closed" type="ck-constr" table="appstore.submissions">
+			<expression> <![CDATA[reviewed IS NULL OR closed IS NOT NULL]]> </expression>
+	</constraint>
+</table>
+
+<index name="submissions_uq_open" table="appstore.submissions"
+	 concurrent="false" unique="true" fast-update="false" buffering="false" nulls-not-distinct="false"
+	 index-type="btree" factor="0">
+		<idxelement use-sorting="false">
+			<column name="plugin_definition_id"/>
+		</idxelement>
+	<predicate> <![CDATA[closed IS NULL AND deleted IS NULL]]> </predicate>
+</index>
+
+<table name="plugin_allowed_organizations" layers="0" collapse-mode="1" rls-enabled="true" max-obj-count="3" z-value="0">
+	<schema name="appstore"/>
+	<role name="fun_owner"/>
+	<comment> <![CDATA[Organizations permitted to install a RESTRICTED listing. A pure association table, replaced wholesale by UpdatePlugin, so it carries no deleted column.]]> </comment>
+	<position x="1560" y="2480"/>
+	<column name="plugin_id" not-null="true">
+		<type name="uuid" length="0"/>
+	</column>
+	<column name="organization_id" not-null="true">
+		<type name="uuid" length="0"/>
+	</column>
+	<column name="created" not-null="true" default-value="now()">
+		<type name="timestamptz" length="0"/>
+	</column>
+	<constraint name="plugin_allowed_organizations_pk" type="pk-constr" table="appstore.plugin_allowed_organizations">
+		<columns names="plugin_id,organization_id" ref-type="src-columns"/>
+	</constraint>
+</table>
+
+<index name="plugin_allowed_organizations_idx_organization_id" table="appstore.plugin_allowed_organizations"
+	 concurrent="false" unique="false" fast-update="false" buffering="false" nulls-not-distinct="false"
+	 index-type="btree" factor="0">
+		<idxelement use-sorting="false">
+			<column name="organization_id"/>
+		</idxelement>
 </index>
 
 <table name="presets" layers="0" collapse-mode="1" rls-enabled="true" max-obj-count="3" z-value="0">
@@ -1705,6 +1806,14 @@ END;]]> </definition>
 	<column name="url" not-null="true">
 		<type name="text" length="0"/>
 	</column>
+	<column name="position" not-null="true" default-value="0">
+		<type name="integer" length="0"/>
+		<comment> <![CDATA[Render order within a listing, matching appstore.plugin_features.position.]]> </comment>
+	</column>
+	<column name="deleted">
+		<type name="timestamptz" length="0"/>
+		<comment> <![CDATA[UpdatePlugin replaces links wholesale; a dropped link is soft-deleted rather than removed, per the project-wide rule.]]> </comment>
+	</column>
 	<constraint name="plugin_documentation_links_pk" type="pk-constr" table="appstore.plugin_documentation_links">
 		<columns names="id" ref-type="src-columns"/>
 	</constraint>
@@ -1716,6 +1825,45 @@ END;]]> </definition>
 
 <policy name="plugin_documentation_links_select_catalog" table="appstore.plugin_documentation_links" command="SELECT" permissive="true">	<roles names="fun_marketplace_catalog_api"/>
 	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id)]]> </expression>
+</policy>
+
+<policy name="plugin_definitions_all_registry" table="appstore.plugin_definitions" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="submissions_all_registry" table="appstore.submissions" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugin_definitions JOIN appstore.plugins ON appstore.plugins.id = appstore.plugin_definitions.plugin_id WHERE appstore.plugin_definitions.id = appstore.submissions.plugin_definition_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugin_definitions JOIN appstore.plugins ON appstore.plugins.id = appstore.plugin_definitions.plugin_id WHERE appstore.plugin_definitions.id = appstore.submissions.plugin_definition_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_features_all_registry" table="appstore.plugin_features" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_features.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_features.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_documentation_links_all_registry" table="appstore.plugin_documentation_links" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugins_tags_all_registry" table="appstore.plugins_tags" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugins_tags.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugins_tags.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="categories_plugins_all_registry" table="appstore.categories_plugins" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.categories_plugins.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.categories_plugins.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_allowed_organizations_all_registry" table="appstore.plugin_allowed_organizations" command="ALL" permissive="true">	<roles names="fun_marketplace_registry_api"/>
+	<expression type="using-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
+</policy>
+
+<policy name="plugin_allowed_organizations_select_api" table="appstore.plugin_allowed_organizations" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 </policy>
 
 <trigger name="require_admin" firing-type="AFTER" per-line="true" constraint="true"
@@ -3554,6 +3702,24 @@ END;]]> </definition>
 	<columns names="id" ref-type="dst-columns"/>
 </constraint>
 
+<constraint name="submissions_fk_plugin_definition" type="fk-constr" comparison-type="MATCH SIMPLE"
+	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="appstore.plugin_definitions" table="appstore.submissions">
+	<columns names="plugin_definition_id" ref-type="src-columns"/>
+	<columns names="id" ref-type="dst-columns"/>
+</constraint>
+
+<constraint name="plugin_allowed_organizations_fk_plugin" type="fk-constr" comparison-type="MATCH SIMPLE"
+	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="appstore.plugins" table="appstore.plugin_allowed_organizations">
+	<columns names="plugin_id" ref-type="src-columns"/>
+	<columns names="id" ref-type="dst-columns"/>
+</constraint>
+
+<constraint name="plugin_allowed_organizations_fk_organization" type="fk-constr" comparison-type="MATCH SIMPLE"
+	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="tenant.organizations" table="appstore.plugin_allowed_organizations">
+	<columns names="organization_id" ref-type="src-columns"/>
+	<columns names="id" ref-type="dst-columns"/>
+</constraint>
+
 <constraint name="project_members_fk_project" type="fk-constr" comparison-type="MATCH SIMPLE"
 	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="tenant.projects" table="tenant.project_members">
 	<columns names="project_id" ref-type="src-columns"/>
@@ -4053,6 +4219,24 @@ END;]]> </definition>
 	 custom-color="#f0f0f0"
 	 src-table="appstore.plugin_features"
 	 dst-table="appstore.plugins" reference-fk="plugin_features_fk_plugin"
+	 src-required="false" dst-required="true"/>
+
+<relationship name="rel_submissions_plugin_definitions" type="relfk" layers="0"
+	 custom-color="#f0f0f0"
+	 src-table="appstore.submissions"
+	 dst-table="appstore.plugin_definitions" reference-fk="submissions_fk_plugin_definition"
+	 src-required="false" dst-required="true"/>
+
+<relationship name="rel_plugin_allowed_organizations_plugins" type="relfk" layers="0"
+	 custom-color="#f0f0f0"
+	 src-table="appstore.plugin_allowed_organizations"
+	 dst-table="appstore.plugins" reference-fk="plugin_allowed_organizations_fk_plugin"
+	 src-required="false" dst-required="true"/>
+
+<relationship name="rel_plugin_allowed_organizations_organizations" type="relfk" layers="0"
+	 custom-color="#f0f0f0"
+	 src-table="appstore.plugin_allowed_organizations"
+	 dst-table="tenant.organizations" reference-fk="plugin_allowed_organizations_fk_organization"
 	 src-required="false" dst-required="true"/>
 
 <relationship name="rel_api_keys_organizations" type="relfk" layers="0"
@@ -4622,6 +4806,11 @@ END;]]> </definition>
 	<privileges select="true" insert="true" update="true"/>
 </permission>
 <permission>
+	<object name="appstore.plugin_allowed_organizations" type="table"/>
+	<roles names="fun_fundament_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
 	<object name="appstore.plugin_definitions" type="table"/>
 	<roles names="fun_fundament_api"/>
 	<privileges select="true" insert="true" update="true"/>
@@ -5044,6 +5233,86 @@ END;]]> </definition>
 <permission>
 	<object name="appstore.preset_plugins" type="table"/>
 	<roles names="fun_marketplace_catalog_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore" type="schema"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges usage="true"/>
+</permission>
+<permission>
+	<object name="authn" type="schema"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges usage="true"/>
+</permission>
+<permission>
+	<object name="authz" type="schema"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges usage="true"/>
+</permission>
+<permission>
+	<object name="authz.outbox" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges insert="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugins" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" update="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugin_definitions" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" update="true"/>
+</permission>
+<permission>
+	<object name="appstore.submissions" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true"/>
+</permission>
+<permission>
+	<object name="closed" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="deleted" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugin_features" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" update="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugin_documentation_links" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" update="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugins_tags" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" delete="true"/>
+</permission>
+<permission>
+	<object name="appstore.categories_plugins" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" delete="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugin_allowed_organizations" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true" delete="true"/>
+</permission>
+<permission>
+	<object name="appstore.tags" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true" insert="true"/>
+</permission>
+<permission>
+	<object name="appstore.categories" type="table"/>
+	<roles names="fun_marketplace_registry_api"/>
 	<privileges select="true"/>
 </permission>
 </dbmodel>

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -1389,10 +1389,6 @@ END;]]> </definition>
 	</constraint>
 </table>
 
-<policy name="plugins_select_all" table="appstore.plugins" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
-	<expression type="using-exp"> <![CDATA[true]]> </expression>
-</policy>
-
 <policy name="plugins_insert_owner" table="appstore.plugins" command="INSERT" permissive="true">	<roles names="fun_fundament_api"/>
 	<expression type="check-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 </policy>
@@ -1613,6 +1609,14 @@ END;]]> </definition>
 			<column name="plugin_definition_id"/>
 		</idxelement>
 	<predicate> <![CDATA[closed IS NULL AND deleted IS NULL]]> </predicate>
+</index>
+
+<index name="submissions_idx_plugin_definition_id" table="appstore.submissions"
+	 concurrent="false" unique="false" fast-update="false" buffering="false" nulls-not-distinct="false"
+	 index-type="btree" factor="0">
+		<idxelement use-sorting="false">
+			<column name="plugin_definition_id"/>
+		</idxelement>
 </index>
 
 <table name="plugin_allowed_organizations" layers="0" collapse-mode="1" rls-enabled="true" max-obj-count="3" z-value="0">
@@ -1864,6 +1868,10 @@ END;]]> </definition>
 
 <policy name="plugin_allowed_organizations_select_api" table="appstore.plugin_allowed_organizations" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
 	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
+</policy>
+
+<policy name="plugins_select_all" table="appstore.plugins" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
+	<expression type="using-exp"> <![CDATA[visibility = 'public' OR organization_id = authn.current_organization_id() OR EXISTS (SELECT 1 FROM appstore.plugin_allowed_organizations WHERE appstore.plugin_allowed_organizations.plugin_id = appstore.plugins.id AND appstore.plugin_allowed_organizations.organization_id = authn.current_organization_id())]]> </expression>
 </policy>
 
 <trigger name="require_admin" firing-type="AFTER" per-line="true" constraint="true"
@@ -3702,6 +3710,12 @@ END;]]> </definition>
 	<columns names="id" ref-type="dst-columns"/>
 </constraint>
 
+<constraint name="submissions_fk_submitter_user" type="fk-constr" comparison-type="MATCH SIMPLE"
+	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="tenant.users" table="appstore.submissions">
+	<columns names="submitter_user_id" ref-type="src-columns"/>
+	<columns names="id" ref-type="dst-columns"/>
+</constraint>
+
 <constraint name="submissions_fk_plugin_definition" type="fk-constr" comparison-type="MATCH SIMPLE"
 	 upd-action="NO ACTION" del-action="NO ACTION" ref-table="appstore.plugin_definitions" table="appstore.submissions">
 	<columns names="plugin_definition_id" ref-type="src-columns"/>
@@ -4225,6 +4239,12 @@ END;]]> </definition>
 	 custom-color="#f0f0f0"
 	 src-table="appstore.submissions"
 	 dst-table="appstore.plugin_definitions" reference-fk="submissions_fk_plugin_definition"
+	 src-required="false" dst-required="true"/>
+
+<relationship name="rel_submissions_users" type="relfk" layers="0"
+	 custom-color="#f0f0f0"
+	 src-table="appstore.submissions"
+	 dst-table="tenant.users" reference-fk="submissions_fk_submitter_user"
 	 src-required="false" dst-required="true"/>
 
 <relationship name="rel_plugin_allowed_organizations_plugins" type="relfk" layers="0"
@@ -5263,12 +5283,32 @@ END;]]> </definition>
 <permission>
 	<object name="appstore.plugin_definitions" type="table"/>
 	<roles names="fun_marketplace_registry_api"/>
-	<privileges select="true" insert="true" update="true"/>
+	<privileges select="true" insert="true"/>
+</permission>
+<permission>
+	<object name="status" parent="appstore.plugin_definitions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="deleted" parent="appstore.plugin_definitions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges update="true"/>
 </permission>
 <permission>
 	<object name="appstore.submissions" type="table"/>
 	<roles names="fun_marketplace_registry_api"/>
-	<privileges select="true" insert="true"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="plugin_definition_id" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges insert="true"/>
+</permission>
+<permission>
+	<object name="submitter_user_id" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_registry_api"/>
+	<privileges insert="true"/>
 </permission>
 <permission>
 	<object name="closed" parent="appstore.submissions" type="column"/>

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1068,6 +1068,7 @@ CREATE TABLE appstore.plugins (
 	image text NOT NULL DEFAULT '',
 	license text NOT NULL DEFAULT '',
 	visibility text NOT NULL DEFAULT 'public',
+	updated timestamptz NOT NULL DEFAULT now(),
 	created timestamptz NOT NULL DEFAULT now(),
 	deleted timestamptz,
 	CONSTRAINT plugins_uq_name UNIQUE NULLS NOT DISTINCT (organization_id,name,deleted),
@@ -1082,7 +1083,9 @@ COMMENT ON COLUMN appstore.plugins.name IS E'Stable identifier, matching the plu
 -- ddl-end --
 COMMENT ON COLUMN appstore.plugins.display_name IS E'Human-readable name shown in the Console, matching the plugin''s definition.yaml metadata.displayName (e.g. "OpenFSC").';
 -- ddl-end --
-COMMENT ON COLUMN appstore.plugins.visibility IS E'RESTRICTED listings are hidden from the public catalog entirely. Nothing writes this until the registry API lands.';
+COMMENT ON COLUMN appstore.plugins.visibility IS E'RESTRICTED listings are hidden from the public catalog entirely. Written by the registry API''s UpdatePlugin.';
+-- ddl-end --
+COMMENT ON COLUMN appstore.plugins.updated IS E'Set by the application on every UpdatePlugin; there is no trigger.';
 -- ddl-end --
 ALTER TABLE appstore.plugins OWNER TO fun_owner;
 -- ddl-end --
@@ -1113,6 +1116,16 @@ CREATE POLICY plugins_update_owner ON appstore.plugins
 	AS PERMISSIVE
 	FOR UPDATE
 	TO fun_fundament_api
+	USING (organization_id = authn.current_organization_id())
+	WITH CHECK (organization_id = authn.current_organization_id());
+-- ddl-end --
+
+-- object: plugins_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_all_registry ON appstore.plugins CASCADE;
+CREATE POLICY plugins_all_registry ON appstore.plugins
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
 	USING (organization_id = authn.current_organization_id())
 	WITH CHECK (organization_id = authn.current_organization_id());
 -- ddl-end --
@@ -1252,6 +1265,73 @@ USING btree
 	published
 )
 WHERE (published IS NOT NULL AND deleted IS NULL);
+-- ddl-end --
+
+-- object: appstore.submissions | type: TABLE --
+-- DROP TABLE IF EXISTS appstore.submissions CASCADE;
+CREATE TABLE appstore.submissions (
+	id uuid NOT NULL DEFAULT uuidv7(),
+	plugin_definition_id uuid NOT NULL,
+	submitter_user_id uuid NOT NULL,
+	reviewer_user_id uuid,
+	rejection_reason text,
+	feedback text NOT NULL DEFAULT '',
+	submitted timestamptz NOT NULL DEFAULT now(),
+	reviewed timestamptz,
+	closed timestamptz,
+	deleted timestamptz,
+	CONSTRAINT submissions_pk PRIMARY KEY (id),
+	CONSTRAINT submissions_ck_rejection_reason CHECK (rejection_reason IS NULL OR rejection_reason IN ('incomplete_metadata', 'duplicate', 'security_concerns', 'naming_guidelines', 'out_of_scope', 'other')),
+	CONSTRAINT submissions_ck_reviewed CHECK ((reviewed IS NULL) = (reviewer_user_id IS NULL)),
+	CONSTRAINT submissions_ck_closed CHECK (reviewed IS NULL OR closed IS NOT NULL)
+);
+-- ddl-end --
+COMMENT ON TABLE appstore.submissions IS E'One review round for one plugin version. The version''s own status column stays authoritative; this table records who submitted, who decided, when and why.';
+-- ddl-end --
+COMMENT ON COLUMN appstore.submissions.reviewer_user_id IS E'Which store reviewers authenticate against is undecided, so this carries no foreign key.';
+-- ddl-end --
+COMMENT ON COLUMN appstore.submissions.submitted IS E'A submission is created by being submitted, so this is also its creation timestamp and there is no separate created column.';
+-- ddl-end --
+COMMENT ON COLUMN appstore.submissions.closed IS E'Set by any terminal outcome. A withdrawal closes a round without a reviewer, which is why this is separate from reviewed.';
+-- ddl-end --
+ALTER TABLE appstore.submissions OWNER TO fun_owner;
+-- ddl-end --
+ALTER TABLE appstore.submissions ENABLE ROW LEVEL SECURITY;
+-- ddl-end --
+
+-- object: submissions_uq_open | type: INDEX --
+-- DROP INDEX IF EXISTS appstore.submissions_uq_open CASCADE;
+CREATE UNIQUE INDEX submissions_uq_open ON appstore.submissions
+USING btree
+(
+	plugin_definition_id
+)
+WHERE (closed IS NULL AND deleted IS NULL);
+-- ddl-end --
+
+-- object: appstore.plugin_allowed_organizations | type: TABLE --
+-- DROP TABLE IF EXISTS appstore.plugin_allowed_organizations CASCADE;
+CREATE TABLE appstore.plugin_allowed_organizations (
+	plugin_id uuid NOT NULL,
+	organization_id uuid NOT NULL,
+	created timestamptz NOT NULL DEFAULT now(),
+	CONSTRAINT plugin_allowed_organizations_pk PRIMARY KEY (plugin_id,organization_id)
+);
+-- ddl-end --
+COMMENT ON TABLE appstore.plugin_allowed_organizations IS E'Organizations permitted to install a RESTRICTED listing. A pure association table, replaced wholesale by UpdatePlugin, so it carries no deleted column.';
+-- ddl-end --
+ALTER TABLE appstore.plugin_allowed_organizations OWNER TO fun_owner;
+-- ddl-end --
+ALTER TABLE appstore.plugin_allowed_organizations ENABLE ROW LEVEL SECURITY;
+-- ddl-end --
+
+-- object: plugin_allowed_organizations_idx_organization_id | type: INDEX --
+-- DROP INDEX IF EXISTS appstore.plugin_allowed_organizations_idx_organization_id CASCADE;
+CREATE INDEX plugin_allowed_organizations_idx_organization_id ON appstore.plugin_allowed_organizations
+USING btree
+(
+	organization_id
+);
 -- ddl-end --
 
 -- object: appstore.presets | type: TABLE --
@@ -1416,8 +1496,14 @@ CREATE TABLE appstore.plugin_documentation_links (
 	title text NOT NULL,
 	url_name text NOT NULL,
 	url text NOT NULL,
+	"position" integer NOT NULL DEFAULT 0,
+	deleted timestamptz,
 	CONSTRAINT plugin_documentation_links_pk PRIMARY KEY (id)
 );
+-- ddl-end --
+COMMENT ON COLUMN appstore.plugin_documentation_links."position" IS E'Render order within a listing, matching appstore.plugin_features.position.';
+-- ddl-end --
+COMMENT ON COLUMN appstore.plugin_documentation_links.deleted IS E'UpdatePlugin replaces links wholesale; a dropped link is soft-deleted rather than removed, per the project-wide rule.';
 -- ddl-end --
 ALTER TABLE appstore.plugin_documentation_links OWNER TO fun_owner;
 -- ddl-end --
@@ -1440,6 +1526,85 @@ CREATE POLICY plugin_documentation_links_select_catalog ON appstore.plugin_docum
 	FOR SELECT
 	TO fun_marketplace_catalog_api
 	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id));
+-- ddl-end --
+
+-- object: plugin_definitions_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_all_registry ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_all_registry ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_definitions.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: submissions_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS submissions_all_registry ON appstore.submissions CASCADE;
+CREATE POLICY submissions_all_registry ON appstore.submissions
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugin_definitions JOIN appstore.plugins ON appstore.plugins.id = appstore.plugin_definitions.plugin_id WHERE appstore.plugin_definitions.id = appstore.submissions.plugin_definition_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugin_definitions JOIN appstore.plugins ON appstore.plugins.id = appstore.plugin_definitions.plugin_id WHERE appstore.plugin_definitions.id = appstore.submissions.plugin_definition_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_features_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_features_all_registry ON appstore.plugin_features CASCADE;
+CREATE POLICY plugin_features_all_registry ON appstore.plugin_features
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_features.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_features.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_documentation_links_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_documentation_links_all_registry ON appstore.plugin_documentation_links CASCADE;
+CREATE POLICY plugin_documentation_links_all_registry ON appstore.plugin_documentation_links
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_documentation_links.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugins_tags_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_tags_all_registry ON appstore.plugins_tags CASCADE;
+CREATE POLICY plugins_tags_all_registry ON appstore.plugins_tags
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugins_tags.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugins_tags.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: categories_plugins_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS categories_plugins_all_registry ON appstore.categories_plugins CASCADE;
+CREATE POLICY categories_plugins_all_registry ON appstore.categories_plugins
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.categories_plugins.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.categories_plugins.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_allowed_organizations_all_registry | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_allowed_organizations_all_registry ON appstore.plugin_allowed_organizations CASCADE;
+CREATE POLICY plugin_allowed_organizations_all_registry ON appstore.plugin_allowed_organizations
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()))
+	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
+-- ddl-end --
+
+-- object: plugin_allowed_organizations_select_api | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_allowed_organizations_select_api ON appstore.plugin_allowed_organizations CASCADE;
+CREATE POLICY plugin_allowed_organizations_select_api ON appstore.plugin_allowed_organizations
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (organization_id = authn.current_organization_id());
 -- ddl-end --
 
 -- object: require_admin | type: TRIGGER --
@@ -2957,6 +3122,27 @@ REFERENCES appstore.plugins (id) MATCH SIMPLE
 ON DELETE NO ACTION ON UPDATE NO ACTION;
 -- ddl-end --
 
+-- object: submissions_fk_plugin_definition | type: CONSTRAINT --
+-- ALTER TABLE appstore.submissions DROP CONSTRAINT IF EXISTS submissions_fk_plugin_definition CASCADE;
+ALTER TABLE appstore.submissions ADD CONSTRAINT submissions_fk_plugin_definition FOREIGN KEY (plugin_definition_id)
+REFERENCES appstore.plugin_definitions (id) MATCH SIMPLE
+ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ddl-end --
+
+-- object: plugin_allowed_organizations_fk_plugin | type: CONSTRAINT --
+-- ALTER TABLE appstore.plugin_allowed_organizations DROP CONSTRAINT IF EXISTS plugin_allowed_organizations_fk_plugin CASCADE;
+ALTER TABLE appstore.plugin_allowed_organizations ADD CONSTRAINT plugin_allowed_organizations_fk_plugin FOREIGN KEY (plugin_id)
+REFERENCES appstore.plugins (id) MATCH SIMPLE
+ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ddl-end --
+
+-- object: plugin_allowed_organizations_fk_organization | type: CONSTRAINT --
+-- ALTER TABLE appstore.plugin_allowed_organizations DROP CONSTRAINT IF EXISTS plugin_allowed_organizations_fk_organization CASCADE;
+ALTER TABLE appstore.plugin_allowed_organizations ADD CONSTRAINT plugin_allowed_organizations_fk_organization FOREIGN KEY (organization_id)
+REFERENCES tenant.organizations (id) MATCH SIMPLE
+ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ddl-end --
+
 -- object: plugins_presets_plugin_id | type: CONSTRAINT --
 -- ALTER TABLE appstore.preset_plugins DROP CONSTRAINT IF EXISTS plugins_presets_plugin_id CASCADE;
 ALTER TABLE appstore.preset_plugins ADD CONSTRAINT plugins_presets_plugin_id FOREIGN KEY (plugin_id)
@@ -3716,6 +3902,14 @@ GRANT SELECT,INSERT,UPDATE
 -- ddl-end --
 
 
+-- object: grant_r_91e308bb11 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.plugin_allowed_organizations
+   TO fun_fundament_api;
+
+-- ddl-end --
+
+
 -- object: grant_raw_799c333c27 | type: PERMISSION --
 GRANT SELECT,INSERT,UPDATE
    ON TABLE appstore.plugin_definitions
@@ -4392,6 +4586,134 @@ GRANT SELECT
 GRANT SELECT
    ON TABLE appstore.preset_plugins
    TO fun_marketplace_catalog_api;
+
+-- ddl-end --
+
+
+-- object: "grant_U_5bbfd58279" | type: PERMISSION --
+GRANT USAGE
+   ON SCHEMA appstore
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: "grant_U_cdf2d83602" | type: PERMISSION --
+GRANT USAGE
+   ON SCHEMA authn
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: "grant_U_58b7ef10c5" | type: PERMISSION --
+GRANT USAGE
+   ON SCHEMA authz
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_a_d6c0a87ef1 | type: PERMISSION --
+GRANT INSERT
+   ON TABLE authz.outbox
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_raw_04e3e3c135 | type: PERMISSION --
+GRANT SELECT,INSERT,UPDATE
+   ON TABLE appstore.plugins
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_raw_9d426cee08 | type: PERMISSION --
+GRANT SELECT,INSERT,UPDATE
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_ra_3148141987 | type: PERMISSION --
+GRANT SELECT,INSERT
+   ON TABLE appstore.submissions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_bb41bdda39 | type: PERMISSION --
+GRANT UPDATE(closed)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_27b9f47f46 | type: PERMISSION --
+GRANT UPDATE(deleted)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_raw_b5e07e3db2 | type: PERMISSION --
+GRANT SELECT,INSERT,UPDATE
+   ON TABLE appstore.plugin_features
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_raw_58e0ba59de | type: PERMISSION --
+GRANT SELECT,INSERT,UPDATE
+   ON TABLE appstore.plugin_documentation_links
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_rad_0cb5215905 | type: PERMISSION --
+GRANT SELECT,INSERT,DELETE
+   ON TABLE appstore.plugins_tags
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_rad_cac5c95b57 | type: PERMISSION --
+GRANT SELECT,INSERT,DELETE
+   ON TABLE appstore.categories_plugins
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_rad_a8c38567c0 | type: PERMISSION --
+GRANT SELECT,INSERT,DELETE
+   ON TABLE appstore.plugin_allowed_organizations
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_ra_478b81c02e | type: PERMISSION --
+GRANT SELECT,INSERT
+   ON TABLE appstore.tags
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_c0d2d103bf | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.categories
+   TO fun_marketplace_registry_api;
 
 -- ddl-end --
 

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1092,15 +1092,6 @@ ALTER TABLE appstore.plugins OWNER TO fun_owner;
 ALTER TABLE appstore.plugins ENABLE ROW LEVEL SECURITY;
 -- ddl-end --
 
--- object: plugins_select_all | type: POLICY --
--- DROP POLICY IF EXISTS plugins_select_all ON appstore.plugins CASCADE;
-CREATE POLICY plugins_select_all ON appstore.plugins
-	AS PERMISSIVE
-	FOR SELECT
-	TO fun_fundament_api
-	USING (true);
--- ddl-end --
-
 -- object: plugins_insert_owner | type: POLICY --
 -- DROP POLICY IF EXISTS plugins_insert_owner ON appstore.plugins CASCADE;
 CREATE POLICY plugins_insert_owner ON appstore.plugins
@@ -1307,6 +1298,15 @@ USING btree
 	plugin_definition_id
 )
 WHERE (closed IS NULL AND deleted IS NULL);
+-- ddl-end --
+
+-- object: submissions_idx_plugin_definition_id | type: INDEX --
+-- DROP INDEX IF EXISTS appstore.submissions_idx_plugin_definition_id CASCADE;
+CREATE INDEX submissions_idx_plugin_definition_id ON appstore.submissions
+USING btree
+(
+	plugin_definition_id
+);
 -- ddl-end --
 
 -- object: appstore.plugin_allowed_organizations | type: TABLE --
@@ -1605,6 +1605,15 @@ CREATE POLICY plugin_allowed_organizations_select_api ON appstore.plugin_allowed
 	FOR SELECT
 	TO fun_fundament_api
 	USING (organization_id = authn.current_organization_id());
+-- ddl-end --
+
+-- object: plugins_select_all | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_select_all ON appstore.plugins CASCADE;
+CREATE POLICY plugins_select_all ON appstore.plugins
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING (visibility = 'public' OR organization_id = authn.current_organization_id() OR EXISTS (SELECT 1 FROM appstore.plugin_allowed_organizations WHERE appstore.plugin_allowed_organizations.plugin_id = appstore.plugins.id AND appstore.plugin_allowed_organizations.organization_id = authn.current_organization_id()));
 -- ddl-end --
 
 -- object: require_admin | type: TRIGGER --
@@ -3122,6 +3131,13 @@ REFERENCES appstore.plugins (id) MATCH SIMPLE
 ON DELETE NO ACTION ON UPDATE NO ACTION;
 -- ddl-end --
 
+-- object: submissions_fk_submitter_user | type: CONSTRAINT --
+-- ALTER TABLE appstore.submissions DROP CONSTRAINT IF EXISTS submissions_fk_submitter_user CASCADE;
+ALTER TABLE appstore.submissions ADD CONSTRAINT submissions_fk_submitter_user FOREIGN KEY (submitter_user_id)
+REFERENCES tenant.users (id) MATCH SIMPLE
+ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ddl-end --
+
 -- object: submissions_fk_plugin_definition | type: CONSTRAINT --
 -- ALTER TABLE appstore.submissions DROP CONSTRAINT IF EXISTS submissions_fk_plugin_definition CASCADE;
 ALTER TABLE appstore.submissions ADD CONSTRAINT submissions_fk_plugin_definition FOREIGN KEY (plugin_definition_id)
@@ -4630,16 +4646,48 @@ GRANT SELECT,INSERT,UPDATE
 -- ddl-end --
 
 
--- object: grant_raw_9d426cee08 | type: PERMISSION --
-GRANT SELECT,INSERT,UPDATE
+-- object: grant_ra_9d426cee08 | type: PERMISSION --
+GRANT SELECT,INSERT
    ON TABLE appstore.plugin_definitions
    TO fun_marketplace_registry_api;
 
 -- ddl-end --
 
 
--- object: grant_ra_3148141987 | type: PERMISSION --
-GRANT SELECT,INSERT
+-- object: grant_w_88f4e8e148 | type: PERMISSION --
+GRANT UPDATE(status)
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_fc29c55d90 | type: PERMISSION --
+GRANT UPDATE(deleted)
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_3148141987 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.submissions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_a_2ea3dd2a4e | type: PERMISSION --
+GRANT INSERT(plugin_definition_id)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: grant_a_31b595f1a1 | type: PERMISSION --
+GRANT INSERT(submitter_user_id)
    ON TABLE appstore.submissions
    TO fun_marketplace_registry_api;
 

--- a/db/migrations/038_marketplace-registry.up.sql
+++ b/db/migrations/038_marketplace-registry.up.sql
@@ -1,0 +1,327 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+-- Hand-added statements. trek's diff emits table grants but not schema-level or
+-- column-level permissions, even when they are modelled in the .dbm, so
+-- everything in this block must be re-added whenever this migration is
+-- regenerated.
+--
+-- Schema USAGE for the registry role:
+--   appstore: without it every table grant below is unusable.
+--   authn: the role's own policies call authn.current_organization_id().
+--   authz: appstore.plugins carries the plugins_outbox trigger, which runs
+--     authz.plugins_sync_trigger() SECURITY INVOKER to queue an OpenFGA sync. Any
+--     role that writes a plugin therefore writes authz.outbox as itself, so
+--     without this every INSERT and UPDATE fails with "permission denied for
+--     schema authz".
+GRANT USAGE ON SCHEMA "appstore" TO "fun_marketplace_registry_api";
+GRANT USAGE ON SCHEMA "authn" TO "fun_marketplace_registry_api";
+GRANT USAGE ON SCHEMA "authz" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."categories" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "categories_plugins_all_registry" ON "appstore"."categories_plugins"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = categories_plugins.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = categories_plugins.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT DELETE ON "appstore"."categories_plugins" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."categories_plugins" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."categories_plugins" TO "fun_marketplace_registry_api";
+
+CREATE TABLE "appstore"."plugin_allowed_organizations" (
+	"plugin_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"created" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE POLICY "plugin_allowed_organizations_all_registry" ON "appstore"."plugin_allowed_organizations"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_allowed_organizations.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_allowed_organizations.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+CREATE POLICY "plugin_allowed_organizations_select_api" ON "appstore"."plugin_allowed_organizations"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_fundament_api
+	USING ((organization_id = authn.current_organization_id()));
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON "appstore"."plugin_allowed_organizations" TO "fun_fundament_api";
+
+GRANT DELETE ON "appstore"."plugin_allowed_organizations" TO "fun_marketplace_registry_api";
+
+GRANT INSERT ON "appstore"."plugin_allowed_organizations" TO "fun_marketplace_registry_api";
+
+GRANT SELECT ON "appstore"."plugin_allowed_organizations" TO "fun_marketplace_registry_api";
+
+CREATE UNIQUE INDEX plugin_allowed_organizations_pk ON appstore.plugin_allowed_organizations USING btree (plugin_id, organization_id);
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" ADD CONSTRAINT "plugin_allowed_organizations_pk" PRIMARY KEY USING INDEX "plugin_allowed_organizations_pk";
+
+CREATE INDEX plugin_allowed_organizations_idx_organization_id ON appstore.plugin_allowed_organizations USING btree (organization_id);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugin_definitions_all_registry" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_definitions.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_definitions.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT UPDATE ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
+
+ALTER TABLE "appstore"."plugin_documentation_links" ADD COLUMN "deleted" timestamp with time zone;
+
+ALTER TABLE "appstore"."plugin_documentation_links" ADD COLUMN "position" integer DEFAULT 0 NOT NULL;
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugin_documentation_links_all_registry" ON "appstore"."plugin_documentation_links"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_documentation_links.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_documentation_links.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."plugin_documentation_links" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugin_documentation_links" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT UPDATE ON "appstore"."plugin_documentation_links" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugin_features_all_registry" ON "appstore"."plugin_features"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_features.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugin_features.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."plugin_features" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugin_features" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT UPDATE ON "appstore"."plugin_features" TO "fun_marketplace_registry_api";
+
+ALTER TABLE "appstore"."plugins" ADD COLUMN "updated" timestamp with time zone DEFAULT now() NOT NULL;
+
+-- Hand-added: the column default stamps every pre-existing row with the
+-- migration timestamp, so registry.v1.Plugin.updated would report the whole
+-- catalog as just-updated at deploy. Nothing has been updated since it was
+-- created, so say that. Re-add whenever this migration is regenerated.
+UPDATE appstore.plugins SET updated = created;
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugins_all_registry" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((organization_id = authn.current_organization_id()))
+	WITH CHECK ((organization_id = authn.current_organization_id()));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."plugins" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugins" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT UPDATE ON "appstore"."plugins" TO "fun_marketplace_registry_api";
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" ADD CONSTRAINT "plugin_allowed_organizations_fk_plugin" FOREIGN KEY (plugin_id) REFERENCES appstore.plugins(id) NOT VALID;
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" VALIDATE CONSTRAINT "plugin_allowed_organizations_fk_plugin";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugins_tags_all_registry" ON "appstore"."plugins_tags"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugins_tags.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.id = plugins_tags.plugin_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT DELETE ON "appstore"."plugins_tags" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."plugins_tags" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugins_tags" TO "fun_marketplace_registry_api";
+
+CREATE TABLE "appstore"."submissions" (
+	"id" uuid DEFAULT uuidv7() NOT NULL,
+	"plugin_definition_id" uuid NOT NULL,
+	"submitter_user_id" uuid NOT NULL,
+	"reviewer_user_id" uuid,
+	"rejection_reason" text COLLATE "pg_catalog"."default",
+	"feedback" text COLLATE "pg_catalog"."default" DEFAULT ''::text NOT NULL,
+	"submitted" timestamp with time zone DEFAULT now() NOT NULL,
+	"reviewed" timestamp with time zone,
+	"closed" timestamp with time zone,
+	"deleted" timestamp with time zone
+);
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_ck_closed" CHECK(((reviewed IS NULL) OR (closed IS NOT NULL)));
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_ck_rejection_reason" CHECK(((rejection_reason IS NULL) OR (rejection_reason = ANY (ARRAY['incomplete_metadata'::text, 'duplicate'::text, 'security_concerns'::text, 'naming_guidelines'::text, 'out_of_scope'::text, 'other'::text]))));
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_ck_reviewed" CHECK(((reviewed IS NULL) = (reviewer_user_id IS NULL)));
+
+CREATE POLICY "submissions_all_registry" ON "appstore"."submissions"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_registry_api
+	USING ((EXISTS ( SELECT 1
+   FROM (appstore.plugin_definitions
+     JOIN appstore.plugins ON ((plugins.id = plugin_definitions.plugin_id)))
+  WHERE ((plugin_definitions.id = submissions.plugin_definition_id) AND (plugins.organization_id = authn.current_organization_id())))))
+	WITH CHECK ((EXISTS ( SELECT 1
+   FROM (appstore.plugin_definitions
+     JOIN appstore.plugins ON ((plugins.id = plugin_definitions.plugin_id)))
+  WHERE ((plugin_definitions.id = submissions.plugin_definition_id) AND (plugins.organization_id = authn.current_organization_id())))));
+
+ALTER TABLE "appstore"."submissions" ENABLE ROW LEVEL SECURITY;
+
+GRANT INSERT ON "appstore"."submissions" TO "fun_marketplace_registry_api";
+
+GRANT SELECT ON "appstore"."submissions" TO "fun_marketplace_registry_api";
+
+-- Column-scoped so WithdrawPluginVersion can close a round and a plugin delete
+-- can soft-delete one, while reviewed, reviewer_user_id, rejection_reason and
+-- feedback stay out of the publisher's reach.
+GRANT UPDATE ("closed") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
+GRANT UPDATE ("deleted") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_fk_plugin_definition" FOREIGN KEY (plugin_definition_id) REFERENCES appstore.plugin_definitions(id) NOT VALID;
+
+ALTER TABLE "appstore"."submissions" VALIDATE CONSTRAINT "submissions_fk_plugin_definition";
+
+CREATE UNIQUE INDEX submissions_pk ON appstore.submissions USING btree (id);
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_pk" PRIMARY KEY USING INDEX "submissions_pk";
+
+CREATE UNIQUE INDEX submissions_uq_open ON appstore.submissions USING btree (plugin_definition_id) WHERE ((closed IS NULL) AND (deleted IS NULL));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "appstore"."tags" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."tags" TO "fun_marketplace_registry_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT INSERT ON "authz"."outbox" TO "fun_marketplace_registry_api";
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" ADD CONSTRAINT "plugin_allowed_organizations_fk_organization" FOREIGN KEY (organization_id) REFERENCES tenant.organizations(id) NOT VALID;
+
+ALTER TABLE "appstore"."plugin_allowed_organizations" VALIDATE CONSTRAINT "plugin_allowed_organizations_fk_organization";
+
+
+-- Statements generated automatically, please review:
+ALTER TABLE appstore.plugin_allowed_organizations OWNER TO fun_owner;
+ALTER TABLE appstore.submissions OWNER TO fun_owner;

--- a/db/migrations/038_marketplace-registry.up.sql
+++ b/db/migrations/038_marketplace-registry.up.sql
@@ -1,10 +1,10 @@
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 
--- Hand-added statements. trek's diff emits table grants but not schema-level or
--- column-level permissions, even when they are modelled in the .dbm, so
--- everything in this block must be re-added whenever this migration is
--- regenerated.
+-- Hand-added statements. trek's diff emits table-wide grants but not
+-- schema-level or column-level ones, even when they are modelled in the .dbm,
+-- so every statement marked "hand-added" in this file must be re-added whenever
+-- the migration is regenerated.
 --
 -- Schema USAGE for the registry role:
 --   appstore: without it every table grant below is unusable.
@@ -115,10 +115,12 @@ GRANT INSERT ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api
 */
 GRANT SELECT ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
 
-/* Hazards:
- - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
-*/
-GRANT UPDATE ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
+-- Hand-added, column-scoped. registry.v1 only ever moves a version's status
+-- (DRAFT/CHANGES_REQUESTED/WITHDRAWN -> PENDING -> WITHDRAWN) and soft-deletes
+-- it. published, hash and manifest are the consent record FUN-20 makes
+-- immutable once approved, so the grant, not just stack 3's Go, refuses them.
+GRANT UPDATE ("status") ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
+GRANT UPDATE ("deleted") ON "appstore"."plugin_definitions" TO "fun_marketplace_registry_api";
 
 ALTER TABLE "appstore"."plugin_documentation_links" ADD COLUMN "deleted" timestamp with time zone;
 
@@ -187,8 +189,16 @@ ALTER TABLE "appstore"."plugins" ADD COLUMN "updated" timestamp with time zone D
 -- Hand-added: the column default stamps every pre-existing row with the
 -- migration timestamp, so registry.v1.Plugin.updated would report the whole
 -- catalog as just-updated at deploy. Nothing has been updated since it was
--- created, so say that. Re-add whenever this migration is regenerated.
+-- created, so say that.
+--
+-- plugins_outbox is AFTER INSERT OR UPDATE FOR EACH ROW, so an unguarded
+-- backfill queues one authz.outbox row and one pg_notify per plugin: a burst of
+-- sync events for a change nobody made, in one statement under the
+-- statement_timeout set at the top of this file. Correcting stored data is not
+-- a change OpenFGA needs to hear about, so the trigger stays off across it.
+ALTER TABLE appstore.plugins DISABLE TRIGGER plugins_outbox;
 UPDATE appstore.plugins SET updated = created;
+ALTER TABLE appstore.plugins ENABLE TRIGGER plugins_outbox;
 
 /* Hazards:
  - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
@@ -199,6 +209,14 @@ CREATE POLICY "plugins_all_registry" ON "appstore"."plugins"
 	TO fun_marketplace_registry_api
 	USING ((organization_id = authn.current_organization_id()))
 	WITH CHECK ((organization_id = authn.current_organization_id()));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Altering a policy could cause queries to fail if not correctly configured or allow unauthorized access to data.
+*/
+ALTER POLICY "plugins_select_all" ON "appstore"."plugins"
+	USING (((visibility = 'public'::text) OR (organization_id = authn.current_organization_id()) OR (EXISTS ( SELECT 1
+   FROM appstore.plugin_allowed_organizations
+  WHERE ((plugin_allowed_organizations.plugin_id = plugins.id) AND (plugin_allowed_organizations.organization_id = authn.current_organization_id()))))));
 
 /* Hazards:
  - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
@@ -282,13 +300,15 @@ CREATE POLICY "submissions_all_registry" ON "appstore"."submissions"
 
 ALTER TABLE "appstore"."submissions" ENABLE ROW LEVEL SECURITY;
 
-GRANT INSERT ON "appstore"."submissions" TO "fun_marketplace_registry_api";
-
 GRANT SELECT ON "appstore"."submissions" TO "fun_marketplace_registry_api";
 
--- Column-scoped so WithdrawPluginVersion can close a round and a plugin delete
--- can soft-delete one, while reviewed, reviewer_user_id, rejection_reason and
--- feedback stay out of the publisher's reach.
+-- Hand-added, column-scoped on both paths. A round is opened with nothing but
+-- the version it reviews and who submitted it, and afterwards the publisher may
+-- only close or soft-delete it. reviewed, reviewer_user_id, rejection_reason and
+-- feedback are the reviewer's alone, so a round cannot be inserted pre-approved
+-- any more than it can be updated into that state.
+GRANT INSERT ("plugin_definition_id") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
+GRANT INSERT ("submitter_user_id") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
 GRANT UPDATE ("closed") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
 GRANT UPDATE ("deleted") ON "appstore"."submissions" TO "fun_marketplace_registry_api";
 
@@ -299,6 +319,8 @@ ALTER TABLE "appstore"."submissions" VALIDATE CONSTRAINT "submissions_fk_plugin_
 CREATE UNIQUE INDEX submissions_pk ON appstore.submissions USING btree (id);
 
 ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_pk" PRIMARY KEY USING INDEX "submissions_pk";
+
+CREATE INDEX submissions_idx_plugin_definition_id ON appstore.submissions USING btree (plugin_definition_id);
 
 CREATE UNIQUE INDEX submissions_uq_open ON appstore.submissions USING btree (plugin_definition_id) WHERE ((closed IS NULL) AND (deleted IS NULL));
 
@@ -320,6 +342,10 @@ GRANT INSERT ON "authz"."outbox" TO "fun_marketplace_registry_api";
 ALTER TABLE "appstore"."plugin_allowed_organizations" ADD CONSTRAINT "plugin_allowed_organizations_fk_organization" FOREIGN KEY (organization_id) REFERENCES tenant.organizations(id) NOT VALID;
 
 ALTER TABLE "appstore"."plugin_allowed_organizations" VALIDATE CONSTRAINT "plugin_allowed_organizations_fk_organization";
+
+ALTER TABLE "appstore"."submissions" ADD CONSTRAINT "submissions_fk_submitter_user" FOREIGN KEY (submitter_user_id) REFERENCES tenant.users(id) NOT VALID;
+
+ALTER TABLE "appstore"."submissions" VALIDATE CONSTRAINT "submissions_fk_submitter_user";
 
 
 -- Statements generated automatically, please review:

--- a/db/trek.yaml
+++ b/db/trek.yaml
@@ -10,6 +10,7 @@ roles:
   - name: fun_authz_worker
   - name: fun_dcim_api
   - name: fun_marketplace_catalog_api
+  - name: fun_marketplace_registry_api
 outputs:
   - sql
 templates:

--- a/marketplace-api/pkg/db/gen/plugin.sql.go
+++ b/marketplace-api/pkg/db/gen/plugin.sql.go
@@ -155,8 +155,8 @@ SELECT
   appstore.plugin_documentation_links.url_name,
   appstore.plugin_documentation_links.url
 FROM appstore.plugin_documentation_links
-WHERE appstore.plugin_documentation_links.plugin_id = $1::uuid
-ORDER BY appstore.plugin_documentation_links.title
+WHERE appstore.plugin_documentation_links.plugin_id = $1::uuid AND appstore.plugin_documentation_links.deleted IS NULL
+ORDER BY appstore.plugin_documentation_links.position, appstore.plugin_documentation_links.title
 `
 
 type PluginDocumentationLinksListParams struct {

--- a/marketplace-api/pkg/db/plugin.sql
+++ b/marketplace-api/pkg/db/plugin.sql
@@ -165,8 +165,8 @@ SELECT
   appstore.plugin_documentation_links.url_name,
   appstore.plugin_documentation_links.url
 FROM appstore.plugin_documentation_links
-WHERE appstore.plugin_documentation_links.plugin_id = sqlc.arg('plugin_id')::uuid
-ORDER BY appstore.plugin_documentation_links.title;
+WHERE appstore.plugin_documentation_links.plugin_id = sqlc.arg('plugin_id')::uuid AND appstore.plugin_documentation_links.deleted IS NULL
+ORDER BY appstore.plugin_documentation_links.position, appstore.plugin_documentation_links.title;
 
 -- name: PluginVersionListByPluginID :many
 -- published IS NOT NULL is explicit because plugin_definitions' policy no longer

--- a/organization-api/pkg/db/gen/models.sqlc.go
+++ b/organization-api/pkg/db/gen/models.sqlc.go
@@ -9,14 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type AppstorePluginDocumentationLink struct {
-	ID       uuid.UUID
-	PluginID uuid.UUID
-	Title    string
-	UrlName  string
-	Url      string
-}
-
 type AppstorePreset struct {
 	ID          uuid.UUID
 	Name        string

--- a/organization-api/pkg/db/gen/plugin.sql.go
+++ b/organization-api/pkg/db/gen/plugin.sql.go
@@ -87,23 +87,31 @@ func (q *Queries) PluginCategoriesListByPluginID(ctx context.Context, arg Plugin
 const pluginDocumentationLinksList = `-- name: PluginDocumentationLinksList :many
 SELECT id, plugin_id, title, url_name, url
 FROM appstore.plugin_documentation_links
-WHERE plugin_id = $1
-ORDER BY title
+WHERE plugin_id = $1 AND deleted IS NULL
+ORDER BY position, title
 `
 
 type PluginDocumentationLinksListParams struct {
 	PluginID uuid.UUID
 }
 
-func (q *Queries) PluginDocumentationLinksList(ctx context.Context, arg PluginDocumentationLinksListParams) ([]AppstorePluginDocumentationLink, error) {
+type PluginDocumentationLinksListRow struct {
+	ID       uuid.UUID
+	PluginID uuid.UUID
+	Title    string
+	UrlName  string
+	Url      string
+}
+
+func (q *Queries) PluginDocumentationLinksList(ctx context.Context, arg PluginDocumentationLinksListParams) ([]PluginDocumentationLinksListRow, error) {
 	rows, err := q.db.Query(ctx, pluginDocumentationLinksList, arg.PluginID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []AppstorePluginDocumentationLink
+	var items []PluginDocumentationLinksListRow
 	for rows.Next() {
-		var i AppstorePluginDocumentationLink
+		var i PluginDocumentationLinksListRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.PluginID,

--- a/organization-api/pkg/db/plugin.sql
+++ b/organization-api/pkg/db/plugin.sql
@@ -72,5 +72,5 @@ ORDER BY c.name;
 -- name: PluginDocumentationLinksList :many
 SELECT id, plugin_id, title, url_name, url
 FROM appstore.plugin_documentation_links
-WHERE plugin_id = $1
-ORDER BY title;
+WHERE plugin_id = $1 AND deleted IS NULL
+ORDER BY position, title;

--- a/organization-api/pkg/organization/plugin_get.go
+++ b/organization-api/pkg/organization/plugin_get.go
@@ -34,7 +34,7 @@ func (s *Server) GetPluginDetail(
 	var (
 		tags       []db.PluginTagsListByPluginIDRow
 		categories []db.PluginCategoriesListByPluginIDRow
-		docLinks   []db.AppstorePluginDocumentationLink
+		docLinks   []db.PluginDocumentationLinksListRow
 	)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -79,7 +79,7 @@ func pluginDetailFromRow(
 	plugin *db.PluginGetByIDRow,
 	tags []db.PluginTagsListByPluginIDRow,
 	categories []db.PluginCategoriesListByPluginIDRow,
-	docLinks []db.AppstorePluginDocumentationLink,
+	docLinks []db.PluginDocumentationLinksListRow,
 ) *organizationv1.PluginDetail {
 	protoTags := make([]*organizationv1.Tag, 0, len(tags))
 	for _, t := range tags {


### PR DESCRIPTION
Adds what appstore lacks for registry.v1.PublicationService (FUN-20).
The listing fields, visibility and the version status vocabulary already
shipped with the catalog schema; what was missing is the review record,
the organization allow-list and a write role.

appstore.submissions is one row per review round rather than one per
version, so a resubmission after CHANGES_REQUESTED leaves the previous
round readable instead of overwriting it. It deliberately does not
repeat plugin_definitions.status — a second copy of the same state is a
second chance for it to drift — and carries no plugin_id or
organization_id, both being reachable through plugin_definition_id.
closed is separate from reviewed because a withdrawal closes a round
with no reviewer, and submissions_uq_open is a partial unique index so
at most one round per version is open while closed rounds accumulate.

plugins.updated backs Plugin.updated, which had nothing to read.
plugin_documentation_links gains deleted and position: it was the only
appstore table without a deleted column, which put UpdatePlugin's
full-replacement semantics in conflict with the soft-delete rule.

plugin_allowed_organizations has no deleted column on purpose. It is a
pure association table replaced wholesale by UpdatePlugin, so
membership is not an auditable grant the way a trust label is.

fun_marketplace_registry_api gets ownership-scoped ALL policies reaching
the owning organization through plugin_id, with USING and WITH CHECK
kept separate so an owner cannot reassign a plugin to another
organization. Its policies reference plugins in one direction only,
avoiding the mutual-reference recursion (SQLSTATE 42P17) the catalog
policies had to work around.

The policies gate ownership and nothing else — deliberately no
deleted IS NULL. Under FOR ALL that predicate is also the USING clause
of an UPDATE, so the moment a statement sets deleted the row stops
satisfying it and the soft delete is refused. Lifecycle filtering is
therefore the queries' job in stack 3/3, and the policies stay a pure
tenancy boundary.

The three GRANT USAGE ON SCHEMA statements are hand-added at the top of
the migration. Modelling them in the .dbm is not enough: trek's diff
emits table grants but skips schema-level ones, so they must be re-added
whenever this migration is regenerated — the same caveat 035 carries.
Without appstore the table grants are unusable and without authn the
policies cannot call authn.current_organization_id(). authz is the
non-obvious one: appstore.plugins carries the plugins_outbox trigger,
which runs authz.plugins_sync_trigger() SECURITY INVOKER, so any role
that writes a plugin writes authz.outbox as itself.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>