### PR TITLE
feat(marketplace): admin API schema (stack 2/3)

### DIFF
--- a/common/dbversion/version.go
+++ b/common/dbversion/version.go
@@ -1,4 +1,4 @@
 package dbversion
 
 // LatestVersion is the latest version for the db migrations.
-const LatestVersion = 40
+const LatestVersion = 41

--- a/common/testdb/roles.go
+++ b/common/testdb/roles.go
@@ -30,6 +30,7 @@ var Roles = []Role{
 	{Name: "fun_dcim_api"},
 	{Name: "fun_marketplace_catalog_api"},
 	{Name: "fun_marketplace_registry_api"},
+	{Name: "fun_marketplace_admin_api"},
 }
 
 // CreateRoles ensures every role in [Roles] exists with the configured

--- a/db/fundament.dbm
+++ b/db/fundament.dbm
@@ -56,6 +56,10 @@ CAUTION: Do not modify this file unless you know what you are doing.
  sql-disabled="true">
 </role>
 
+<role name="fun_marketplace_admin_api"
+ sql-disabled="true">
+</role>
+
 <database name="fundament" is-template="false" allow-conns="true" sql-disabled="true">
 </database>
 
@@ -1870,6 +1874,28 @@ END;]]> </definition>
 	<expression type="check-exp"> <![CDATA[EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id())]]> </expression>
 </policy>
 
+<policy name="plugins_select_admin" table="appstore.plugins" command="SELECT" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="plugin_definitions_all_admin" table="appstore.plugin_definitions" command="ALL" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+	<expression type="check-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="submissions_all_admin" table="appstore.submissions" command="ALL" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+	<expression type="check-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="plugins_tags_select_admin" table="appstore.plugins_tags" command="SELECT" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+</policy>
+
+<policy name="categories_plugins_select_admin" table="appstore.categories_plugins" command="SELECT" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[true]]> </expression>
+</policy>
+
 <policy name="plugin_allowed_organizations_select_api" table="appstore.plugin_allowed_organizations" command="SELECT" permissive="true">	<roles names="fun_fundament_api"/>
 	<expression type="using-exp"> <![CDATA[organization_id = authn.current_organization_id()]]> </expression>
 </policy>
@@ -1988,6 +2014,10 @@ END;]]> </definition>
 
 <policy name="organizations_select_catalog" table="tenant.organizations" command="SELECT" permissive="true">	<roles names="fun_marketplace_catalog_api"/>
 	<expression type="using-exp"> <![CDATA[deleted IS NULL AND EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.organization_id = tenant.organizations.id AND appstore.plugins.deleted IS NULL AND appstore.plugins.visibility = 'public')]]> </expression>
+</policy>
+
+<policy name="organizations_select_admin" table="tenant.organizations" command="SELECT" permissive="true">	<roles names="fun_marketplace_admin_api"/>
+	<expression type="using-exp"> <![CDATA[deleted IS NULL AND EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.organization_id = tenant.organizations.id AND appstore.plugins.deleted IS NULL)]]> </expression>
 </policy>
 
 <policy name="organization_limits_organization_policy" table="tenant.organization_limits" command="ALL" permissive="true">	<roles names="fun_fundament_api"/>
@@ -5397,6 +5427,91 @@ END;]]> </definition>
 <permission>
 	<object name="appstore.categories" type="table"/>
 	<roles names="fun_marketplace_registry_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore" type="schema"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges usage="true"/>
+</permission>
+<permission>
+	<object name="tenant" type="schema"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges usage="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugins" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugin_definitions" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="status" parent="appstore.plugin_definitions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="published" parent="appstore.plugin_definitions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="appstore.submissions" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="reviewer_user_id" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="reviewed" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="closed" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="rejection_reason" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="feedback" parent="appstore.submissions" type="column"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges update="true"/>
+</permission>
+<permission>
+	<object name="appstore.categories" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore.tags" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore.plugins_tags" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="appstore.categories_plugins" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
+	<privileges select="true"/>
+</permission>
+<permission>
+	<object name="tenant.organizations" type="table"/>
+	<roles names="fun_marketplace_admin_api"/>
 	<privileges select="true"/>
 </permission>
 </dbmodel>

--- a/db/fundament.sql
+++ b/db/fundament.sql
@@ -1601,6 +1601,53 @@ CREATE POLICY plugin_allowed_organizations_all_registry ON appstore.plugin_allow
 	WITH CHECK (EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.id = appstore.plugin_allowed_organizations.plugin_id AND appstore.plugins.organization_id = authn.current_organization_id()));
 -- ddl-end --
 
