### PR TITLE
refactor(authz): split store resolution out of the evaluation client

### DIFF
--- a/authn-api/cmd/fun-authn-api/main.go
+++ b/authn-api/cmd/fun-authn-api/main.go
@@ -135,10 +135,12 @@ func run() error {
 		"store_name", cfg.OpenFGA.StoreName,
 	)
 
-	authzClient, err := authz.New(cfg.OpenFGA)
+	authzStore, err := authz.NewStore(cfg.OpenFGA)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenFGA client: %w", err)
 	}
+
+	authzClient := authz.NewClient(authzStore)
 
 	logger.Debug("OpenFGA client connected")
 
@@ -179,7 +181,7 @@ func run() error {
 		if err := db.Pool.Ping(ctx); err != nil {
 			errs = append(errs, "database: "+err.Error())
 		}
-		if err := authzClient.Healthy(ctx); err != nil {
+		if err := authzStore.Healthy(ctx); err != nil {
 			errs = append(errs, "openfga: "+err.Error())
 		}
 

--- a/authz-worker/cmd/fun-authz-worker/main.go
+++ b/authz-worker/cmd/fun-authz-worker/main.go
@@ -99,7 +99,7 @@ func run() error {
 	)
 
 	// The store id is generated at creation, so services resolve it by name.
-	resolver, err := authz.New(cfg.OpenFGA)
+	store, err := authz.NewStore(cfg.OpenFGA)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenFGA client: %w", err)
 	}
@@ -122,7 +122,7 @@ func run() error {
 	healthServer := startHealthServer(&cfg, logger, w)
 
 	// On a first install the bootstrap Job has usually not run yet.
-	storeID, err := awaitStore(ctx, logger, resolver, cfg.OpenFGA.StoreName)
+	storeID, err := awaitStore(ctx, logger, store, cfg.OpenFGA.StoreName)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			logger.Info("stopped while waiting for the OpenFGA store")
@@ -164,12 +164,12 @@ func run() error {
 
 // awaitStore blocks until the store named in the configuration exists.
 func awaitStore(
-	ctx context.Context, logger *slog.Logger, resolver *authz.Client, name string,
+	ctx context.Context, logger *slog.Logger, store *authz.Store, name string,
 ) (string, error) {
 	const retry = 5 * time.Second
 
 	for {
-		id, err := resolver.StoreIDFor(ctx)
+		id, err := store.ID(ctx)
 		if err == nil {
 			return id, nil
 		}

--- a/common/authz/client.go
+++ b/common/authz/client.go
@@ -10,40 +10,18 @@ import (
 	"github.com/openfga/go-sdk/client"
 )
 
-// ErrNoStore reports that no store with the configured name exists.
-var ErrNoStore = errors.New("openfga store not provisioned")
-
-// Config holds configuration for the OpenFGA client.
-type Config struct {
-	APIURL string `env:"OPENFGA_API_URL,required,notEmpty"`
-	// The store id is generated at creation, so services resolve it from this name.
-	StoreName string `env:"OPENFGA_STORE_NAME,notEmpty" envDefault:"fundament"`
-}
-
 // Client wraps the OpenFGA SDK client with an AuthZEN-compatible interface.
 // See https://openid.github.io/authzen/ for the AuthZEN specification.
 //
 // Checks run against the store's latest authorization model; no id is pinned.
 type Client struct {
 	fga   *client.OpenFgaClient
-	store *storeRef
+	store *Store
 }
 
-// New creates a new authorization client. The store is resolved on first use,
-// so a service can start before OpenFGA is provisioned and report itself
-// unready until it is.
-func New(cfg Config) (*Client, error) {
-	fgaClient, err := client.NewSdkClient(&client.ClientConfiguration{ApiUrl: cfg.APIURL})
-	if err != nil {
-		return nil, fmt.Errorf("create OpenFGA client: %w", err)
-	}
-
-	return &Client{fga: fgaClient, store: &storeRef{name: cfg.StoreName}}, nil
-}
-
-// StoreIDFor returns the store id for a request.
-func (c *Client) StoreIDFor(ctx context.Context) (string, error) {
-	return c.store.get(ctx, c.fga)
+// NewClient creates an authorization client that evaluates against store.
+func NewClient(store *Store) *Client {
+	return &Client{fga: store.fga, store: store}
 }
 
 // CanViewCluster is a convenience wrapper around Evaluate for the frequently
@@ -64,41 +42,6 @@ func (c *Client) CanViewCluster(ctx context.Context, userID, clusterID uuid.UUID
 		return false, fmt.Errorf("openfga can_view: %w", err)
 	}
 	return dec.Decision, nil
-}
-
-// Healthy checks that the store still exists, looking it up again by name when
-// it does not.
-//
-// GetStore is the probe: Check answers from an in-process typesystem cache and
-// cannot observe a replaced datastore.
-func (c *Client) Healthy(ctx context.Context) error {
-	id, err := c.StoreIDFor(ctx)
-	if err != nil {
-		return fmt.Errorf("openfga: %w", err)
-	}
-
-	if err := c.getStore(ctx, id); err == nil {
-		return nil
-	}
-
-	fresh, err := c.store.resolve(ctx, c.fga)
-	if err != nil {
-		return fmt.Errorf("openfga: %w", err)
-	}
-
-	if err := c.getStore(ctx, fresh); err != nil {
-		return fmt.Errorf("openfga: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Client) getStore(ctx context.Context, id string) error {
-	if _, err := c.fga.GetStore(ctx).Options(client.ClientGetStoreOptions{StoreId: &id}).Execute(); err != nil {
-		return fmt.Errorf("get store %s: %w", id, err)
-	}
-
-	return nil
 }
 
 // Evaluate performs a single access evaluation following the AuthZEN Access Evaluation API.
@@ -144,7 +87,7 @@ func (c *Client) Evaluate(ctx context.Context, req EvaluationRequest) (Decision,
 		checkReq.Context = &checkContext
 	}
 
-	storeID, err := c.StoreIDFor(ctx)
+	storeID, err := c.store.ID(ctx)
 	if err != nil {
 		return Decision{Decision: false}, err
 	}

--- a/common/authz/client_test.go
+++ b/common/authz/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestObjectConstructors(t *testing.T) {
@@ -220,17 +221,14 @@ func TestEvaluations_ValidSemantics(t *testing.T) {
 	}
 }
 
-func TestNew_InvalidConfig(t *testing.T) {
-	// Test that New returns an error for invalid configuration
+func TestNewStore_InvalidConfig(t *testing.T) {
 	cfg := Config{
 		APIURL:    "", // Empty URL should cause an error
 		StoreName: "fundament",
 	}
 
-	_, err := New(cfg)
-	if err == nil {
-		t.Fatal("expected error for empty API URL, got nil")
-	}
+	_, err := NewStore(cfg)
+	require.Error(t, err)
 }
 
 func TestDecision_DefaultsToFalse(t *testing.T) {

--- a/common/authz/store.go
+++ b/common/authz/store.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -12,48 +13,99 @@ import (
 	"github.com/openfga/go-sdk/client"
 )
 
-// storeRef caches the id of the store this client evaluates against. The id is
-// generated at creation, so it is looked up from the name.
-type storeRef struct {
+// ErrNoStore reports that no store with the configured name exists.
+var ErrNoStore = errors.New("openfga store not provisioned")
+
+// Config holds configuration for the OpenFGA client.
+type Config struct {
+	APIURL string `env:"OPENFGA_API_URL,required,notEmpty"`
+	// The store id is generated at creation, so services resolve it from this name.
+	StoreName string `env:"OPENFGA_STORE_NAME,notEmpty" envDefault:"fundament"`
+}
+
+// Store caches the id of the store named in the config. The id is generated at
+// creation, so it is looked up from the name.
+type Store struct {
+	fga  *client.OpenFgaClient
 	name string
 
 	mu sync.RWMutex
 	id string
 }
 
-func (s *storeRef) cached() string {
+// NewStore references the store named in the config. The id is resolved on
+// first use, so a service can start before OpenFGA is provisioned and report
+// itself unready until it is.
+func NewStore(cfg Config) (*Store, error) {
+	fga, err := client.NewSdkClient(&client.ClientConfiguration{ApiUrl: cfg.APIURL})
+	if err != nil {
+		return nil, fmt.Errorf("create OpenFGA client: %w", err)
+	}
+
+	return &Store{fga: fga, name: cfg.StoreName}, nil
+}
+
+// ID returns the cached id, resolving it the first time.
+func (s *Store) ID(ctx context.Context) (string, error) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	id := s.id
+	s.mu.RUnlock()
 
-	return s.id
+	if id != "" {
+		return id, nil
+	}
+
+	return s.refresh(ctx)
 }
 
-func (s *storeRef) set(id string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// Healthy checks that the referenced store still exists, resolving it again by
+// name when it does not.
+//
+// GetStore is the probe: Check answers from an in-process typesystem cache and
+// cannot observe a replaced datastore.
+func (s *Store) Healthy(ctx context.Context) error {
+	id, err := s.ID(ctx)
+	if err != nil {
+		return fmt.Errorf("openfga: %w", err)
+	}
 
-	s.id = id
+	if err := s.exists(ctx, id); err == nil {
+		return nil
+	}
+
+	fresh, err := s.refresh(ctx)
+	if err != nil {
+		return fmt.Errorf("openfga: %w", err)
+	}
+
+	if err := s.exists(ctx, fresh); err != nil {
+		return fmt.Errorf("openfga: %w", err)
+	}
+
+	return nil
 }
 
-// resolve looks the store up and caches it.
-func (s *storeRef) resolve(ctx context.Context, fga *client.OpenFgaClient) (string, error) {
-	id, err := ResolveStoreID(ctx, fga, s.name)
+// refresh resolves the id again and replaces the cache, for when the cached
+// store no longer exists.
+func (s *Store) refresh(ctx context.Context) (string, error) {
+	id, err := ResolveStoreID(ctx, s.fga, s.name)
 	if err != nil {
 		return "", err
 	}
 
-	s.set(id)
+	s.mu.Lock()
+	s.id = id
+	s.mu.Unlock()
 
 	return id, nil
 }
 
-// get returns the cached id, looking it up the first time.
-func (s *storeRef) get(ctx context.Context, fga *client.OpenFgaClient) (string, error) {
-	if id := s.cached(); id != "" {
-		return id, nil
+func (s *Store) exists(ctx context.Context, id string) error {
+	if _, err := s.fga.GetStore(ctx).Options(client.ClientGetStoreOptions{StoreId: &id}).Execute(); err != nil {
+		return fmt.Errorf("get store %s: %w", id, err)
 	}
 
-	return s.resolve(ctx, fga)
+	return nil
 }
 
 // ResolveStoreID returns the id of the store called name, or ErrNoStore.

--- a/common/authz/store_test.go
+++ b/common/authz/store_test.go
@@ -35,13 +35,13 @@ func storesServer(t *testing.T, stores []map[string]any, calls *int) *httptest.S
 	return srv
 }
 
-func newRef(t *testing.T, url string) (*storeRef, *client.OpenFgaClient) {
+func newRef(t *testing.T, url string) *Store {
 	t.Helper()
 
-	fga, err := client.NewSdkClient(&client.ClientConfiguration{ApiUrl: url})
+	store, err := NewStore(Config{APIURL: url, StoreName: "fundament"})
 	require.NoError(t, err)
 
-	return &storeRef{name: "fundament"}, fga
+	return store
 }
 
 func TestResolvePicksTheOldestMatch(t *testing.T) {
@@ -52,9 +52,9 @@ func TestResolvePicksTheOldestMatch(t *testing.T) {
 		{"id": "03other", "name": "something-else", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"},
 	}, nil)
 
-	ref, fga := newRef(t, srv.URL)
+	ref := newRef(t, srv.URL)
 
-	id, err := ref.resolve(context.Background(), fga)
+	id, err := ref.refresh(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "01older", id, "every service must converge on the same store")
 }
@@ -67,9 +67,9 @@ func TestResolveBreaksTiesOnID(t *testing.T) {
 		{"id": "aaa", "name": "fundament", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
 	}, nil)
 
-	ref, fga := newRef(t, srv.URL)
+	ref := newRef(t, srv.URL)
 
-	id, err := ref.resolve(context.Background(), fga)
+	id, err := ref.refresh(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "aaa", id)
 }
@@ -86,32 +86,32 @@ func TestResolveSkipsSoftDeletedStores(t *testing.T) {
 		{"id": "02live", "name": "fundament", "created_at": "2026-01-02T00:00:00Z", "updated_at": "2026-01-02T00:00:00Z"},
 	}, nil)
 
-	ref, fga := newRef(t, srv.URL)
+	ref := newRef(t, srv.URL)
 
-	id, err := ref.resolve(context.Background(), fga)
+	id, err := ref.refresh(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "02live", id)
 }
 
 func TestResolveReportsNoStore(t *testing.T) {
 	srv := storesServer(t, nil, nil)
-	ref, fga := newRef(t, srv.URL)
+	ref := newRef(t, srv.URL)
 
-	_, err := ref.resolve(context.Background(), fga)
+	_, err := ref.refresh(context.Background())
 	require.ErrorIs(t, err, ErrNoStore)
 }
 
-func TestGetCachesAfterFirstResolve(t *testing.T) {
+func TestIDCachesAfterFirstResolve(t *testing.T) {
 	calls := 0
 	srv := storesServer(t, []map[string]any{
 		{"id": "01abc", "name": "fundament", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
 	}, &calls)
 
-	ref, fga := newRef(t, srv.URL)
+	ref := newRef(t, srv.URL)
 	ctx := context.Background()
 
 	for range 3 {
-		id, err := ref.get(ctx, fga)
+		id, err := ref.ID(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "01abc", id)
 	}

--- a/kube-api-proxy/cmd/fun-kube-api-proxy/main.go
+++ b/kube-api-proxy/cmd/fun-kube-api-proxy/main.go
@@ -73,10 +73,12 @@ func run() error {
 		}
 	}
 
-	authzClient, err := authz.New(cfg.OpenFGA)
+	authzStore, err := authz.NewStore(cfg.OpenFGA)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenFGA client: %w", err)
 	}
+
+	authzClient := authz.NewClient(authzStore)
 
 	var gardenerClient *gardener.Client
 	if cfg.KubeProxyMode == "real" {
@@ -97,7 +99,7 @@ func run() error {
 		GardenerClient:          gardenerClient,
 		MockPluginTemplatesDir:  cfg.MockPluginTemplatesDir,
 		PluginSandboxKubeconfig: cfg.PluginSandboxKubeconfig,
-	}, authzClient)
+	}, authzClient, authzStore)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy server: %w", err)
 	}

--- a/kube-api-proxy/pkg/proxy/server.go
+++ b/kube-api-proxy/pkg/proxy/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	logger        *slog.Logger
 	authValidator *auth.Validator
 	authz         *authz.Client
+	store         *authz.Store
 	tokenCache    *tokenpkg.Cache
 	kubeHandler   http.Handler
 	handler       http.Handler
@@ -48,7 +49,7 @@ type Server struct {
 	serveUnauthedMockAssets bool
 }
 
-func New(logger *slog.Logger, cfg *Config, authzClient *authz.Client) (*Server, error) {
+func New(logger *slog.Logger, cfg *Config, authzClient *authz.Client, store *authz.Store) (*Server, error) {
 	if cfg.Mode == "" {
 		cfg.Mode = "mock"
 	}
@@ -83,6 +84,7 @@ func New(logger *slog.Logger, cfg *Config, authzClient *authz.Client) (*Server, 
 		logger:                  logger,
 		authValidator:           auth.NewValidatorForAudience(cfg.JWTSecret, auth.ConsoleAuthCookieName, auth.ConsoleIssuer, auth.TokenTypeUser, logger),
 		authz:                   authzClient,
+		store:                   store,
 		tokenCache:              tokenCache,
 		kubeHandler:             kubeHandler,
 		serveUnauthedMockAssets: serveUnauthedMockAssets,
@@ -119,7 +121,7 @@ func New(logger *slog.Logger, cfg *Config, authzClient *authz.Client) (*Server, 
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
-		if err := s.authz.Healthy(ctx); err != nil {
+		if err := s.store.Healthy(ctx); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("openfga: " + err.Error()))
 			return

--- a/kube-api-proxy/pkg/proxy/server_test.go
+++ b/kube-api-proxy/pkg/proxy/server_test.go
@@ -26,7 +26,7 @@ func newMockServer(t *testing.T, cfg *proxy.Config) *httptest.Server {
 	if cfg.Mode == "" {
 		cfg.Mode = "mock"
 	}
-	srv, err := proxy.New(slog.New(slog.NewTextHandler(io.Discard, nil)), cfg, nil)
+	srv, err := proxy.New(slog.New(slog.NewTextHandler(io.Discard, nil)), cfg, nil, nil)
 	require.NoError(t, err)
 	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
@@ -111,7 +111,7 @@ func TestClusterProxy_RejectsPluginToken(t *testing.T) {
 	srv, err := proxy.New(logger, &proxy.Config{
 		JWTSecret: secret,
 		Mode:      "mock",
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(srv.Handler())

--- a/organization-api/cmd/fun-organization-api/main.go
+++ b/organization-api/cmd/fun-organization-api/main.go
@@ -98,10 +98,12 @@ func run() error {
 		"store_name", cfg.OpenFGA.StoreName,
 	)
 
-	authzClient, err := authz.New(cfg.OpenFGA)
+	authzStore, err := authz.NewStore(cfg.OpenFGA)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenFGA client: %w", err)
 	}
+
+	authzClient := authz.NewClient(authzStore)
 
 	logger.Debug("OpenFGA client connected")
 
@@ -208,7 +210,7 @@ func run() error {
 		if err := db.Pool.Ping(ctx); err != nil {
 			errs = append(errs, "database: "+err.Error())
 		}
-		if err := authzClient.Healthy(ctx); err != nil {
+		if err := authzStore.Healthy(ctx); err != nil {
 			errs = append(errs, "openfga: "+err.Error())
 		}
 		if breaker.IsOpen() {

--- a/plugin-proxy/cmd/fun-plugin-proxy/main.go
+++ b/plugin-proxy/cmd/fun-plugin-proxy/main.go
@@ -66,16 +66,18 @@ func run() error {
 
 	// OpenFGA backs the asset handler's can_view gate in every mode and, in
 	// real mode, doubles as the installation proxy's cluster authorizer.
-	openfga, err := openfgaauthz.New(cfg.OpenFGA)
+	openfgaStore, err := openfgaauthz.NewStore(cfg.OpenFGA)
 	if err != nil {
 		return fmt.Errorf("openfga client: %w", err)
 	}
 
+	openfga := openfgaauthz.NewClient(openfgaStore)
+
 	publicMux := http.NewServeMux()
-	registerHealth(publicMux, openfga, logger)
+	registerHealth(publicMux, openfgaStore, logger)
 
 	internalMux := http.NewServeMux()
-	registerHealth(internalMux, openfga, logger)
+	registerHealth(internalMux, openfgaStore, logger)
 
 	// Static assets + strict CSP.
 	cfgCsp := &assets.CSPConfig{
@@ -251,7 +253,7 @@ func run() error {
 	return runErr
 }
 
-func registerHealth(mux *http.ServeMux, authzClient *openfgaauthz.Client, logger *slog.Logger) {
+func registerHealth(mux *http.ServeMux, store *openfgaauthz.Store, logger *slog.Logger) {
 	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
@@ -263,7 +265,7 @@ func registerHealth(mux *http.ServeMux, authzClient *openfgaauthz.Client, logger
 		// The can_view gate runs in every mode, so an unresolved store means
 		// this pod cannot authorize any request. This mux is also served
 		// publicly, so the reason is logged rather than returned.
-		if err := authzClient.Healthy(ctx); err != nil {
+		if err := store.Healthy(ctx); err != nil {
 			logger.Error("readiness: openfga unavailable", "err", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("not ready"))


### PR DESCRIPTION
## What

Splits `common/authz` into two independently-owned pieces:

- **`Store`** (`store.go`) owns store identity end to end: `NewStore(cfg)` creates the SDK connection, `ID(ctx)` returns the cached id (resolving on first use), `Healthy(ctx)` probes existence via GetStore and re-resolves by name when the store is gone. `Config` and `ErrNoStore` moved here too.
- **`Client`** (`client.go`) is evaluation only: `NewClient(store)` takes the store as a dependency and keeps `Evaluate`/`Evaluations`/`CanViewCluster`. The `Healthy`/`StoreIDFor` passthroughs are gone.

Services construct both in `main` and keep their own store reference for readiness:

```go
store, err := authz.NewStore(cfg.OpenFGA)
client := authz.NewClient(store)
// readyz: store.Healthy(ctx)
```

## Why

The client was secretly a store-manager with evaluation bolted on — the resolve/get/ResolveStoreID naming mix and the worker constructing a full evaluation client just to resolve a store id were symptoms. Now the dependency direction is explicit: Store depends on nothing, Client depends on Store, mains compose them.

- **authz-worker** drops the duplicate `authz.Client` entirely and uses just `NewStore` + its raw SDK client for writes.
- **kube-api-proxy**'s `proxy.New` takes `(client, store)` — client for `checkPermission`, store for `/readyz`.
- **authn-api / organization-api / plugin-proxy** readiness probes call `store.Healthy(ctx)` directly.

One SDK connection per service is preserved: `NewClient` reuses the store's handle.

## Note

Readiness wiring is now a convention rather than a method on the client — new services must remember to wire `store.Healthy` into `/readyz` themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wfSCcVn7TYTBrco3L3G8F
