### PR TITLE
ci: publish the Helm chart as a versioned OCI artifact

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,6 +45,7 @@ jobs:
         run: echo "ref_name=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}
@@ -52,3 +53,20 @@ jobs:
           build-args: ${{ inputs.build-args }}
           push: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
           tags: ${{ env.IMAGE_PREFIX }}/${{ inputs.image-name }}:latest,${{ env.IMAGE_PREFIX }}/${{ inputs.image-name }}:${{ github.sha }}-${{ steps.sanitize.outputs.ref_name }}-${{ github.run_number }}
+
+      # publish-chart stamps the chart with digests rather than tags, and matrix
+      # jobs cannot aggregate outputs - so each build leaves its digest as an
+      # artifact for the chart job to collect.
+      - name: Record digest
+        if: steps.build.outputs.digest != ''
+        run: |
+          mkdir -p digest
+          echo '${{ steps.build.outputs.digest }}' > "digest/${{ inputs.image-name }}"
+
+      - name: Upload digest
+        if: steps.build.outputs.digest != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ inputs.image-name }}
+          path: digest/
+          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       context: ${{ matrix.context }}
       build-args: ${{ matrix.build-args }}
 
-  # Packages the chart with every image tag stamped into values.yaml, so one
+  # Packages the chart with every image digest stamped into values.yaml, so one
   # version string names the chart and the exact images it deploys.
   #
   # This lives in build.yml rather than its own workflow because
@@ -168,8 +168,6 @@ jobs:
       - name: Compute chart version
         id: version
         run: |
-          REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
-          IMAGE_TAG="${{ github.sha }}-${REF_NAME}-${{ github.run_number }}"
           if [ "${{ github.event_name }}" = "push" ]; then
             CHART_VERSION="0.1.0-master.${{ github.run_number }}"
             CHART_REPO="${IMAGE_PREFIX}/charts"
@@ -178,7 +176,6 @@ jobs:
             CHART_REPO="${IMAGE_PREFIX}/charts-pr"
           fi
           {
-            echo "IMAGE_TAG=${IMAGE_TAG}"
             echo "CHART_VERSION=${CHART_VERSION}"
             echo "CHART_REPO=${CHART_REPO}"
           } >> "$GITHUB_ENV"
@@ -194,6 +191,13 @@ jobs:
       # The revision annotation is what makes a version resolvable back to a
       # commit (`helm show chart`); without it 0.1.0-master.2366 names a build
       # nobody can diff.
+      - name: Collect image digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: digests
+          merge-multiple: true
+
       - name: Stamp the chart
         run: |
           V="$CHART_VERSION" SHA="${{ github.sha }}" mise exec -- yq -i '
@@ -202,10 +206,24 @@ jobs:
             .annotations."org.opencontainers.image.revision" = strenv(SHA) |
             .annotations."org.opencontainers.image.source" = "https://github.com/fundament-oss/fundament"
           ' charts/fundament/Chart.yaml
-          TAG="$IMAGE_TAG" V="$CHART_VERSION" mise exec -- yq -i '
-            .images |= map_values(sub(":latest$"; ":" + strenv(TAG))) |
-            .deploymentVersion = strenv(V)
-          ' charts/fundament/values.yaml
+          V="$CHART_VERSION" mise exec -- yq -i '.deploymentVersion = strenv(V)' charts/fundament/values.yaml
+
+          # By digest, not tag: a tag can be repointed after review, a digest
+          # cannot. The image name is the last path segment of the ref, which is
+          # what build-image.yml named the artifact after. A missing digest fails
+          # the build - every image in `images:` must have a build in the matrix.
+          for key in $(mise exec -- yq -r '.images | keys | .[]' charts/fundament/values.yaml); do
+            ref=$(mise exec -- yq -r ".images.\"$key\"" charts/fundament/values.yaml)
+            repo=${ref%:*}
+            file="digests/${repo##*/}"
+            if [ ! -s "$file" ]; then
+              echo "no digest for images.$key ($ref)" >&2
+              exit 1
+            fi
+            KEY="$key" VAL="${repo}@$(cat "$file")" mise exec -- \
+              yq -i '.images[strenv(KEY)] = strenv(VAL)' charts/fundament/values.yaml
+          done
+          mise exec -- yq '.images' charts/fundament/values.yaml
 
       - name: Lint and package
         run: |