+-- object: plugins_select_admin | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_select_admin ON appstore.plugins CASCADE;
+CREATE POLICY plugins_select_admin ON appstore.plugins
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+-- ddl-end --
+
+-- object: plugin_definitions_all_admin | type: POLICY --
+-- DROP POLICY IF EXISTS plugin_definitions_all_admin ON appstore.plugin_definitions CASCADE;
+CREATE POLICY plugin_definitions_all_admin ON appstore.plugin_definitions
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_admin_api
+	USING (true)
+	WITH CHECK (true);
+-- ddl-end --
+
+-- object: submissions_all_admin | type: POLICY --
+-- DROP POLICY IF EXISTS submissions_all_admin ON appstore.submissions CASCADE;
+CREATE POLICY submissions_all_admin ON appstore.submissions
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_admin_api
+	USING (true)
+	WITH CHECK (true);
+-- ddl-end --
+
+-- object: plugins_tags_select_admin | type: POLICY --
+-- DROP POLICY IF EXISTS plugins_tags_select_admin ON appstore.plugins_tags CASCADE;
+CREATE POLICY plugins_tags_select_admin ON appstore.plugins_tags
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+-- ddl-end --
+
+-- object: categories_plugins_select_admin | type: POLICY --
+-- DROP POLICY IF EXISTS categories_plugins_select_admin ON appstore.categories_plugins CASCADE;
+CREATE POLICY categories_plugins_select_admin ON appstore.categories_plugins
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+-- ddl-end --
+
 -- object: plugin_allowed_organizations_select_api | type: POLICY --
 -- DROP POLICY IF EXISTS plugin_allowed_organizations_select_api ON appstore.plugin_allowed_organizations CASCADE;
 CREATE POLICY plugin_allowed_organizations_select_api ON appstore.plugin_allowed_organizations
@@ -1791,6 +1838,15 @@ CREATE POLICY organizations_select_catalog ON tenant.organizations
 	FOR SELECT
 	TO fun_marketplace_catalog_api
 	USING (deleted IS NULL AND EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.organization_id = tenant.organizations.id AND appstore.plugins.deleted IS NULL AND appstore.plugins.visibility = 'public'));
+-- ddl-end --
+
+-- object: organizations_select_admin | type: POLICY --
+-- DROP POLICY IF EXISTS organizations_select_admin ON tenant.organizations CASCADE;
+CREATE POLICY organizations_select_admin ON tenant.organizations
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (deleted IS NULL AND EXISTS (SELECT 1 FROM appstore.plugins WHERE appstore.plugins.organization_id = tenant.organizations.id AND appstore.plugins.deleted IS NULL));
 -- ddl-end --
 
 -- object: organization_limits_organization_policy | type: POLICY --
@@ -4800,6 +4856,142 @@ GRANT SELECT,INSERT
 GRANT SELECT
    ON TABLE appstore.categories
    TO fun_marketplace_registry_api;
+
+-- ddl-end --
+
+
+-- object: "grant_U_06186b41ac" | type: PERMISSION --
+GRANT USAGE
+   ON SCHEMA appstore
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: "grant_U_1ef32a10b1" | type: PERMISSION --
+GRANT USAGE
+   ON SCHEMA tenant
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_2c220bdfe0 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.plugins
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_55abf03dc9 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_1828d4a177 | type: PERMISSION --
+GRANT UPDATE(status)
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_e7370906e9 | type: PERMISSION --
+GRANT UPDATE(published)
+   ON TABLE appstore.plugin_definitions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_f165ddaba3 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_9153607b55 | type: PERMISSION --
+GRANT UPDATE(reviewer_user_id)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_1066fc42d8 | type: PERMISSION --
+GRANT UPDATE(reviewed)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_bf2e75bd96 | type: PERMISSION --
+GRANT UPDATE(closed)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_32d8da87e3 | type: PERMISSION --
+GRANT UPDATE(rejection_reason)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_w_6a8ec3d2b0 | type: PERMISSION --
+GRANT UPDATE(feedback)
+   ON TABLE appstore.submissions
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_eda1398348 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.categories
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_df7e1a526f | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.tags
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_ad567998bf | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.plugins_tags
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_297c355a5c | type: PERMISSION --
+GRANT SELECT
+   ON TABLE appstore.categories_plugins
+   TO fun_marketplace_admin_api;
+
+-- ddl-end --
+
+
+-- object: grant_r_b6d3ca0302 | type: PERMISSION --
+GRANT SELECT
+   ON TABLE tenant.organizations
+   TO fun_marketplace_admin_api;
 
 -- ddl-end --
 

