### PR TITLE
ci: publish the plugin-controller image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,9 @@ jobs:
           - image-name: kube-api-proxy
             dockerfile: kube-api-proxy/Dockerfile
             context: "."
+          - image-name: plugin-controller
+            dockerfile: plugin-controller/Dockerfile
+            context: "."
           - image-name: plugin-proxy
             dockerfile: plugin-proxy/Dockerfile
             context: "."


### PR DESCRIPTION
plugin-controller was the only image in the chart's `images:` block without a build job, so `ghcr.io/fundament-oss/fundament/plugin-controller` had never been pushed. Anonymous pulls returned DENIED — which looks like a private package but is the same response GHCR gives for one that doesn't exist. This broke the shoot-side plugin machinery, since cluster-worker provisions that image onto tenant shoots via `pluginController.shootImage` and shoot nodes hold no registry credentials.

- Add `plugin-controller` to the build matrix in `.github/workflows/build.yml`.

Verified on this PR's build: the package is created public like the rest of the set, and `ghcr.io/fundament-oss/fundament/plugin-controller:latest` is now anonymously pullable. No manual visibility change is needed.
