### PR TITLE
feat(k3d): enable Kubernetes API audit logging on both local clusters

### DIFF
--- a/deploy/k3d/audit-policy.yaml
+++ b/deploy/k3d/audit-policy.yaml
@@ -1,0 +1,89 @@
+# Kubernetes API audit policy for the local k3d clusters, so log-analysis tooling has real
+# events to develop against. Sized for a laptop, not a production audit trail.
+# Levels: None drops, Metadata keeps who/what/when, Request adds the sent object,
+# RequestResponse adds what the API server returned. First matching rule wins.
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  # users and userGroups within one rule are AND-ed, so identity classes need separate rules.
+  #
+  # Reads by the control plane: high volume, no detection value. Their writes fall through to
+  # the rules below, so nothing a controller *changes* is lost.
+  - level: None
+    verbs: ["get", "list", "watch"]
+    users:
+      - system:apiserver
+      - system:kube-scheduler
+      - system:kube-controller-manager
+      - system:kube-proxy
+      - system:volume-scheduler
+      - system:k3s-supervisor
+      - system:k3s-controller
+      - system:serviceaccount:kube-system:generic-garbage-collector
+
+  - level: None
+    verbs: ["get", "list", "watch"]
+    userGroups: ["system:nodes"]
+
+  - level: None
+    verbs: ["get", "list", "watch"]
+    userGroups: ["system:serviceaccounts:kube-system"]
+
+  # Leader election and endpoint churn: written constantly by healthy components, and an
+  # attacker gains nothing by touching them.
+  - level: None
+    resources:
+      - group: "coordination.k8s.io"
+        resources: ["leases"]
+      - group: ""
+        resources: ["endpoints", "events"]
+      - group: "discovery.k8s.io"
+        resources: ["endpointslices"]
+
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /livez*
+      - /readyz*
+      - /version
+      - /metrics
+      - /openapi*
+      - /api*
+
+  # RBAC and admission, with bodies. Metadata alone says "a binding was created"; the body says
+  # which role it granted and to whom, which is the difference between noticing a change and
+  # knowing it was a privilege escalation. Admission config is here because disabling a webhook
+  # is how an attacker turns off the cluster's own guardrails.
+  - level: RequestResponse
+    resources:
+      - group: "rbac.authorization.k8s.io"
+        resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
+      - group: "admissionregistration.k8s.io"
+        resources: ["*"]
+
+  # ServiceAccount writes, with bodies: a new identity in the cluster, and the usual way an
+  # attacker persists after the way in is closed.
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: ""
+        resources: ["serviceaccounts"]
+
+  # Token requests: who minted a credential for which identity, and for how long.
+  # Request, never RequestResponse -- the response body is the token itself.
+  - level: Request
+    resources:
+      - group: ""
+        resources: ["serviceaccounts/token"]
+
+  # Secrets and ConfigMaps: which secret was read, by whom, when -- never its contents.
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: ["secrets", "configmaps"]
+
+  # Everything else, including failed and unauthenticated requests: who tried what, and whether
+  # the API server allowed it. This is what a password-spray or an enumeration sweep looks like.
+  - level: Metadata

--- a/deploy/k3d/config.yaml
+++ b/deploy/k3d/config.yaml
@@ -30,6 +30,21 @@ options:
       - arg: --kube-apiserver-arg=feature-gates=WatchList=true
         nodeFilters:
           - server:*
+      # Audit logging for local log-analysis testing, not a production audit trail.
+      - arg: --kube-apiserver-arg=audit-policy-file=/etc/rancher/k3s/audit-policy.yaml
+        nodeFilters:
+          - server:*
+      - arg: --kube-apiserver-arg=audit-log-path=/var/log/k8s-audit/audit.log
+        nodeFilters:
+          - server:*
+      # Kept small: a local cluster has no reason to hold audit history.
+      # maxbackup 0 would mean "retain every rotation", so 1 is the floor.
+      - arg: --kube-apiserver-arg=audit-log-maxsize=10
+        nodeFilters:
+          - server:*
+      - arg: --kube-apiserver-arg=audit-log-maxbackup=1
+        nodeFilters:
+          - server:*
 registries:
   create:
     name: "registry.localhost"