--- a/db/migrations/041_marketplace-admin.up.sql
+++ b/db/migrations/041_marketplace-admin.up.sql
@@ -1,0 +1,129 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+-- Hand-added statements. trek's diff emits table-wide grants but not
+-- schema-level or column-level ones, even when they are modelled in the .dbm,
+-- so every statement marked "hand-added" in this file must be re-added whenever
+-- the migration is regenerated.
+--
+-- Schema USAGE for the admin role:
+--   appstore: without it every table grant below is unusable.
+--   tenant: ListPublishers resolves publishing organizations, which
+--     organization-api cannot serve to a reviewer (FUN-20).
+GRANT USAGE ON SCHEMA "appstore" TO "fun_marketplace_admin_api";
+GRANT USAGE ON SCHEMA "tenant" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."categories" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "categories_plugins_select_admin" ON "appstore"."categories_plugins"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."categories_plugins" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugin_definitions_all_admin" ON "appstore"."plugin_definitions"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_admin_api
+	USING (true)
+	WITH CHECK (true);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugin_definitions" TO "fun_marketplace_admin_api";
+
+-- Hand-added, column-scoped. A decision moves a version's status out of
+-- PENDING and stamps published on approval. hash, manifest and image are the
+-- consent record FUN-20 makes immutable, so the grant, not just stack 3's Go,
+-- refuses them.
+GRANT UPDATE ("status") ON "appstore"."plugin_definitions" TO "fun_marketplace_admin_api";
+GRANT UPDATE ("published") ON "appstore"."plugin_definitions" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugins_select_admin" ON "appstore"."plugins"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugins" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "plugins_tags_select_admin" ON "appstore"."plugins_tags"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (true);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."plugins_tags" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "submissions_all_admin" ON "appstore"."submissions"
+	AS PERMISSIVE
+	FOR ALL
+	TO fun_marketplace_admin_api
+	USING (true)
+	WITH CHECK (true);
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+
+-- Hand-added, column-scoped. A decision records who decided, when and why, and
+-- closes the round. Which version a round reviews and who submitted it are the
+-- publisher's alone, so the reviewer cannot rewrite them.
+GRANT UPDATE ("reviewer_user_id") ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+GRANT UPDATE ("reviewed") ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+GRANT UPDATE ("closed") ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+GRANT UPDATE ("rejection_reason") ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+GRANT UPDATE ("feedback") ON "appstore"."submissions" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "appstore"."tags" TO "fun_marketplace_admin_api";
+
+/* Hazards:
+ - AUTHZ_UPDATE: Adding a permissive policy could allow unauthorized access to data.
+*/
+CREATE POLICY "organizations_select_admin" ON "tenant"."organizations"
+	AS PERMISSIVE
+	FOR SELECT
+	TO fun_marketplace_admin_api
+	USING (((deleted IS NULL) AND (EXISTS ( SELECT 1
+   FROM appstore.plugins
+  WHERE ((plugins.organization_id = organizations.id) AND (plugins.deleted IS NULL))))));
+
+/* Hazards:
+ - AUTHZ_UPDATE: Granting privileges could allow unauthorized access to data.
+*/
+GRANT SELECT ON "tenant"."organizations" TO "fun_marketplace_admin_api";
+

--- a/db/trek.yaml
+++ b/db/trek.yaml
@@ -11,6 +11,7 @@ roles:
   - name: fun_dcim_api
   - name: fun_marketplace_catalog_api
   - name: fun_marketplace_registry_api
+  - name: fun_marketplace_admin_api
 outputs:
   - sql
 templates:


### PR DESCRIPTION
Give the review backoffice its own database role,
fun_marketplace_admin_api, following the registry's isolation pattern
(FUN-20): each surface reaches only what it needs.

The role is not organization-scoped — a reviewer acts on submissions from
every publishing organization — so its policies grant cross-tenant reads
on the listing tables and USING (true) on submissions and
plugin_definitions. What it may write is fenced by column grants instead:
a decision records who decided, when and why (submissions), and moves the
version's status, stamping published on approval (plugin_definitions).
hash, manifest and image stay immutable, and a round's identity — which
version, who submitted — stays the publisher's alone.

tenant.organizations gets a SELECT policy covering every organization
with a listing, published or not: ListPublishers must resolve a publisher
whose first version is still under review, which the catalog's
public-only policy deliberately hides.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012byUogXd9BpJWMmV1HeACJ