@@ -215,10 +233,11 @@ jobs:
       - name: Verify the package
         run: |
           TGZ="dist/fundament-${CHART_VERSION}.tgz"
-          # An unstamped image would deploy whatever :latest points at, which on
-          # this registry is regularly an open PR build.
-          if mise exec -- helm show values "$TGZ" | grep ':latest'; then
-            echo "ERROR: the packaged chart still references :latest" >&2
+          # Every image must be digest-pinned. A tag survives review and can be
+          # repointed afterwards; on this registry :latest is rewritten by every
+          # pull_request build.
+          if mise exec -- helm show values "$TGZ" | mise exec -- yq -r '.images[]' | grep -v '@sha256:'; then
+            echo "ERROR: the packaged chart has image references that are not digests" >&2
             exit 1
           fi
           mise exec -- helm show chart "$TGZ"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,98 @@ jobs:
       context: ${{ matrix.context }}
       build-args: ${{ matrix.build-args }}
 
+  # Packages the chart with every image tag stamped into values.yaml, so one
+  # version string names the chart and the exact images it deploys.
+  #
+  # This lives in build.yml rather than its own workflow because
+  # github.run_number is per workflow file: sharing it with `build` is what
+  # makes chart 0.1.0-master.<n> and image tag <sha>-master-<n> the same build.
+  # `needs: build` also cannot cross workflow files, and a version that can
+  # outlive a failed image build does not identify anything.
+  #
+  # Master charts go to charts/, PR builds to charts-pr/. They must not share a
+  # repository: semver compares prerelease identifiers as ASCII, so
+  # 0.1.0-pr417.2345 sorts ABOVE 0.1.0-master.2363, and anything tracking a
+  # version range on master would silently pull a PR build.
+  publish-chart:
+    needs: [gate, build]
+    if: github.event_name == 'push' || needs.gate.outputs.should_deploy == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      chart_version: ${{ steps.version.outputs.chart_version }}
+      chart_repo: ${{ steps.version.outputs.chart_repo }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: jdx/mise-action@v3
+
+      - name: Compute chart version
+        id: version
+        run: |
+          REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
+          IMAGE_TAG="${{ github.sha }}-${REF_NAME}-${{ github.run_number }}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            CHART_VERSION="0.1.0-master.${{ github.run_number }}"
+            CHART_REPO="${IMAGE_PREFIX}/charts"
+          else
+            CHART_VERSION="0.1.0-pr${PR_NUMBER}.${{ github.run_number }}"
+            CHART_REPO="${IMAGE_PREFIX}/charts-pr"
+          fi
+          {
+            echo "IMAGE_TAG=${IMAGE_TAG}"
+            echo "CHART_VERSION=${CHART_VERSION}"
+            echo "CHART_REPO=${CHART_REPO}"
+          } >> "$GITHUB_ENV"
+          {
+            echo "chart_version=${CHART_VERSION}"
+            echo "chart_repo=${CHART_REPO}"
+          } >> "$GITHUB_OUTPUT"
+
+      # Stamped in the CI workspace and never committed. The chart in git keeps
+      # its :latest defaults, which is what leaves skaffold and every consumer
+      # that reads charts/fundament straight from the repo unaffected.
+      #
+      # The revision annotation is what makes a version resolvable back to a
+      # commit (`helm show chart`); without it 0.1.0-master.2366 names a build
+      # nobody can diff.
+      - name: Stamp the chart
+        run: |
+          V="$CHART_VERSION" SHA="${{ github.sha }}" mise exec -- yq -i '
+            .version = strenv(V) |
+            .appVersion = strenv(V) |
+            .annotations."org.opencontainers.image.revision" = strenv(SHA) |
+            .annotations."org.opencontainers.image.source" = "https://github.com/fundament-oss/fundament"
+          ' charts/fundament/Chart.yaml
+          TAG="$IMAGE_TAG" V="$CHART_VERSION" mise exec -- yq -i '
+            .images |= map_values(sub(":latest$"; ":" + strenv(TAG))) |
+            .deploymentVersion = strenv(V)
+          ' charts/fundament/values.yaml
+
+      - name: Lint and package
+        run: |
+          mise exec -- helm lint charts/fundament
+          mise exec -- helm package charts/fundament --destination dist
+
+      - name: Verify the package
+        run: |
+          TGZ="dist/fundament-${CHART_VERSION}.tgz"
+          # An unstamped image would deploy whatever :latest points at, which on
+          # this registry is regularly an open PR build.
+          if mise exec -- helm show values "$TGZ" | grep ':latest'; then
+            echo "ERROR: the packaged chart still references :latest" >&2
+            exit 1
+          fi
+          mise exec -- helm show chart "$TGZ"
+
+      - name: Push
+        run: |
+          echo '${{ secrets.GITHUB_TOKEN }}' | mise exec -- helm registry login ghcr.io \
+            --username '${{ github.actor }}' --password-stdin
+          mise exec -- helm push "dist/fundament-${CHART_VERSION}.tgz" "oci://${CHART_REPO}"
+
   deploy:
     needs: [gate, build]
     if: needs.gate.outputs.should_deploy == 'true'

--- a/Justfile
+++ b/Justfile
@@ -81,12 +81,6 @@ setup-certs:
 
 # --- Deployment commands ---
 
-# Update helm dependencies
-helm-deps:
-    helm dependency update deploy/charts/ingress-nginx
-    helm dependency update deploy/charts/db
-    helm dependency update deploy/charts/fundament
-
 # Deploy to local k3d cluster (development mode, keeps resources on exit)
 dev *flags:
     SKAFFOLD_DEFAULT_REPO="localhost:5111" \

--- a/charts/fundament/.helmignore
+++ b/charts/fundament/.helmignore
@@ -16,3 +16,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# CI input for the PR preview environment, not part of the chart.
+pr-overlay.yaml


### PR DESCRIPTION
charts/fundament` has been `version: 0.1.0` since it was written and has never been
  packaged, so nothing names a deployed stack — fire-cp pins nine image digests by hand
  against a git SHA, digikluster drives twelve `ImagePolicy` objects, and PR previews stamp
  sixteen tags. The chart already carries everything else the deploy needs (all values files,
  the CRD, the OpenFGA model), so stamping the image tags in at package time makes one
  version string name the whole thing.
  
  `publish-chart` runs after the image matrix and pushes to
  `oci://ghcr.io/fundament-oss/fundament/charts` on master, `charts-pr` on pull requests.

  - Lives in `build.yml` rather than its own workflow because `github.run_number` is per
    workflow file — sharing it with `build` is what makes chart `0.1.0-master.<n>` and image
    tag `<sha>-master-<n>` the same build. `needs: build` also cannot cross workflow files.
  - Master and PR charts use separate repositories: semver compares prerelease identifiers as
    ASCII, so `0.1.0-pr417.2345` sorts *above* `0.1.0-master.2363`, and a version range on 
    master would otherwise pull an open PR's chart.
  - `Chart.yaml` gains `org.opencontainers.image.revision`, so a version resolves back to a
    commit via `helm show chart`.
  - `.helmignore` excludes `pr-overlay.yaml`, which was shipping inside the tarball.
  - Drops the `helm-deps` target: it points at `deploy/charts/`, which has never existed in
    this repo's history, and no chart here declares `dependencies:`.
  
  **Nothing currently deployed changes.** Stamping happens in the CI workspace and is never
  committed, so `charts/fundament` in git keeps its `:latest` defaults — digikluster and PR
  previews read the chart from git and are unaffected.
  
  Verified locally against the chart at master: both `yq` stamps produce the 17 expected image
  refs, `helm lint` and `package` are clean, both packaging guards behave, and `helm show
  chart` surfaces the revision annotation. `actionlint` is unchanged from master's baseline.
  
  The first master merge creates the `charts` package and the first PR run creates
  `charts-pr`; both need an anonymous-pull check afterwards
  (`helm pull oci://ghcr.io/fundament-oss/fundament/charts/fundament --version 0.1.0-master.<n>`)