@@ -41,6 +56,7 @@ registries:
         endpoint:
           - http://registry.localhost:5000
 volumes:
+  - volume: ${PWD}/deploy/k3d/audit-policy.yaml:/etc/rancher/k3s/audit-policy.yaml
   - volume: ${PWD}/deploy/k3d/resources/cloudnative-pg.yaml:/var/lib/rancher/k3s/server/manifests/cloudnative-pg.yaml
   - volume: ${PWD}/deploy/k3d/resources/cert-manager.yaml:/var/lib/rancher/k3s/server/manifests/cert-manager.yaml
   - volume: ${PWD}/deploy/k3d/resources/ingress-nginx.yaml:/var/lib/rancher/k3s/server/manifests/ingress-nginx.yaml

--- a/plugins/sandbox/k3d-config.yaml
+++ b/plugins/sandbox/k3d-config.yaml
@@ -13,6 +13,21 @@ options:
       - arg: --kube-apiserver-arg=feature-gates=WatchList=true
         nodeFilters:
           - server:*
+      # Audit logging for local log-analysis testing, not a production audit trail.
+      - arg: --kube-apiserver-arg=audit-policy-file=/etc/rancher/k3s/audit-policy.yaml
+        nodeFilters:
+          - server:*
+      - arg: --kube-apiserver-arg=audit-log-path=/var/log/k8s-audit/audit.log
+        nodeFilters:
+          - server:*
+      # Kept small: a local cluster has no reason to hold audit history.
+      # maxbackup 0 would mean "retain every rotation", so 1 is the floor.
+      - arg: --kube-apiserver-arg=audit-log-maxsize=10
+        nodeFilters:
+          - server:*
+      - arg: --kube-apiserver-arg=audit-log-maxbackup=1
+        nodeFilters:
+          - server:*
 registries:
   create:
     name: "plugin-registry.localhost"
@@ -24,4 +39,5 @@ registries:
         endpoint:
           - http://plugin-registry.localhost:5000
 volumes:
+  - volume: ${PWD}/../deploy/k3d/audit-policy.yaml:/etc/rancher/k3s/audit-policy.yaml
   - volume: ${PWD}/../charts/fundament/crds/plugininstallations.plugins.fundament.io.yaml:/var/lib/rancher/k3s/server/manifests/plugininstallations.plugins.fundament.io.yaml


### PR DESCRIPTION
The local k3d clusters emit no API audit events, so there is nothing for log-analysis tooling to develop
  against. This adds an audit policy and a bounded audit log to the platform cluster and the plugin sandbox.
  It is meant for local testing, not as a production audit trail.

  **k3s accepts these flags only at cluster-creation time**, so an existing cluster has to be recreated to
  pick them up: `just cluster-delete && just cluster-create`, and the same under `plugins/`.

  ## What the policy keeps

  | Kept | At what level | Why |
  |---|---|---|
  | RBAC, admission config, ServiceAccount writes | request + response body | the body is the difference
  between knowing a binding was created and knowing which role it granted to whom |
  | Token requests | request only | the response body is the token itself |
  | Secrets and ConfigMaps | metadata | which secret, by whom, when — never contents |
  | everything else, incl. failed and unauthenticated requests | metadata | what a spray or an enumeration
  sweep looks like |

  Control-plane and kube-system reads, leases, endpoints, events and health endpoints are dropped. They are
  high volume with nothing to read, and the writes those same components make still fall through, so nothing
  a controller changes is lost.

  ## Size on disk

  Capped at one rotation of 10 MB per cluster. `maxbackup` is `1` deliberately: Kubernetes reads `0` as
  *retain every rotation*, which is unbounded.

  Both clusters mount `deploy/k3d/audit-policy.yaml`, so the two cannot drift.

  ## Testing

  Recreate both clusters, then `docker exec k3d-fundament-server-0 tail -f /var/log/k8s-audit/audit.log` —
  and the same for `k3d-fundament-plugin-server-0`. Creating a ClusterRoleBinding should appear with its
  request body; reading a Secret should appear as metadata with no contents.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)